### PR TITLE
🎨 Palette: Disable spellcheck and autocomplete in ETB search bar

### DIFF
--- a/packages/frontend/src/features/etb/ui/molecules/EtbSearchBar.tsx
+++ b/packages/frontend/src/features/etb/ui/molecules/EtbSearchBar.tsx
@@ -19,6 +19,10 @@ export function EtbSearchBar({ value, onChange, placeholder = 'Einträge durchsu
         value={value ?? ''}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        spellCheck={false}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
         className={cn(
           'w-full py-2 pr-4 pl-9 text-sm',
           'rounded-lg border border-gray-300',


### PR DESCRIPTION
Disabled spellcheck, autocomplete, autocorrect, and autocapitalize in the ETB search bar (`EtbSearchBar.tsx`) to prevent browser interference when searching for entries.

---
*PR created automatically by Jules for task [16161899389157653729](https://jules.google.com/task/16161899389157653729) started by @rubenvitt*