### PR TITLE
✨(frontend): Add Storybook for component documentation

### DIFF
--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+storybook-static
 
 # Editor directories and files
 .vscode/*

--- a/packages/frontend/.storybook/main.ts
+++ b/packages/frontend/.storybook/main.ts
@@ -1,0 +1,26 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx|mdx)'],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-links',
+    '@storybook/addon-interactions',
+    '@storybook/addon-a11y',
+    'msw-storybook-addon',
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  typescript: {
+    check: false,
+    reactDocgen: 'react-docgen-typescript',
+  },
+  viteFinal: async (config) => {
+    // Ensure Vite handles CSS modules and Tailwind properly
+    return config;
+  },
+};
+
+export default config;

--- a/packages/frontend/.storybook/manager.ts
+++ b/packages/frontend/.storybook/manager.ts
@@ -1,0 +1,13 @@
+import { addons } from '@storybook/manager-api';
+import { themes } from '@storybook/theming';
+
+addons.setConfig({
+  theme: {
+    ...themes.normal,
+    brandTitle: 'BlueLight Hub Components',
+    brandUrl: 'https://github.com/bluelight-hub/app',
+  },
+  sidebar: {
+    showRoots: true,
+  },
+});

--- a/packages/frontend/.storybook/preview.tsx
+++ b/packages/frontend/.storybook/preview.tsx
@@ -1,0 +1,126 @@
+import type { Preview } from '@storybook/react';
+import React, { useEffect } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { initialize, mswLoader } from 'msw-storybook-addon';
+import { ThemeProvider } from '../src/providers/ThemeProvider';
+import { useThemeStore } from '../src/stores/useThemeStore';
+import '../src/index.css';
+import '@fontsource-variable/inter';
+import '@fontsource-variable/montserrat';
+import '@fontsource-variable/nunito';
+
+// Initialize MSW
+initialize({
+  onUnhandledRequest: 'bypass',
+});
+
+// Create a client for each story
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+// Theme wrapper component
+const ThemeWrapper = ({ theme, children }: { theme: string; children: React.ReactNode }) => {
+  const setTheme = useThemeStore((state) => state.setTheme);
+
+  useEffect(() => {
+    setTheme(theme as 'light' | 'dark');
+    // Update document class for Tailwind
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [theme, setTheme]);
+
+  return <>{children}</>;
+};
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    viewport: {
+      viewports: {
+        mobile: {
+          name: 'Mobile',
+          styles: {
+            width: '375px',
+            height: '667px',
+          },
+        },
+        tablet: {
+          name: 'Tablet',
+          styles: {
+            width: '768px',
+            height: '1024px',
+          },
+        },
+        desktop: {
+          name: 'Desktop',
+          styles: {
+            width: '1280px',
+            height: '800px',
+          },
+        },
+      },
+    },
+    docs: {
+      autodocs: 'tag',
+    },
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#f9fafb' },
+        { name: 'dark', value: '#111827' },
+      ],
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const theme = context.globals.theme || 'light';
+      return (
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ThemeProvider>
+              <ThemeWrapper theme={theme}>
+                <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
+                  <Story />
+                </div>
+              </ThemeWrapper>
+            </ThemeProvider>
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+    },
+  ],
+  loaders: [mswLoader],
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'light',
+      toolbar: {
+        icon: 'circlehollow',
+        items: [
+          { value: 'light', icon: 'sun', title: 'Light' },
+          { value: 'dark', icon: 'moon', title: 'Dark' },
+        ],
+        showName: true,
+        dynamicTitle: true,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/packages/frontend/STORYBOOK.md
+++ b/packages/frontend/STORYBOOK.md
@@ -1,0 +1,139 @@
+# Storybook für BlueLight Hub Frontend
+
+Storybook ist als zentrale Dokumentations- und Entwicklungsumgebung für alle Frontend-Komponenten implementiert.
+
+## 🚀 Quick Start
+
+```bash
+# Storybook starten (Port 6006)
+pnpm storybook
+
+# Storybook bauen
+pnpm build-storybook
+
+# Storybook Tests ausführen
+pnpm test-storybook
+```
+
+## 📁 Struktur
+
+Stories befinden sich neben den jeweiligen Komponenten:
+
+```
+src/components/
+├── atoms/
+│   ├── Button/
+│   │   ├── Button.tsx
+│   │   ├── Button.test.tsx
+│   │   └── Button.stories.tsx      # Story-Datei
+├── molecules/
+│   └── ...
+└── organisms/
+    └── ...
+```
+
+## 📝 Story schreiben
+
+### Basis-Story (CSF 3.0):
+
+```typescript
+import type { Meta, StoryObj } from '@storybook/react';
+import { MyComponent } from './MyComponent';
+
+const meta = {
+  title: 'Category/ComponentName',
+  component: MyComponent,
+  parameters: {
+    layout: 'centered', // oder 'fullscreen', 'padded'
+  },
+  tags: ['autodocs'], // Automatische Dokumentation
+  argTypes: {
+    // Prop-Controls definieren
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary'],
+    },
+  },
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    // Standard-Props
+    children: 'Button Text',
+  },
+};
+```
+
+### Story mit MSW (API Mocking):
+
+```typescript
+import { http, HttpResponse } from 'msw';
+
+export const WithAPIData: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/data', () => {
+          return HttpResponse.json({ 
+            data: 'mocked data' 
+          });
+        }),
+      ],
+    },
+  },
+};
+```
+
+## 🎨 Theme Integration
+
+Theme-Switching ist global in der Toolbar verfügbar. Komponenten passen sich automatisch an:
+
+- Light Mode: Standard-Theme
+- Dark Mode: Dunkles Theme mit Tailwind `dark:` Klassen
+
+## 🧪 Testing
+
+### Accessibility Tests:
+Alle Stories werden automatisch auf Barrierefreiheit getestet (a11y addon).
+
+### Interaction Tests:
+```typescript
+import { within, userEvent } from '@storybook/test';
+
+export const ClickExample: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    await userEvent.click(button);
+  },
+};
+```
+
+## 🔧 Addons
+
+- **Controls**: Interaktive Prop-Anpassung
+- **Actions**: Event-Handler Logging
+- **Viewport**: Responsive Testing
+- **A11y**: Accessibility Checks
+- **MSW**: API Mocking für realistische Daten
+
+## 📚 Best Practices
+
+1. **Atomic Design**: Stories nach Atomic Design Struktur organisieren
+2. **Realistische Daten**: Mock-Daten sollten realistisch sein
+3. **Edge Cases**: Stories für Fehler- und Ladezustände erstellen
+4. **Dokumentation**: JSDoc-Kommentare für automatische Dokumentation
+5. **Status Badges**: Komponenten-Status mit Tags kennzeichnen
+
+## 🚀 Deployment
+
+Storybook wird automatisch bei jedem Push auf `main` gebaut und deployed.
+
+## 🔗 Nützliche Links
+
+- [Storybook Dokumentation](https://storybook.js.org/docs)
+- [CSF 3.0 Format](https://storybook.js.org/docs/api/csf)
+- [MSW Integration](https://github.com/mswjs/msw-storybook-addon)

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,7 +15,10 @@
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "test:cov": "vitest run --coverage",
-    "test:watch": "vitest watch"
+    "test:watch": "vitest watch",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+    "test-storybook": "test-storybook"
   },
   "dependencies": {
     "@bluelight-hub/shared": "workspace:*",
@@ -45,6 +48,12 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",
+    "@storybook/addon-a11y": "^8.5.1",
+    "@storybook/addon-essentials": "^8.5.1",
+    "@storybook/addon-interactions": "^8.5.1",
+    "@storybook/addon-links": "^8.5.1",
+    "@storybook/react-vite": "^8.5.1",
+    "@storybook/test": "^8.5.1",
     "@tauri-apps/cli": "^2.5.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -61,7 +70,10 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "jsdom": "^26.1.0",
+    "msw": "^2.7.0",
+    "msw-storybook-addon": "^2.0.7",
     "react-router-dom": "7.5.1",
+    "storybook": "^8.5.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "8.30.1",
     "vite": "^6.3.2",

--- a/packages/frontend/src/components/atoms/Divider.stories.tsx
+++ b/packages/frontend/src/components/atoms/Divider.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Divider from './Divider';
+
+const meta = {
+  title: 'Atoms/Divider',
+  component: Divider,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes for styling',
+    },
+    'data-testid': {
+      control: 'text',
+      description: 'Test ID for testing purposes',
+      defaultValue: 'divider',
+    },
+  },
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const CustomSpacing: Story = {
+  args: {
+    className: 'my-8',
+  },
+};
+
+export const Thicker: Story = {
+  args: {
+    className: 'border-t-2',
+  },
+};
+
+export const ColoredDivider: Story = {
+  args: {
+    className: 'border-blue-500',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A divider with custom color',
+      },
+    },
+  },
+};

--- a/packages/frontend/src/components/atoms/Logo.stories.tsx
+++ b/packages/frontend/src/components/atoms/Logo.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Logo from './Logo';
+import { ThemeProvider } from '../../providers/ThemeProvider';
+
+const meta = {
+  title: 'Atoms/Logo',
+  component: Logo,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes for styling',
+    },
+    'data-testid': {
+      control: 'text',
+      description: 'Test ID for testing purposes',
+      defaultValue: 'logo',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} satisfies Meta<typeof Logo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Small: Story = {
+  args: {
+    className: 'h-8 w-auto',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    className: 'h-16 w-auto',
+  },
+};
+
+export const ExtraLarge: Story = {
+  args: {
+    className: 'h-24 w-auto',
+  },
+};
+
+export const WithCustomStyling: Story = {
+  args: {
+    className: 'h-12 w-auto drop-shadow-lg',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Logo with drop shadow effect',
+      },
+    },
+  },
+};

--- a/packages/frontend/src/components/atoms/StatusIndicator.stories.tsx
+++ b/packages/frontend/src/components/atoms/StatusIndicator.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatusIndicator } from './StatusIndicator';
+import { fn } from '@storybook/test';
+import { http, HttpResponse } from 'msw';
+
+const meta = {
+  title: 'Atoms/StatusIndicator',
+  component: StatusIndicator,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes for styling',
+    },
+    withText: {
+      control: 'boolean',
+      description: 'Whether to show the status text',
+      defaultValue: false,
+    },
+    onStatusChange: {
+      description: 'Callback when status changes',
+    },
+    'data-testid': {
+      control: 'text',
+      description: 'Test ID for testing purposes',
+      defaultValue: 'status-indicator',
+    },
+  },
+} satisfies Meta<typeof StatusIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Mock the backend health endpoint
+const mockHandlers = {
+  online: http.get('/api/health', () => {
+    return HttpResponse.json({
+      status: 'ok',
+      info: {
+        database: { status: 'up' },
+        memory: { status: 'up' },
+      },
+    });
+  }),
+  offline: http.get('/api/health', () => {
+    return HttpResponse.json({
+      status: 'offline',
+      info: {
+        database: { status: 'down' },
+      },
+    });
+  }),
+  error: http.get('/api/health', () => {
+    return HttpResponse.error();
+  }),
+};
+
+export const Online: Story = {
+  args: {
+    onStatusChange: fn(),
+  },
+  parameters: {
+    msw: {
+      handlers: [mockHandlers.online],
+    },
+  },
+};
+
+export const OnlineWithText: Story = {
+  args: {
+    withText: true,
+    onStatusChange: fn(),
+  },
+  parameters: {
+    msw: {
+      handlers: [mockHandlers.online],
+    },
+  },
+};
+
+export const Offline: Story = {
+  args: {
+    withText: true,
+    onStatusChange: fn(),
+  },
+  parameters: {
+    msw: {
+      handlers: [mockHandlers.offline],
+    },
+  },
+};
+
+export const Error: Story = {
+  args: {
+    withText: true,
+    onStatusChange: fn(),
+  },
+  parameters: {
+    msw: {
+      handlers: [mockHandlers.error],
+    },
+  },
+};
+
+export const CustomStyling: Story = {
+  args: {
+    className: 'scale-150',
+    withText: true,
+    onStatusChange: fn(),
+  },
+  parameters: {
+    msw: {
+      handlers: [mockHandlers.online],
+    },
+    docs: {
+      description: {
+        story: 'Status indicator with custom scale',
+      },
+    },
+  },
+};

--- a/packages/frontend/src/components/atoms/UserProfile.stories.tsx
+++ b/packages/frontend/src/components/atoms/UserProfile.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import UserProfile from './UserProfile';
+import { fn } from '@storybook/test';
+import { EinsatzProvider } from '../../contexts/EinsatzContext';
+import { useUserProfileStore } from '../../stores/useUserProfileStore';
+
+const meta = {
+  title: 'Atoms/UserProfile',
+  component: UserProfile,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    href: {
+      control: 'text',
+      description: 'Link href (not used but required)',
+      defaultValue: '#',
+    },
+    hideText: {
+      control: 'boolean',
+      description: 'Hide the user name text',
+      defaultValue: false,
+    },
+    onClick: {
+      description: 'Callback when profile is clicked',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes',
+    },
+    'data-testid': {
+      control: 'text',
+      description: 'Test ID for testing purposes',
+      defaultValue: 'user-profile',
+    },
+  },
+  decorators: [
+    (Story) => {
+      // Set up mock user profile
+      useUserProfileStore.setState({
+        profile: {
+          id: '1',
+          name: 'Max Mustermann',
+          email: 'max.mustermann@example.com',
+          imageUrl: 'https://ui-avatars.com/api/?name=Max+Mustermann&background=0D8ABC&color=fff',
+          roles: ['user'],
+        },
+      });
+
+      return (
+        <EinsatzProvider>
+          <div className="w-64 bg-white dark:bg-gray-900">
+            <Story />
+          </div>
+        </EinsatzProvider>
+      );
+    },
+  ],
+} satisfies Meta<typeof UserProfile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    href: '#',
+    onClick: fn(),
+  },
+};
+
+export const HiddenText: Story = {
+  args: {
+    href: '#',
+    hideText: true,
+    onClick: fn(),
+  },
+};
+
+export const WithLongName: Story = {
+  args: {
+    href: '#',
+    onClick: fn(),
+  },
+  decorators: [
+    (Story) => {
+      useUserProfileStore.setState({
+        profile: {
+          id: '2',
+          name: 'Friedrich-Wilhelm von Brandenburg-Preußen',
+          email: 'friedrich.wilhelm@example.com',
+          imageUrl: 'https://ui-avatars.com/api/?name=FW&background=0D8ABC&color=fff',
+          roles: ['admin'],
+        },
+      });
+      return <Story />;
+    },
+  ],
+};
+
+export const NoProfile: Story = {
+  args: {
+    href: '#',
+    onClick: fn(),
+  },
+  decorators: [
+    (Story) => {
+      useUserProfileStore.setState({ profile: null });
+      return <Story />;
+    },
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story: 'When no user profile is available, the component renders nothing',
+      },
+    },
+  },
+};

--- a/packages/frontend/src/components/molecules/etb/ETBHeader.stories.tsx
+++ b/packages/frontend/src/components/molecules/etb/ETBHeader.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ETBHeader } from './ETBHeader';
+import { fn } from '@storybook/test';
+
+const meta = {
+  title: 'Molecules/ETB/ETBHeader',
+  component: ETBHeader,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    inputVisible: {
+      control: 'boolean',
+      description: 'Whether the input form is visible',
+    },
+    setInputVisible: {
+      description: 'Function to toggle input form visibility',
+    },
+  },
+} satisfies Meta<typeof ETBHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    inputVisible: false,
+    setInputVisible: fn(),
+  },
+};
+
+export const WithInputVisible: Story = {
+  args: {
+    inputVisible: true,
+    setInputVisible: fn(),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Header state when the input form is visible',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  args: {
+    inputVisible: false,
+    setInputVisible: fn(),
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile',
+    },
+    docs: {
+      description: {
+        story: 'Header appearance on mobile devices',
+      },
+    },
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    inputVisible: false,
+    setInputVisible: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    // Story interactions can be added here
+    // For example, clicking the "Neuer Eintrag" button
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Interactive story demonstrating button clicks',
+      },
+    },
+  },
+};

--- a/packages/frontend/src/components/molecules/sidebar/SidebarContent.stories.tsx
+++ b/packages/frontend/src/components/molecules/sidebar/SidebarContent.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SidebarContent from './SidebarContent';
+import { fn } from '@storybook/test';
+import { EinsatzProvider } from '../../../contexts/EinsatzContext';
+import { useUserProfileStore } from '../../../stores/useUserProfileStore';
+import { NavigationItem } from '../../../config/navigation';
+import { PiHouse, PiClipboardText, PiUsers } from 'react-icons/pi';
+
+const mockNavigation: NavigationItem[] = [
+  {
+    name: 'Dashboard',
+    href: '/app/dashboard',
+    icon: PiHouse,
+  },
+  {
+    name: 'Einsatztagebuch',
+    href: '/app/einsatztagebuch',
+    icon: PiClipboardText,
+  },
+  {
+    name: 'Team',
+    href: '/app/team',
+    icon: PiUsers,
+    children: [
+      { name: 'Mitglieder', href: '/app/team/members' },
+      { name: 'Rollen', href: '/app/team/roles' },
+    ],
+  },
+];
+
+const meta = {
+  title: 'Molecules/Sidebar/SidebarContent',
+  component: SidebarContent,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    navigation: {
+      description: 'Navigation items to display',
+    },
+    onNavigate: {
+      description: 'Callback when navigation item is clicked',
+    },
+  },
+  decorators: [
+    (Story) => {
+      // Set up mock user profile
+      useUserProfileStore.setState({
+        profile: {
+          id: '1',
+          name: 'Max Mustermann',
+          email: 'max.mustermann@example.com',
+          imageUrl: 'https://ui-avatars.com/api/?name=Max+Mustermann&background=0D8ABC&color=fff',
+          roles: ['user'],
+        },
+      });
+
+      return (
+        <EinsatzProvider>
+          <div className="h-screen">
+            <Story />
+          </div>
+        </EinsatzProvider>
+      );
+    },
+  ],
+} satisfies Meta<typeof SidebarContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    navigation: mockNavigation,
+    onNavigate: fn(),
+  },
+};
+
+export const WithManyItems: Story = {
+  args: {
+    navigation: [
+      ...mockNavigation,
+      { name: 'Einsätze', href: '/app/einsaetze', icon: PiClipboardText },
+      { name: 'Fahrzeuge', href: '/app/fahrzeuge', icon: PiClipboardText },
+      { name: 'Gefahren', href: '/app/gefahren', icon: PiClipboardText },
+      { name: 'Checklisten', href: '/app/checklisten', icon: PiClipboardText },
+      { name: 'Kommunikation', href: '/app/kommunikation', icon: PiClipboardText },
+      { name: 'Kräfte', href: '/app/kraefte', icon: PiClipboardText },
+      { name: 'Lagekarte', href: '/app/lagekarte', icon: PiClipboardText },
+      { name: 'Notizen', href: '/app/notizen', icon: PiClipboardText },
+      { name: 'Reminders', href: '/app/reminders', icon: PiClipboardText },
+    ],
+    onNavigate: fn(),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Sidebar with many navigation items to test scrolling',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  args: {
+    navigation: mockNavigation,
+    onNavigate: fn(),
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile',
+    },
+  },
+};


### PR DESCRIPTION
- Set up Storybook 8.x with Vite builder
- Configure essential addons (Controls, Actions, A11y, MSW)
- Add theme integration with light/dark mode support
- Create stories for all existing atoms
- Add sample stories for molecules
- Configure MSW for API mocking
- Add comprehensive Storybook documentation

Closes #145