### PR TITLE
♻️(ui): Move filter reset to Dialog.Footer for API consistency

### DIFF
--- a/packages/frontend/src/components/organisms/dashboard/MobileFilterDialog.tsx
+++ b/packages/frontend/src/components/organisms/dashboard/MobileFilterDialog.tsx
@@ -115,11 +115,13 @@ export const MobileFilterDialog = ({ isOpen, onClose, statusFilter, sortOption, 
             ))}
           </div>
         </div>
+      </Dialog.Body>
 
+      <Dialog.Footer>
         <Button intent="secondary" onClick={handleReset} className="w-full">
           Filter zurücksetzen
         </Button>
-      </Dialog.Body>
+      </Dialog.Footer>
     </Dialog>
   );
 };


### PR DESCRIPTION
Relocate "Filter zurücksetzen" button from Dialog.Body to Dialog.Footer to align with the new Dialog API pattern that supports optional loading state.

Fixes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)