### PR TITLE
🎨 Palette: Improve Alert component accessibility

### DIFF
--- a/packages/frontend/src/shared/ui/atoms/__tests__/alert.atom.test.tsx
+++ b/packages/frontend/src/shared/ui/atoms/__tests__/alert.atom.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Alert } from '../alert.atom';
+
+describe('Alert Atom', () => {
+  it('should render with default role "status" for info status', () => {
+    render(<Alert status="info" title="Info" />);
+    const alert = screen.getByRole('status');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Info');
+  });
+
+  it('should render with role "alert" for error status', () => {
+    render(<Alert status="error" title="Error" />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Error');
+  });
+
+  it('should render with role "status" for warning status', () => {
+    render(<Alert status="warning" title="Warning" />);
+    const alert = screen.getByRole('status');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Warning');
+  });
+
+  it('should render with role "status" for success status', () => {
+    render(<Alert status="success" title="Success" />);
+    const alert = screen.getByRole('status');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Success');
+  });
+
+  it('should allow overriding the role', () => {
+    render(<Alert status="error" title="Quiet Error" role="status" />);
+    const alert = screen.getByRole('status');
+    expect(alert).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/shared/ui/atoms/alert.atom.tsx
+++ b/packages/frontend/src/shared/ui/atoms/alert.atom.tsx
@@ -9,6 +9,11 @@ interface AlertProps {
   icon?: React.ReactNode;
   className?: string;
   children?: React.ReactNode;
+  /**
+   * Accessible role for the alert.
+   * Defaults to 'alert' for error status, and 'status' for others.
+   */
+  role?: string;
 }
 
 /**
@@ -16,7 +21,7 @@ interface AlertProps {
  *
  * Komponente für Benachrichtigungen und Warnungen
  */
-function Alert({ status = 'info', title, description, icon, className, children }: AlertProps) {
+function Alert({ status = 'info', title, description, icon, className, children, role }: AlertProps) {
   const statusStyles = {
     info: 'bg-blue-50 border-blue-200 text-blue-800',
     warning: 'bg-yellow-50 border-yellow-200 text-yellow-800',
@@ -31,8 +36,11 @@ function Alert({ status = 'info', title, description, icon, className, children 
     success: <PiCheckCircleFill className="h-5 w-5" aria-hidden="true" />,
   };
 
+  // Determine role based on status if not provided
+  const defaultRole = status === 'error' ? 'alert' : 'status';
+
   return (
-    <div className={cn('flex gap-3 rounded-lg border p-4', statusStyles[status], className)}>
+    <div role={role || defaultRole} className={cn('flex gap-3 rounded-lg border p-4', statusStyles[status], className)}>
       <div className="flex-shrink-0">{icon || defaultIcons[status]}</div>
       <div className="flex-1">
         {title && <h3 className="mb-1 font-medium text-sm">{title}</h3>}


### PR DESCRIPTION
💡 What: Added ARIA roles to the `Alert` component.
🎯 Why: Screen readers were not automatically announcing dynamic alerts (especially errors).
♿ Accessibility:
  - Error alerts now have `role="alert"` (assertive).
  - Other alerts have `role="status"` (polite).
  - Tests added to verify role assignment.

---
*PR created automatically by Jules for task [6671983410449677466](https://jules.google.com/task/6671983410449677466) started by @rubenvitt*