### PR TITLE
Fix Compodoc coverage config

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "nest start --watch",
-    "docs:build": "compodoc -p tsconfig.json -d docs",
-    "docs:serve": "compodoc -p tsconfig.json -d docs --serve",
-    "docs:cov": "pnpm compodoc --coverageTest -p tsconfig.json",
+    "docs:build": "compodoc -p tsconfig.compodoc.json -d docs",
+    "docs:serve": "compodoc -p tsconfig.compodoc.json -d docs --serve",
+    "docs:cov": "pnpm compodoc --coverageTest -p tsconfig.compodoc.json",
     "build": "prisma generate && nest build",
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "nest start",

--- a/packages/backend/tsconfig.compodoc.json
+++ b/packages/backend/tsconfig.compodoc.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [
+        "src/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist",
+        "prisma/**/*",
+        "src/__mocks__/**/*"
+    ]
+}


### PR DESCRIPTION
## Summary
- add tsconfig.compodoc.json to exclude generated code from docs
- update docs scripts to use the new configuration

## Testing
- `pnpm docs:cov` *(fails: Error when performing the request to https://registry.npmjs.org/... EHOSTUNREACH)*