### PR TITLE
🐛(release): Fix Tauri-Build und Docker-Build in Release Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev
 
       # Use reusable build action for dependencies
       - name: Setup Build Environment


### PR DESCRIPTION
- libasound2-dev als Ubuntu-Abhängigkeit für alsa-sys Crate hinzugefügt
- pnpm prune --prod durch pnpm install --prod ersetzt (prune unterstützt kein --filter und ist in neueren pnpm-Versionen veraltet)
- Prisma Client wird separat aus dem Builder-Stage kopiert

https://claude.ai/code/session_01X9drAd7RS62RrbEkRCoRCH