### PR TITLE
Implement initial einsatz seed logic

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,7 +22,8 @@
     "prisma:studio": "prisma studio",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "prisma:deploy": "prisma migrate deploy"
+    "prisma:deploy": "prisma migrate deploy",
+    "seed:einsatz": "ts-node -r tsconfig-paths/register src/scripts/seed-einsatz.ts"
   },
   "dependencies": {
     "@bluelight-hub/shared": "workspace:*",

--- a/packages/backend/src/modules/einsatz/__tests__/einsatz.controller.spec.ts
+++ b/packages/backend/src/modules/einsatz/__tests__/einsatz.controller.spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EinsatzController } from '../einsatz.controller';
+import { EinsatzService } from '../einsatz.service';
+import { CreateEinsatzDto } from '../dto/create-einsatz.dto';
+
+describe('EinsatzController', () => {
+    let controller: EinsatzController;
+    const serviceMock = {
+        findAll: jest.fn(),
+        create: jest.fn(),
+    } as unknown as EinsatzService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [EinsatzController],
+            providers: [{ provide: EinsatzService, useValue: serviceMock }],
+        }).compile();
+
+        controller = module.get<EinsatzController>(EinsatzController);
+        jest.clearAllMocks();
+    });
+
+    it('should be defined', () => {
+        expect(controller).toBeDefined();
+    });
+
+    describe('create', () => {
+        it('delegiert an den Service', async () => {
+            const dto: CreateEinsatzDto = { name: 'Alpha' };
+            const created = { id: '1', name: 'Alpha', createdAt: new Date(), updatedAt: new Date() };
+            (serviceMock.create as jest.Mock).mockResolvedValue(created);
+
+            const result = await controller.create(dto);
+
+            expect(result).toBe(created);
+            expect(serviceMock.create).toHaveBeenCalledWith(dto);
+        });
+    });
+});

--- a/packages/backend/src/modules/einsatz/__tests__/einsatz.service.spec.ts
+++ b/packages/backend/src/modules/einsatz/__tests__/einsatz.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '@/prisma/prisma.service';
+import { EinsatzService } from '../einsatz.service';
+import { CreateEinsatzDto } from '../dto/create-einsatz.dto';
+
+describe('EinsatzService', () => {
+    let service: EinsatzService;
+    const prismaMock = {
+        einsatz: {
+            findMany: jest.fn(),
+            findUnique: jest.fn(),
+            count: jest.fn(),
+            create: jest.fn(),
+        },
+    } as unknown as PrismaService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                EinsatzService,
+                { provide: PrismaService, useValue: prismaMock },
+            ],
+        }).compile();
+
+        service = module.get<EinsatzService>(EinsatzService);
+        jest.clearAllMocks();
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    describe('create', () => {
+        it('legt einen Einsatz an', async () => {
+            const dto: CreateEinsatzDto = { name: 'Test' };
+            const created = { id: '1', name: 'Test', createdAt: new Date(), updatedAt: new Date() };
+            (prismaMock.einsatz.create as jest.Mock).mockResolvedValue(created);
+
+            const result = await service.create(dto);
+
+            expect(result).toBe(created);
+            expect(prismaMock.einsatz.create).toHaveBeenCalledWith({ data: dto });
+        });
+    });
+
+    describe('count', () => {
+        it('gibt die Anzahl der Einsätze zurück', async () => {
+            (prismaMock.einsatz.count as jest.Mock).mockResolvedValue(5);
+
+            const result = await service.count();
+
+            expect(result).toBe(5);
+            expect(prismaMock.einsatz.count).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/backend/src/modules/einsatz/dev-seed.service.ts
+++ b/packages/backend/src/modules/einsatz/dev-seed.service.ts
@@ -1,0 +1,33 @@
+import { Inject, Injectable, LoggerService, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EinsatzService } from './einsatz.service';
+
+/**
+ * Erstellt im Entwicklungsmodus automatisch einen Einsatz, falls keiner existiert.
+ */
+@Injectable()
+export class DevSeedService implements OnModuleInit {
+    constructor(
+        private readonly einsatzService: EinsatzService,
+        private readonly configService: ConfigService,
+        @Inject('Logger') private readonly logger: LoggerService,
+    ) { }
+
+    async onModuleInit() {
+        if (this.configService.get<string>('NODE_ENV') !== 'development') {
+            return;
+        }
+        if (this.configService.get<string>('SEED_INITIAL_EINSATZ') === 'false') {
+            this.logger.debug('Initialer Einsatz-Seed deaktiviert');
+            return;
+        }
+        const count = await this.einsatzService.count();
+        if (count > 0) {
+            return;
+        }
+        const name = this.configService.get<string>('DEV_EINSATZ_NAME')
+            || `Dev-Einsatz ${new Date().toISOString()}`;
+        await this.einsatzService.create({ name });
+        this.logger.log(`Initialer Einsatz "${name}" wurde angelegt`);
+    }
+}

--- a/packages/backend/src/modules/einsatz/dto/create-einsatz.dto.ts
+++ b/packages/backend/src/modules/einsatz/dto/create-einsatz.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+/**
+ * DTO zum Anlegen eines neuen Einsatzes.
+ */
+export class CreateEinsatzDto {
+    /**
+     * Name des Einsatzes
+     */
+    @ApiProperty({ description: 'Name des Einsatzes', example: 'Einsatz Alpha' })
+    @IsString()
+    @IsNotEmpty()
+    name!: string;
+}

--- a/packages/backend/src/modules/einsatz/einsatz.controller.ts
+++ b/packages/backend/src/modules/einsatz/einsatz.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { EinsatzService } from './einsatz.service';
 import { Einsatz } from './entities/einsatz.entity';
+import { CreateEinsatzDto } from './dto/create-einsatz.dto';
 
 @ApiTags('Einsatz')
 @Controller('einsatz')
@@ -11,5 +12,10 @@ export class EinsatzController {
     @Get()
     async findAll(): Promise<Einsatz[]> {
         return this.einsatzService.findAll();
+    }
+
+    @Post()
+    async create(@Body() dto: CreateEinsatzDto): Promise<Einsatz> {
+        return this.einsatzService.create(dto);
     }
 }

--- a/packages/backend/src/modules/einsatz/einsatz.module.ts
+++ b/packages/backend/src/modules/einsatz/einsatz.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from '@/prisma/prisma.module';
+import { ConfigModule } from '@/config/config.module';
 import { EinsatzService } from './einsatz.service';
 import { EinsatzController } from './einsatz.controller';
+import { DevSeedService } from './dev-seed.service';
 
 @Module({
-    imports: [PrismaModule],
+    imports: [PrismaModule, ConfigModule],
     controllers: [EinsatzController],
-    providers: [EinsatzService],
+    providers: [EinsatzService, DevSeedService],
     exports: [EinsatzService],
 })
 export class EinsatzModule {}

--- a/packages/backend/src/modules/einsatz/einsatz.service.ts
+++ b/packages/backend/src/modules/einsatz/einsatz.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
 import { Einsatz } from './entities/einsatz.entity';
+import { CreateEinsatzDto } from './dto/create-einsatz.dto';
 
 @Injectable()
 export class EinsatzService {
@@ -8,6 +9,14 @@ export class EinsatzService {
 
     async findAll(): Promise<Einsatz[]> {
         return this.prisma.einsatz.findMany();
+    }
+
+    async count(): Promise<number> {
+        return this.prisma.einsatz.count();
+    }
+
+    async create(data: CreateEinsatzDto): Promise<Einsatz> {
+        return this.prisma.einsatz.create({ data });
     }
 
     async findById(id: string): Promise<Einsatz> {

--- a/packages/backend/src/scripts/seed-einsatz.ts
+++ b/packages/backend/src/scripts/seed-einsatz.ts
@@ -1,0 +1,26 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from '../app.module';
+import { EinsatzService } from '../modules/einsatz/einsatz.service';
+import { LoggerService } from '@nestjs/common';
+
+async function bootstrap() {
+    const app = await NestFactory.createApplicationContext(AppModule, { logger: false });
+    const service = app.get(EinsatzService);
+    const logger = app.get<LoggerService>('Logger');
+
+    const nameIndex = process.argv.indexOf('--name');
+    let name = '';
+    if (nameIndex >= 0 && process.argv[nameIndex + 1]) {
+        name = process.argv[nameIndex + 1];
+    }
+    if (!name) {
+        name = `Einsatz ${new Date().toISOString()}`;
+    }
+
+    await service.create({ name });
+    logger.log(`Einsatz "${name}" wurde angelegt`);
+    await app.close();
+}
+
+bootstrap();
+


### PR DESCRIPTION
## Summary
- add DTO and create method for Einsatz
- expose POST /einsatz endpoint
- seed initial Einsatz in dev mode
- provide CLI command to seed an Einsatz
- test controller and service

## Testing
- `pnpm test`
- `pnpm generate-api` *(fails: connect EHOSTUNREACH)*
