### PR TITLE
🐛(docker): Fix Docker build, uploads path and image tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,14 +155,12 @@ jobs:
               echo "TAGS<<EOF"
               echo "type=raw,value=latest"
               echo "type=raw,value=main"
-              echo "type=raw,value=main-${GITHUB_RUN_NUMBER}"
               echo "EOF"
             } >> $GITHUB_ENV
           else
             {
               echo "TAGS<<EOF"
               echo "type=raw,value=${BRANCH}"
-              echo "type=raw,value=${BRANCH}-${GITHUB_RUN_NUMBER}"
               echo "EOF"
             } >> $GITHUB_ENV
           fi
@@ -357,3 +355,35 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           RELEASE_NOTES: ${{ github.workspace }}/RELEASE_NOTES.md
         run: npx semantic-release
+
+      - name: Get released version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Released version: $VERSION"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag Docker images with release version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+
+          # Tag app image with version
+          docker buildx imagetools create \
+            -t "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${BRANCH}"
+
+          # Tag migrations image with version
+          docker buildx imagetools create \
+            -t "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/migrations:${VERSION}" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/migrations:${BRANCH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY --from=backend-builder /app/packages/backend/package.json ./packages/backen
 COPY --from=frontend-builder /app/packages/frontend/dist ./public
 
 ENV NODE_ENV=production
+ENV UPLOADS_PATH=/app/uploads
 WORKDIR /app/packages/backend
 
 # Prepare uploads directory and ensure node user owns runtime paths

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -9,7 +9,7 @@ import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { ServeStaticModule } from '@nestjs/serve-static';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { AppController } from './app.controller';
 import { AuthModule } from './modules/auth/auth.module';
 import { InfrastructureCommonModule } from './infrastructure/common.module';
@@ -84,7 +84,7 @@ import { SchedulerModule } from './infrastructure/scheduler/scheduler.module';
       },
     }),
     ServeStaticModule.forRoot({
-      rootPath: join(process.cwd(), process.env.UPLOADS_PATH || 'uploads'),
+      rootPath: resolve(process.cwd(), process.env.UPLOADS_PATH || 'uploads'),
       serveRoot: '/uploads',
       serveStaticOptions: {
         index: false,

--- a/packages/backend/src/modules/lagekarte/controllers/lagekarte.controller.ts
+++ b/packages/backend/src/modules/lagekarte/controllers/lagekarte.controller.ts
@@ -38,7 +38,7 @@ import {
 } from '@nestjs/swagger';
 import { ApiWrappedCreatedResponse } from '@/modules/common/decorators/api-wrapped-response.decorator';
 import { diskStorage } from 'multer';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { existsSync, mkdirSync, unlinkSync } from 'node:fs';
 import { SaveLagekarteStateDto } from '../dto/save-lagekarte-state.dto';
 import { Lagekarte } from '@/generated/prisma/client';
@@ -102,7 +102,7 @@ export class LagekarteController {
   ) {
     // Get uploads path from ENV or use default (relative to project root)
     const uploadsBase = this.configService.get<string>('UPLOADS_PATH') || 'uploads';
-    this.uploadsPath = join(process.cwd(), uploadsBase);
+    this.uploadsPath = resolve(process.cwd(), uploadsBase);
     this.uploadDir = join(this.uploadsPath, 'lagekarte');
 
     // Ensure uploads directory exists
@@ -249,7 +249,7 @@ export class LagekarteController {
         destination: (_req, _file, cb) => {
           // Use project root for uploads (consistent with ServeStaticModule)
           const uploadsBase = process.env.UPLOADS_PATH || 'uploads';
-          const uploadsPath = join(process.cwd(), uploadsBase);
+          const uploadsPath = resolve(process.cwd(), uploadsBase);
           const uploadDir = join(uploadsPath, 'lagekarte');
 
           // Ensure directory exists


### PR DESCRIPTION
## Summary

- Fix Docker backend build failing with pnpm v10 (`ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE`)
- Fix uploads path resolution so absolute `UPLOADS_PATH` env var works correctly in Docker
- Tag Docker images with actual semantic-release version instead of pipeline run number
- Add Docker build smoke test to CI pipeline to catch Dockerfile issues early in PRs

## Changes

**Docker**
- Add `.npmrc` with `inject-workspace-packages=true` for pnpm v10 compatibility
- Copy `.npmrc` into Docker build context
- Set `UPLOADS_PATH=/app/uploads` in Dockerfile

**Backend**
- Use `path.resolve` instead of `path.join` for `UPLOADS_PATH` in `app.module.ts` and `lagekarte.controller.ts` (fixes absolute path handling)

**CI/CD**
- Add `docker-build` job to CI pipeline (builds production + migrations targets without push)
- Add `docker` change detection filter for Dockerfile, .npmrc, lockfile etc.
- Remove `GITHUB_RUN_NUMBER` from Docker image tags
- Re-tag Docker images with release version after semantic-release in release job

## Test plan

- [ ] Verify Docker backend image builds successfully in CI
- [ ] Verify `pnpm deploy --prod` works with `inject-workspace-packages=true`
- [ ] Verify uploads directory resolves to `/app/uploads/lagekarte` in container
- [ ] Verify Docker images are tagged with correct release version (e.g. `1.0.0-alpha.55`)
- [ ] Verify CI pipeline runs Docker build smoke test on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)