### PR TITLE
Dediziertes Migrations-Docker-Image und Production-Dockerfile fixen

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,10 +17,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # App image (production target)
           - platform: linux/amd64
             runner: ubuntu-24.04
+            target: production
+            variant: app
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+            target: production
+            variant: app
+          # Migrations image
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            target: migrations
+            variant: migrations
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            target: migrations
+            variant: migrations
     permissions:
       contents: read
       packages: write
@@ -38,22 +52,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine image name
+        id: image
+        run: |
+          if [ "${{ matrix.variant }}" = "app" ]; then
+            echo "name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ steps.image.outputs.name }}
 
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
+          target: ${{ matrix.target }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+          outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}-${{ matrix.variant }}
+          cache-to: type=gha,scope=${{ matrix.platform }}-${{ matrix.variant }},mode=max
 
       - name: Export digest
         run: |
@@ -64,7 +88,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.runner }}
+          name: digests-${{ matrix.variant }}-${{ matrix.runner }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -72,6 +96,14 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: app
+            image_suffix: ""
+          - variant: migrations
+            image_suffix: "/migrations"
     permissions:
       contents: read
       packages: write
@@ -81,7 +113,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-*
+          pattern: digests-${{ matrix.variant }}-*
           merge-multiple: true
 
       - name: Log in to GitHub Container Registry
@@ -98,7 +130,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -110,4 +142,4 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}@sha256:%s ' *)

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,28 +31,30 @@ RUN pnpm --filter @bluelight-hub/frontend build
 FROM shared-builder AS backend-builder
 RUN pnpm --filter @bluelight-hub/backend build
 
+## Production dependencies: generate Prisma client, then prune dev deps
+FROM base AS prod-deps
+COPY packages/backend/prisma ./packages/backend/prisma
+RUN cd packages/backend && pnpm exec prisma generate
+RUN CI=true pnpm prune --prod
+
 ## Production image: minimal runtime with pre-built artifacts only
 FROM node:25-alpine AS production
-RUN apk add --no-cache python3 make g++ wget \
-    && npm install -g pnpm
+RUN apk add --no-cache python3 make g++ wget
 WORKDIR /app
 
-# Copy workspace metadata needed for pnpm to resolve workspaces
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY packages/shared/package.json ./packages/shared/
-COPY packages/backend/package.json ./packages/backend/
-
-# Reuse node_modules (mit generiertem Prisma Client) aus dem Backend-Builder
-COPY --from=backend-builder /app/node_modules ./node_modules
-
-# Dev-Abhängigkeiten entfernen, Prisma-Client bleibt erhalten
-# --filter begrenzt prune auf das Backend-Package, damit pnpm die Workspace-Struktur korrekt auflöst
-RUN CI=true pnpm --filter @bluelight-hub/backend prune --prod
+# Production node_modules (Prisma client generated, dev deps removed)
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=prod-deps /app/package.json ./
+COPY --from=prod-deps /app/pnpm-lock.yaml ./
+COPY --from=prod-deps /app/pnpm-workspace.yaml ./
+COPY --from=prod-deps /app/packages/backend/package.json ./packages/backend/
+COPY --from=prod-deps /app/packages/shared/package.json ./packages/shared/
 
 # Copy build outputs and runtime assets
 COPY --from=shared-builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=shared-builder /app/packages/shared/client ./packages/shared/client
 COPY --from=backend-builder /app/packages/backend/dist ./packages/backend/dist
+COPY --from=backend-builder /app/packages/backend/src/generated ./packages/backend/src/generated
 COPY --from=backend-builder /app/packages/backend/prisma ./packages/backend/prisma
 COPY --from=backend-builder /app/packages/backend/.config ./packages/backend/.config
 COPY --from=frontend-builder /app/packages/frontend/dist ./public
@@ -65,10 +67,17 @@ RUN mkdir -p /app/uploads/lagekarte \
     && chown -R node:node /app/uploads
 
 USER node
-EXPOSE 3090
+EXPOSE 3091
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3090/api/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3091/api/health || exit 1
 
 # Start NestJS backend (dist/src/main wird von nest build erzeugt)
 CMD ["node", "dist/src/main"]
+
+## Migrations image: Prisma CLI + schema + migrations only
+FROM base AS migrations
+COPY packages/backend/prisma ./packages/backend/prisma
+WORKDIR /app/packages/backend
+RUN pnpm exec prisma generate
+CMD ["pnpm", "exec", "prisma", "migrate", "deploy"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,27 @@ services:
       retries: 5
       start_period: 10s
 
-  app:
+  migrations:
+    image: ${MIGRATIONS_IMAGE:-ghcr.io/rubenvitt/bluelight-hub/migrations:latest}
     build:
       context: .
       dockerfile: Dockerfile
+      target: migrations
+    environment:
+      - DATABASE_URL=postgresql://${DATABASE_USER:-bluelight}:${DATABASE_PASSWORD:-bluelight}@postgres:5432/${DATABASE_NAME:-bluelight-hub}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+    profiles:
+      - full-app
+
+  app:
+    image: ${APP_IMAGE:-ghcr.io/rubenvitt/bluelight-hub:latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
     ports:
       - "3091:3091"
     volumes:
@@ -34,6 +51,8 @@ services:
       - DATABASE_PASSWORD=${DATABASE_PASSWORD:-bluelight}
       - DATABASE_NAME=${DATABASE_NAME:-bluelight-hub}
     depends_on:
+      migrations:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- **Port-Fix**: EXPOSE und Healthcheck von 3090 auf 3091 korrigiert (Match mit Backend-Port)
- **Neuer `prod-deps` Stage**: Prisma Client wird vor Dev-Dependency Prune generiert, saubere Production node_modules
- **Neuer `migrations` Target**: Schlankes Docker-Image mit Prisma CLI für `prisma migrate deploy` (kein Runtime-Install mehr nötig)
- **docker-compose**: Migrations-Service mit GHCR-Image-Referenz, App startet erst nach erfolgreicher Migration
- **Pipeline**: Build-Matrix erweitert für parallelen Build beider Images (app + migrations) als Multi-Arch (amd64 + arm64)

Fixes #358

## Test plan
- [x] `docker build --target production .` baut erfolgreich
- [x] `docker build --target migrations .` baut erfolgreich
- [ ] Production-Image starten und Healthcheck `/api/health` auf Port 3091 verifizieren
- [ ] Migrations-Image gegen PostgreSQL testen: `prisma migrate deploy` läuft korrekt
- [ ] Pipeline-Run auf GitHub Actions verifizieren (beide Images gebaut + gepushed)
- [ ] `docker compose --profile full-app up` testet den kompletten Flow (postgres → migrations → app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)