### PR TITLE
🐛 Disable password manager autofill in login combobox

### DIFF
--- a/packages/frontend/src/shared/ui/headless/combobox.tsx
+++ b/packages/frontend/src/shared/ui/headless/combobox.tsx
@@ -120,6 +120,9 @@ export function Combobox({
             )}
             autoCorrect={'off'}
             autoComplete={'off'}
+            data-1p-ignore="true"
+            data-lpignore="true"
+            data-form-type="other"
             placeholder={placeholder}
             onChange={(event) => handleQueryChange(event.target.value)}
             onBlur={() => {


### PR DESCRIPTION
## Summary
- Fügt `data-1p-ignore`, `data-lpignore` und `data-form-type="other"` Attribute zur Combobox hinzu
- Verhindert, dass Passwort-Manager (1Password, LastPass, etc.) Autofill-Vorschläge im Login-Formular anzeigen
- Benutzer müssen den Benutzernamen manuell eingeben

## Test plan
- [ ] Login-Seite öffnen mit 1Password-Extension aktiv
- [ ] Verifizieren, dass keine Autofill-Vorschläge erscheinen
- [ ] Login-Seite öffnen mit LastPass-Extension aktiv
- [ ] Verifizieren, dass keine Autofill-Vorschläge erscheinen
- [ ] Manuelle Eingabe funktioniert weiterhin

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)