### PR TITLE
🐛(docker): Fix migrations image prisma config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,5 +79,7 @@ CMD ["node", "dist/src/main"]
 FROM base AS migrations
 COPY packages/backend/prisma ./packages/backend/prisma
 WORKDIR /app/packages/backend
+# Minimale Config ohne dotenvx - DATABASE_URL kommt direkt als Environment-Variable
+RUN printf 'import { defineConfig } from "prisma/config";\nexport default defineConfig({ datasource: { url: process.env.DATABASE_URL } });\n' > prisma.config.ts
 RUN pnpm exec prisma generate
 CMD ["pnpm", "exec", "prisma", "migrate", "deploy"]


### PR DESCRIPTION
## Summary

- Fix Docker migrations target failing with "datasource.url property is required" error
- The original `prisma.config.ts` imports `@dotenvx/dotenvx/config` which throws in the container environment
- Generate a minimal inline prisma config that reads `DATABASE_URL` directly from environment variables

## Changes

**Docker**
- Add inline `prisma.config.ts` generation in the migrations Dockerfile target
- No dotenvx dependency needed — `DATABASE_URL` comes from compose environment

## Test plan

- [ ] Build migrations image: `docker build --target migrations -t blh-migrations .`
- [ ] Run migrations container with `DATABASE_URL` env var and verify `prisma migrate deploy` succeeds
- [ ] Verify production image still builds and starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)