### PR TITLE
🔧(release): Improve Claude release notes prompt template

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -21,7 +21,7 @@ module.exports = {
       'semantic-release-claude-changelog',
       {
         escaping: 'none',
-        promptTemplate: `Erstelle Release Notes für Version {{version}} (veröffentlicht am {{date}}) des Projekts Bluelight Hub – eine Desktop & Web App für Blaulicht-Organisationen im Katastrophenschutz.
+        promptTemplate: `Erstelle Release Notes des Projekts Bluelight Hub – eine Desktop & Web App für Blaulicht-Organisationen im Katastrophenschutz.
 
 Hier sind die Commits dieses Releases:
 
@@ -52,7 +52,7 @@ Die Release Notes sollen:
 9. Kompakt und scanbar – Qualität vor Quantität
 10. Bei Breaking Changes (💥) diese prominent am Anfang hervorheben
 
-Starte direkt mit dem Versions-Header im Format: ## v{{version}}`,
+Starte direkt mit den Release notes gruppiert wie oben beschrieben mit ## ...`,
       },
     ],
     [


### PR DESCRIPTION
## Summary

- Remove redundant version/date placeholders from the Claude release notes prompt, since semantic-release already handles the version header
- Simplify the output instruction to start directly with grouped sections

## Changes

**Config**
- `.releaserc.js`: Removed `{{version}}` and `{{date}}` from prompt template, updated output format instruction

## Test plan

- [ ] Trigger a release and verify the generated release notes no longer have a duplicate version header
- [ ] Confirm release notes start directly with grouped sections (✨, 🐛, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)