### PR TITLE
Add swagger dark mode

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -2,6 +2,8 @@ import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import * as packageJson from '../package.json';
 import { AppModule } from './app.module';
 import { logger } from './logger/consola.logger';
@@ -31,7 +33,15 @@ async function bootstrap() {
         url: 'http://localhost:3000',
         description: 'Local Environment',
     }];
-    SwaggerModule.setup('api', app, document, {});
+
+    // Lese Dark-Mode-Styles für Swagger UI ein
+    const swaggerCss = readFileSync(
+        join(__dirname, '../swagger-dark.css'),
+        'utf8',
+    );
+
+    // Aktiviere Swagger UI unter /api mit den eingelesenen Styles
+    SwaggerModule.setup('api', app, document, { customCss: swaggerCss });
 
     app.enableCors();
 

--- a/packages/backend/swagger-dark.css
+++ b/packages/backend/swagger-dark.css
@@ -1,0 +1,13 @@
+/* Dunkles Theme für Swagger UI */
+body {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+
+.swagger-ui .topbar,
+.swagger-ui .info {
+  background: #242424;
+  color: #f5f5f5;
+}
+
+/* Weitere Anpassungen nach Bedarf */


### PR DESCRIPTION
## Summary
- add swagger-dark.css
- load custom CSS in backend startup to enable dark theme

## Testing
- `pnpm test`