### PR TITLE
🛡️ Sentinel: Harden Content Security Policy

### DIFF
--- a/packages/backend/src/infrastructure/config/security.config.ts
+++ b/packages/backend/src/infrastructure/config/security.config.ts
@@ -7,21 +7,21 @@ import type { HelmetOptions } from 'helmet';
  */
 
 /**
- * Helmet-Konfiguration für sichere HTTP-Header
+ * Strikte Helmet-Konfiguration für sichere HTTP-Header (Anwendungsstandard)
  *
  * Diese Konfiguration setzt verschiedene Sicherheits-Header,
  * um die Anwendung gegen gängige Webangriffe zu schützen.
  * Enthält CSP, HSTS, X-Frame-Options und weitere Schutzmaßnahmen.
+ * CSP ist restriktiv und erlaubt keine unsicheren Inline-Skripte oder -Stile.
  *
  * @constant {HelmetOptions}
  */
 export const helmetConfig: HelmetOptions = {
-  // Content Security Policy - Verhindert XSS-Angriffe
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      styleSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
-      scriptSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
+      styleSrc: ["'self'"], // Keine unsicheren Inline-Stile
+      scriptSrc: ["'self'"], // Keine unsicheren Inline-Skripte
       imgSrc: ["'self'", 'data:', 'https:'],
       connectSrc: ["'self'"],
       fontSrc: ["'self'"],
@@ -31,30 +31,42 @@ export const helmetConfig: HelmetOptions = {
       frameAncestors: ["'none'"],
     },
   },
-  // Cross-Origin-Embedder-Policy
-  crossOriginEmbedderPolicy: false, // Für Swagger UI deaktiviert
-  // DNS Prefetch Control
+  crossOriginEmbedderPolicy: true,
   dnsPrefetchControl: { allow: false },
-  // Frameguard - Verhindert Clickjacking
   frameguard: { action: 'deny' },
-  // Hide Powered By - Versteckt X-Powered-By Header
   hidePoweredBy: true,
-  // HSTS - HTTP Strict Transport Security
   hsts: {
     maxAge: 31536000, // 1 Jahr
     includeSubDomains: true,
     preload: true,
   },
-  // IE No Open - Verhindert IE Downloads zu öffnen
   ieNoOpen: true,
-  // No Sniff - Verhindert MIME-Type Sniffing
   noSniff: true,
-  // Origin Agent Cluster
   originAgentCluster: true,
-  // Permitted Cross Domain Policies
   permittedCrossDomainPolicies: false,
-  // Referrer Policy
   referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+};
+
+/**
+ * Gelockerte Helmet-Konfiguration speziell für die Swagger UI
+ *
+ * Diese Konfiguration ist eine Erweiterung der strikten Konfiguration,
+ * erlaubt jedoch 'unsafe-inline' für Skripte und Stile, was für die
+ * Funktionsfähigkeit der Swagger UI notwendig ist.
+ * Sie sollte NUR für den Swagger-Endpunkt verwendet werden.
+ *
+ * @constant {HelmetOptions}
+ */
+export const swaggerHelmetConfig: HelmetOptions = {
+  ...helmetConfig,
+  contentSecurityPolicy: {
+    directives: {
+      ...(helmetConfig.contentSecurityPolicy as { directives: Record<string, unknown> }).directives,
+      styleSrc: ["'self'", "'unsafe-inline'"], // Erforderlich für Swagger UI
+      scriptSrc: ["'self'", "'unsafe-inline'"], // Erforderlich für Swagger UI
+    },
+  },
+  crossOriginEmbedderPolicy: false, // Erforderlich für Swagger UI
 };
 
 /**

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -12,7 +12,8 @@ import { AppModule } from './app.module';
 import { validateInsecureMode } from './infrastructure/config/bootstrap-validation';
 import { PerformanceInterceptor } from './infrastructure/http/interceptors/performance.interceptor';
 import { TransformInterceptor } from './infrastructure/http/interceptors/transform.interceptor';
-import { corsConfig, helmetConfig } from './infrastructure/config/security.config';
+import { corsConfig, helmetConfig, swaggerHelmetConfig } from './infrastructure/config/security.config';
+import type { NextFunction, Request, Response } from 'express';
 
 require('@dotenvx/dotenvx').config();
 
@@ -140,7 +141,14 @@ X-Server-Access-Token: <plaintext_token>
   SwaggerModule.setup('api', app, document, {});
 
   // Apply Helmet middleware for security headers
-  app.use(helmet(helmetConfig));
+  // We use a stricter policy for the app and a more lenient one for Swagger UI
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    if (req.path.startsWith('/api')) {
+      helmet(swaggerHelmetConfig)(req, res, next);
+    } else {
+      helmet(helmetConfig)(req, res, next);
+    }
+  });
 
   // Apply cookie parser middleware
   app.use(cookieParser());


### PR DESCRIPTION
This PR hardens the application's Content Security Policy (CSP) by implementing a stricter default policy and applying a more lenient one only to the Swagger UI route. This significantly reduces the XSS attack surface while preserving developer tool functionality.

**Vulnerability:** The previous implementation used a single, globally permissive CSP that allowed `'unsafe-inline'` for scripts and styles to support Swagger UI. This exposed the entire application to unnecessary XSS risks.

**Fix:**
1.  **Dual CSP Strategy:** Created two distinct Helmet.js configurations:
    *   `helmetConfig`: A strict default policy that disallows all inline scripts and styles.
    *   `swaggerHelmetConfig`: A specific, more lenient policy for Swagger UI that permits `'unsafe-inline'`.
2.  **Conditional Application:** Modified `main.ts` to apply the strict `helmetConfig` to all incoming requests by default, and the lenient `swaggerHelmetConfig` only to requests targeting the `/api` path.

**Impact:** The application is now significantly more secure against XSS attacks. The attack surface has been minimized by adhering to the principle of least privilege.

**Verification:**
- The backend builds successfully.
- Smoke tests were attempted but blocked by a local environment issue (Docker pull rate limit). Given the targeted nature of the change and a successful code review, the risk of regression is low.

---
*PR created automatically by Jules for task [8468163731767489311](https://jules.google.com/task/8468163731767489311) started by @rubenvitt*