### PR TITLE
🛡️ Sentinel: Restrict permissive CSP to Swagger UI only

### DIFF
--- a/packages/backend/src/infrastructure/config/security.config.ts
+++ b/packages/backend/src/infrastructure/config/security.config.ts
@@ -7,32 +7,9 @@ import type { HelmetOptions } from 'helmet';
  */
 
 /**
- * Helmet-Konfiguration für sichere HTTP-Header
- *
- * Diese Konfiguration setzt verschiedene Sicherheits-Header,
- * um die Anwendung gegen gängige Webangriffe zu schützen.
- * Enthält CSP, HSTS, X-Frame-Options und weitere Schutzmaßnahmen.
- *
- * @constant {HelmetOptions}
+ * Gemeinsame Helmet-Optionen, die für alle Konfigurationen gelten.
  */
-export const helmetConfig: HelmetOptions = {
-  // Content Security Policy - Verhindert XSS-Angriffe
-  contentSecurityPolicy: {
-    directives: {
-      defaultSrc: ["'self'"],
-      styleSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
-      scriptSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI
-      imgSrc: ["'self'", 'data:', 'https:'],
-      connectSrc: ["'self'"],
-      fontSrc: ["'self'"],
-      objectSrc: ["'none'"],
-      mediaSrc: ["'self'"],
-      frameSrc: ["'none'"],
-      frameAncestors: ["'none'"],
-    },
-  },
-  // Cross-Origin-Embedder-Policy
-  crossOriginEmbedderPolicy: false, // Für Swagger UI deaktiviert
+const sharedHelmetOptions: HelmetOptions = {
   // DNS Prefetch Control
   dnsPrefetchControl: { allow: false },
   // Frameguard - Verhindert Clickjacking
@@ -58,12 +35,65 @@ export const helmetConfig: HelmetOptions = {
 };
 
 /**
+ * Gemeinsame CSP-Directives.
+ */
+const sharedCSPDirectives = {
+  defaultSrc: ["'self'"],
+  imgSrc: ["'self'", 'data:', 'https:'],
+  connectSrc: ["'self'"],
+  fontSrc: ["'self'"],
+  objectSrc: ["'none'"],
+  mediaSrc: ["'self'"],
+  frameSrc: ["'none'"],
+  frameAncestors: ["'none'"],
+};
+
+/**
+ * Strikte Helmet-Konfiguration (Standard für die App)
+ *
+ * Deaktiviert 'unsafe-inline' in der CSP für maximale Sicherheit.
+ */
+export const strictHelmetConfig: HelmetOptions = {
+  ...sharedHelmetOptions,
+  contentSecurityPolicy: {
+    directives: {
+      ...sharedCSPDirectives,
+      styleSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+    },
+  },
+  crossOriginEmbedderPolicy: true,
+};
+
+/**
+ * Helmet-Konfiguration für Swagger UI
+ *
+ * Erlaubt 'unsafe-inline' in der CSP, damit Swagger UI korrekt funktioniert.
+ * Diese Konfiguration sollte NUR für die Swagger-Routen verwendet werden.
+ */
+export const swaggerHelmetConfig: HelmetOptions = {
+  ...sharedHelmetOptions,
+  contentSecurityPolicy: {
+    directives: {
+      ...sharedCSPDirectives,
+      styleSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI benötigt
+      scriptSrc: ["'self'", "'unsafe-inline'"], // Für Swagger UI benötigt
+    },
+  },
+  crossOriginEmbedderPolicy: false, // Für Swagger UI deaktiviert
+};
+
+/**
+ * Abwärtskompatibler Export (entspricht der bisherigen helmetConfig)
+ * @deprecated Nutze strictHelmetConfig oder swaggerHelmetConfig je nach Route
+ */
+export const helmetConfig: HelmetOptions = swaggerHelmetConfig;
+
+/**
  * CORS-Konfiguration für verschiedene Umgebungen
  *
  * Definiert Cross-Origin Resource Sharing Einstellungen
  * für Development- und Production-Umgebungen.
- *
- * @constant
  */
 /**
  * Dynamische Origin-Validierung für Tauri und Development

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -12,7 +12,8 @@ import { AppModule } from './app.module';
 import { validateInsecureMode } from './infrastructure/config/bootstrap-validation';
 import { PerformanceInterceptor } from './infrastructure/http/interceptors/performance.interceptor';
 import { TransformInterceptor } from './infrastructure/http/interceptors/transform.interceptor';
-import { corsConfig, helmetConfig } from './infrastructure/config/security.config';
+import { corsConfig, strictHelmetConfig, swaggerHelmetConfig } from './infrastructure/config/security.config';
+import type { NextFunction, Request, Response } from 'express';
 
 require('@dotenvx/dotenvx').config();
 
@@ -139,8 +140,19 @@ X-Server-Access-Token: <plaintext_token>
 
   SwaggerModule.setup('api', app, document, {});
 
-  // Apply Helmet middleware for security headers
-  app.use(helmet(helmetConfig));
+  /**
+   * Konditionale Anwendung von Helmet-Sicherheits-Headern.
+   *
+   * Verwendet eine strikte CSP für alle App-Routen und eine permissivere
+   * Konfiguration für Swagger UI, damit dieses korrekt gerendert werden kann.
+   */
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    // Swagger UI wird unter /api serviert. API-Routen sind versioniert (/api/v-...).
+    const isSwaggerPath = req.path === '/api' || req.path === '/api/' || req.path.startsWith('/api-json') || (req.path.startsWith('/api/') && !req.path.includes('/v-'));
+
+    const helmetOptions = isSwaggerPath ? swaggerHelmetConfig : strictHelmetConfig;
+    return helmet(helmetOptions)(req, res, next);
+  });
 
   // Apply cookie parser middleware
   app.use(cookieParser());


### PR DESCRIPTION
I have implemented a security enhancement that restricts the permissive Content Security Policy (CSP) to only the Swagger UI routes.

Previously, the backend applied a global Helmet configuration that allowed `'unsafe-inline'` for both scripts and styles across the entire application to support Swagger UI. This weakened the XSS protection for all other routes, including the API.

My changes include:
1. Refactoring `packages/backend/src/infrastructure/config/security.config.ts` to provide two distinct configurations:
   - `strictHelmetConfig`: Disallows `'unsafe-inline'` and enables `crossOriginEmbedderPolicy`.
   - `swaggerHelmetConfig`: Maintains the permissive settings required for Swagger UI.
2. Updating `packages/backend/src/main.ts` with a conditional middleware that applies `swaggerHelmetConfig` only to Swagger-related paths (`/api`, `/api-json`, and non-versioned assets under `/api/`) and uses `strictHelmetConfig` for everything else.

This follows the principle of least privilege and significantly hardens the application's security posture.

---
*PR created automatically by Jules for task [15361909041344445443](https://jules.google.com/task/15361909041344445443) started by @rubenvitt*