### PR TITLE
🛡️ Sentinel: HIGH Fix Overly Permissive CSP

### DIFF
--- a/packages/backend/src/infrastructure/config/security.config.ts
+++ b/packages/backend/src/infrastructure/config/security.config.ts
@@ -15,13 +15,13 @@ import type { HelmetOptions } from 'helmet';
  *
  * @constant {HelmetOptions}
  */
-export const helmetConfig: HelmetOptions = {
+export const defaultHelmetConfig: HelmetOptions = {
   // Content Security Policy - Verhindert XSS-Angriffe
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      styleSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
-      scriptSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
+      styleSrc: ["'self'"],
+      scriptSrc: ["'self'"],
       imgSrc: ["'self'", 'data:', 'https:'],
       connectSrc: ["'self'"],
       fontSrc: ["'self'"],
@@ -55,6 +55,26 @@ export const helmetConfig: HelmetOptions = {
   permittedCrossDomainPolicies: false,
   // Referrer Policy
   referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+};
+
+/**
+ * Helmet-Konfiguration speziell für die Swagger-UI.
+ *
+ * Diese Konfiguration ist eine Erweiterung der Standard-Helmet-Konfiguration
+ * und lockert die Content Security Policy (CSP), um 'unsafe-inline' für
+ * Skripte und Stile zu erlauben, was für die Swagger-UI erforderlich ist.
+ *
+ * @constant {HelmetOptions}
+ */
+export const swaggerHelmetConfig: HelmetOptions = {
+  ...defaultHelmetConfig,
+  contentSecurityPolicy: {
+    directives: {
+      ...defaultHelmetConfig.contentSecurityPolicy.directives,
+      styleSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
+      scriptSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
+    },
+  },
 };
 
 /**

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -12,7 +12,11 @@ import { AppModule } from './app.module';
 import { validateInsecureMode } from './infrastructure/config/bootstrap-validation';
 import { PerformanceInterceptor } from './infrastructure/http/interceptors/performance.interceptor';
 import { TransformInterceptor } from './infrastructure/http/interceptors/transform.interceptor';
-import { corsConfig, helmetConfig } from './infrastructure/config/security.config';
+import {
+  corsConfig,
+  defaultHelmetConfig,
+  swaggerHelmetConfig,
+} from './infrastructure/config/security.config';
 
 require('@dotenvx/dotenvx').config();
 
@@ -139,8 +143,19 @@ X-Server-Access-Token: <plaintext_token>
 
   SwaggerModule.setup('api', app, document, {});
 
-  // Apply Helmet middleware for security headers
-  app.use(helmet(helmetConfig));
+  // Conditionally apply Helmet middleware based on the request path.
+  // The Swagger UI, hosted at /api, requires a more lenient Content Security Policy
+  // ('unsafe-inline') to function correctly. The actual API endpoints are versioned
+  // and exist under paths like /api/v-alpha, so they can receive a stricter policy.
+  app.use((req, res, next) => {
+    const isSwaggerRoute = req.path.startsWith('/api') && !req.path.startsWith('/api/v-');
+
+    if (isSwaggerRoute) {
+      helmet(swaggerHelmetConfig)(req, res, next);
+    } else {
+      helmet(defaultHelmetConfig)(req, res, next);
+    }
+  });
 
   // Apply cookie parser middleware
   app.use(cookieParser());


### PR DESCRIPTION
This submission addresses a HIGH severity security vulnerability by hardening the Content Security Policy (CSP). It replaces a single, overly permissive global policy with a dual-policy approach: a strict default configuration is applied to the entire application, while a more lenient policy is conditionally and exclusively applied to the Swagger UI route, which requires it. This follows the principle of least privilege and significantly reduces the application's attack surface against Cross-Site Scripting (XSS).

---
*PR created automatically by Jules for task [2348601812469542483](https://jules.google.com/task/2348601812469542483) started by @rubenvitt*