### PR TITLE
🐛 Fix Tauri version format for cross-platform builds

### DIFF
--- a/packages/frontend/scripts/sync-tauri-version.js
+++ b/packages/frontend/scripts/sync-tauri-version.js
@@ -3,12 +3,12 @@
  * Synchronisiert die Version aus package.json in tauri.conf.json.
  * Wird automatisch bei `npm version` via lifecycle script ausgeführt.
  *
- * Konvertiert Semver-Prerelease zu MSI-kompatiblem Format:
- * - `1.0.0-alpha.37` → `1.0.0.37`
- * - `1.0.0-beta.5` → `1.0.0.5`
+ * Konvertiert Semver-Prerelease zu Tauri/MSI-kompatiblem Format:
+ * - `1.0.0-alpha.37` → `1.0.0-37`
+ * - `1.0.0-beta.5` → `1.0.0-5`
  * - `1.0.0` → `1.0.0`
  *
- * MSI erfordert numerische Versionen im Format X.Y.Z oder X.Y.Z.BUILD
+ * Numerisches Prerelease ist gültiges Semver UND MSI-kompatibel.
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -18,12 +18,12 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
- * Konvertiert Semver zu MSI-kompatiblem Format
+ * Konvertiert Semver zu Tauri/MSI-kompatiblem Format
  *
  * @param {string} semver - Semver Version (z.B. "1.0.0-alpha.37")
- * @returns {string} MSI-kompatible Version (z.B. "1.0.0.37")
+ * @returns {string} Tauri-kompatible Version (z.B. "1.0.0-37")
  */
-function toMsiVersion(semver) {
+function toTauriVersion(semver) {
   // Match: major.minor.patch[-prerelease.num]
   const match = semver.match(/^(\d+)\.(\d+)\.(\d+)(?:-[a-zA-Z]+\.(\d+))?/);
 
@@ -33,9 +33,9 @@ function toMsiVersion(semver) {
 
   const [, major, minor, patch, prereleaseNum] = match;
 
-  // MSI Format: X.Y.Z oder X.Y.Z.BUILD
+  // Format: X.Y.Z-NUM (gültiges Semver mit numerischem Prerelease)
   if (prereleaseNum) {
-    return `${major}.${minor}.${patch}.${prereleaseNum}`;
+    return `${major}.${minor}.${patch}-${prereleaseNum}`;
   }
 
   return `${major}.${minor}.${patch}`;
@@ -49,12 +49,12 @@ try {
   const tauriConf = JSON.parse(readFileSync(tauriConfPath, 'utf8'));
 
   const oldVersion = tauriConf.version;
-  const msiVersion = toMsiVersion(packageJson.version);
-  tauriConf.version = msiVersion;
+  const tauriVersion = toTauriVersion(packageJson.version);
+  tauriConf.version = tauriVersion;
 
   writeFileSync(tauriConfPath, `${JSON.stringify(tauriConf, null, 2)}\n`);
 
-  console.log(`✅ Tauri version synced: ${oldVersion} → ${msiVersion} (from ${packageJson.version})`);
+  console.log(`✅ Tauri version synced: ${oldVersion} → ${tauriVersion} (from ${packageJson.version})`);
 } catch (error) {
   console.error('❌ Failed to sync Tauri version:', error.message);
   process.exit(1);

--- a/packages/frontend/src-tauri/tauri.conf.json
+++ b/packages/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "bluelight-hub",
-  "version": "1.0.0.37",
+  "version": "1.0.0-37",
   "identifier": "dev.rubeen.bluelight-hub",
   "build": {
     "beforeDevCommand": "pnpm dev:vite",


### PR DESCRIPTION
## Summary

Fix Tauri version format to work on both macOS (requires semver) and Windows MSI (requires numeric).

**Problem:**
- `1.0.0-alpha.37` → macOS ✅, MSI ❌ (non-numeric prerelease)
- `1.0.0.37` → macOS ❌ (not semver), MSI ✅

**Solution:**
- `1.0.0-37` → macOS ✅ (valid semver), MSI ✅ (numeric prerelease)

## Changes

Updated `sync-tauri-version.js` to convert:
- `1.0.0-alpha.37` → `1.0.0-37`
- `1.0.0-beta.5` → `1.0.0-5`
- `1.0.0` → `1.0.0` (unchanged)

## Test plan

- [ ] macOS build succeeds
- [ ] Windows MSI build succeeds
- [ ] Linux build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)