### PR TITLE
🐛(docker): Fix production image missing pnpm workspace deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ WORKDIR /app
 
 # Production node_modules (Prisma client generated, dev deps removed)
 COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=prod-deps /app/packages/backend/node_modules ./packages/backend/node_modules
+COPY --from=prod-deps /app/packages/shared/node_modules ./packages/shared/node_modules
 COPY --from=prod-deps /app/package.json ./
 COPY --from=prod-deps /app/pnpm-lock.yaml ./
 COPY --from=prod-deps /app/pnpm-workspace.yaml ./


### PR DESCRIPTION
## Summary

- Fix `Cannot find module '@nestjs/common'` error in production Docker container
- pnpm's strict module isolation means package-level `node_modules` must be explicitly copied, not just root `node_modules`
- Also includes prior fixes: Docker build targets, migrations image, lint-staged config, worktree support, and root endpoint access during setup

## Changes

**Docker**
- Copy `packages/backend/node_modules` and `packages/shared/node_modules` from `prod-deps` stage into the production image
- Added inline prisma config to migrations target (prior commit)
- Fixed Docker build targets and added migrations image (prior commit)

**Config**
- Excluded generated files from lint-staged check
- Fixed command file path resolution for worktrees
- Added concurrency group to prevent parallel releases
- Replaced gitmoji template with Claude-generated release notes

**API**
- Allow root endpoint access during setup

**Dependencies**
- Bumped TanStack and dev dependencies

## Test plan

- [ ] Build Docker image: `docker compose build app`
- [ ] Run production container and verify NestJS starts without module errors
- [ ] Verify health check passes: `GET /api/health`
- [ ] Run migrations image: `docker compose --profile full-app up migrations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)