### PR TITLE
🛡️ Sentinel: Harden Content Security Policy

### DIFF
--- a/packages/backend/src/infrastructure/config/security.config.ts
+++ b/packages/backend/src/infrastructure/config/security.config.ts
@@ -20,8 +20,8 @@ export const helmetConfig: HelmetOptions = {
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      styleSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
-      scriptSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
+      styleSrc: ["'self'"],
+      scriptSrc: ["'self'"],
       imgSrc: ["'self'", 'data:', 'https:'],
       connectSrc: ["'self'"],
       fontSrc: ["'self'"],
@@ -54,6 +54,45 @@ export const helmetConfig: HelmetOptions = {
   // Permitted Cross Domain Policies
   permittedCrossDomainPolicies: false,
   // Referrer Policy
+  referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+};
+
+/**
+ * Gelockerte Helmet-Konfiguration speziell für die Swagger UI.
+ * Erlaubt 'unsafe-inline' für Skripte und Styles, was für Swagger erforderlich ist.
+ * DIESE KONFIGURATION SOLLTE NUR FÜR DEN SWAGGER-ENDPOINT VERWENDET WERDEN.
+ *
+ * @constant {HelmetOptions}
+ */
+export const swaggerHelmetConfig: HelmetOptions = {
+  // Content Security Policy - Verhindert XSS-Angriffe
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
+      scriptSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
+      imgSrc: ["'self'", 'data:', 'https:'],
+      connectSrc: ["'self'"],
+      fontSrc: ["'self'"],
+      objectSrc: ["'none'"],
+      mediaSrc: ["'self'"],
+      frameSrc: ["'none'"],
+      frameAncestors: ["'none'"],
+    },
+  },
+  crossOriginEmbedderPolicy: false,
+  dnsPrefetchControl: { allow: false },
+  frameguard: { action: 'deny' },
+  hidePoweredBy: true,
+  hsts: {
+    maxAge: 31536000,
+    includeSubDomains: true,
+    preload: true,
+  },
+  ieNoOpen: true,
+  noSniff: true,
+  originAgentCluster: true,
+  permittedCrossDomainPolicies: false,
   referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
 };
 

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -12,7 +12,7 @@ import { AppModule } from './app.module';
 import { validateInsecureMode } from './infrastructure/config/bootstrap-validation';
 import { PerformanceInterceptor } from './infrastructure/http/interceptors/performance.interceptor';
 import { TransformInterceptor } from './infrastructure/http/interceptors/transform.interceptor';
-import { corsConfig, helmetConfig } from './infrastructure/config/security.config';
+import { corsConfig, helmetConfig, swaggerHelmetConfig } from './infrastructure/config/security.config';
 
 require('@dotenvx/dotenvx').config();
 
@@ -139,8 +139,15 @@ X-Server-Access-Token: <plaintext_token>
 
   SwaggerModule.setup('api', app, document, {});
 
-  // Apply Helmet middleware for security headers
-  app.use(helmet(helmetConfig));
+  // Apply Helmet middleware conditionally
+  // Use lenient policy for Swagger UI, strict policy for everything else
+  app.use((req, res, next) => {
+    if (req.originalUrl.startsWith('/api')) {
+      helmet(swaggerHelmetConfig)(req, res, next);
+    } else {
+      helmet(helmetConfig)(req, res, next);
+    }
+  });
 
   // Apply cookie parser middleware
   app.use(cookieParser());


### PR DESCRIPTION
This change hardens the application's Content Security Policy (CSP) to mitigate Cross-Site Scripting (XSS) risks. It establishes a strict default policy and applies a more lenient one only to the Swagger UI endpoint, following security best practices.

---
*PR created automatically by Jules for task [10938972367102480866](https://jules.google.com/task/10938972367102480866) started by @rubenvitt*