### PR TITLE
🐛(docker): Fix Docker build and release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -33,6 +34,14 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - '.github/**'
+            docker:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '.npmrc'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - 'packages/*/package.json'
 
   # Linux build with PostgreSQL database
   build-and-test-linux:
@@ -157,10 +166,41 @@ jobs:
       - name: Check JSDoc coverage
         run: pnpm --filter @bluelight-hub/backend check:jsdoc:public || true
 
+  # Docker build smoke test (no push)
+  docker-build:
+    name: Docker Build
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build production image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: production
+          push: false
+          cache-from: type=gha,scope=docker-build-production
+          cache-to: type=gha,scope=docker-build-production,mode=max
+
+      - name: Build migrations image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: migrations
+          push: false
+          cache-from: type=gha,scope=docker-build-migrations
+          cache-to: type=gha,scope=docker-build-migrations,mode=max
+
   # Summary job for branch protection
   summary:
     name: CI Pipeline Summary
-    needs: [detect-changes, build-and-test-linux, build-and-test-other]
+    needs: [detect-changes, build-and-test-linux, build-and-test-other, docker-build]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -169,15 +209,18 @@ jobs:
           changes="${{ needs.detect-changes.result }}"
           linux="${{ needs.build-and-test-linux.result }}"
           other="${{ needs.build-and-test-other.result }}"
+          docker="${{ needs.docker-build.result }}"
           if [[ "$changes" != "success" ]]; then
             echo "❌ Change detection failed: $changes"
             exit 1
           fi
           if [[ "$linux" != "success" && "$linux" != "skipped" ]] || \
-             [[ "$other" != "success" && "$other" != "skipped" ]]; then
+             [[ "$other" != "success" && "$other" != "skipped" ]] || \
+             [[ "$docker" != "success" && "$docker" != "skipped" ]]; then
             echo "❌ One or more jobs failed"
             echo "Linux: $linux"
             echo "Other: $other"
+            echo "Docker: $docker"
             exit 1
           fi
           echo "✅ All CI checks passed"
@@ -191,6 +234,7 @@ jobs:
 
           linux="${{ needs.build-and-test-linux.result }}"
           other="${{ needs.build-and-test-other.result }}"
+          docker="${{ needs.docker-build.result }}"
 
           status_icon() {
             case "$1" in
@@ -202,9 +246,11 @@ jobs:
 
           echo "| Build & Test (Linux) | $(status_icon "$linux") $linux |" >> $GITHUB_STEP_SUMMARY
           echo "| Build & Test (Other) | $(status_icon "$other") $other |" >> $GITHUB_STEP_SUMMARY
+          echo "| Docker Build | $(status_icon "$docker") $docker |" >> $GITHUB_STEP_SUMMARY
           echo "| Lightweight Checks | ℹ️ non-blocking |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Platform Results" >> $GITHUB_STEP_SUMMARY
           echo "- Linux: $linux (with PostgreSQL)" >> $GITHUB_STEP_SUMMARY
           echo "- macOS: $other" >> $GITHUB_STEP_SUMMARY
           echo "- Windows: $other (tests skipped)" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker: $docker" >> $GITHUB_STEP_SUMMARY

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+inject-workspace-packages=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache python3 make g++ wget \
 WORKDIR /app
 
 # Copy only dependency manifests to maximize cache hits
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY packages/backend/package.json ./packages/backend/
 COPY packages/frontend/package.json ./packages/frontend/
 COPY packages/shared/package.json ./packages/shared/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
 
 overrides:
   mermaid: '>=11.10.0'


### PR DESCRIPTION
## Summary

- Fix Docker backend build failing with `ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE` by enabling `inject-workspace-packages=true` (pnpm v10 requirement)
- Fix Docker build targets, add dedicated migrations image, and add release-branch tags to Docker images
- Various config fixes: lint-staged generated files exclusion, worktree command paths, root endpoint access during setup

## Changes

**Docker / Config**
- Add `.npmrc` with `inject-workspace-packages=true` for pnpm v10 compatibility
- Copy `.npmrc` into Docker build context
- Replace `pnpm prune` with `pnpm deploy` for reliable production deps isolation
- Add dedicated migrations image target
- Add inline prisma config to migrations target

**CI/CD**
- Add release-branch tags (alpha, beta, latest) to Docker images
- Fix Docker build targets in release pipeline
- Add concurrency group to prevent parallel releases
- Accelerate CI pipeline for PRs
- Replace gitmoji template with Claude-generated release notes

**Backend**
- Allow root endpoint access during setup
- Exclude generated files from lint-staged check
- Fix command file path resolution for worktrees

## Test plan

- [ ] Verify Docker backend image builds successfully in CI
- [ ] Verify `pnpm deploy --prod` works with `inject-workspace-packages=true`
- [ ] Verify migrations image builds and runs correctly
- [ ] Verify release pipeline creates correct Docker tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)