### PR TITLE
🔧(release): Fix doppelte Release Notes und aktiviere GitHub-Kommentare

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -160,10 +160,8 @@ WIP Änderungen:
           'frontend-artifacts/**/*.exe',
           'frontend-artifacts/**/*.deb',
         ],
-        successComment:
-          '🎉 Dieses Issue/PR wurde im Release [v${nextRelease.version}](${releases.filter(release => release.name)[0]?.url || ""}) veröffentlicht.',
-        failComment:
-          '❌ Das Release ist fehlgeschlagen. Details in den [CI Logs](${branch.url}).',
+        successComment: '🎉 Dieses Issue/PR wurde im Release [v${nextRelease.version}](${releases.filter(release => release.name)[0]?.url || ""}) veröffentlicht.',
+        failComment: '❌ Das Release ist fehlgeschlagen. Details in den [CI Logs](${branch.url}).',
       },
     ],
   ],

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -124,7 +124,6 @@ WIP Änderungen:
         },
       },
     ],
-    '@semantic-release/release-notes-generator',
     [
       '@semantic-release/changelog',
       {
@@ -161,8 +160,10 @@ WIP Änderungen:
           'frontend-artifacts/**/*.exe',
           'frontend-artifacts/**/*.deb',
         ],
-        successComment: false,
-        failComment: false,
+        successComment:
+          '🎉 Dieses Issue/PR wurde im Release [v${nextRelease.version}](${releases.filter(release => release.name)[0]?.url || ""}) veröffentlicht.',
+        failComment:
+          '❌ Das Release ist fehlgeschlagen. Details in den [CI Logs](${branch.url}).',
       },
     ],
   ],


### PR DESCRIPTION
- Entferne redundantes @semantic-release/release-notes-generator Plugin,
  da semantic-release-gitmoji bereits eigene Notes generiert (verhindert
  doppelte CHANGELOG-Einträge auf Deutsch + Englisch)
- Aktiviere successComment/failComment im @semantic-release/github Plugin,
  damit Issues und PRs automatisch benachrichtigt werden wenn sie in einem
  Release enthalten sind

https://claude.ai/code/session_01Uh1EomSPJYaminYQzip6PT