### PR TITLE
🐛(backend): handle missing Befehl handler results without runtime crash

### DIFF
--- a/packages/backend/src/modules/befehl/controllers/befehl.controller.ts
+++ b/packages/backend/src/modules/befehl/controllers/befehl.controller.ts
@@ -263,6 +263,10 @@ export class BefehlController {
 
     const result = await this.createBefehlHandler.execute(command);
 
+    if (!result) {
+      throw new InternalServerErrorException('Befehl-Erstellung lieferte kein Ergebnis');
+    }
+
     if (result.isFailure) {
       throw new BadRequestException(result.error);
     }
@@ -293,6 +297,10 @@ export class BefehlController {
     const command = new QuittierenBefehlCommand(id, dto.empfaengerId, dto.quittierungArt, dto.kommentar);
 
     const result = await this.quittierenBefehlHandler.execute(command);
+
+    if (!result) {
+      throw new InternalServerErrorException('Befehl-Quittierung lieferte kein Ergebnis');
+    }
 
     if (result.isFailure) {
       if (result.error === BEFEHL_ERROR_CODES.NOT_FOUND) {
@@ -335,6 +343,10 @@ export class BefehlController {
 
     const result = await this.aendereEmpfaengerStatusHandler.execute(command);
 
+    if (!result) {
+      throw new InternalServerErrorException('Empfänger-Status-Änderung lieferte kein Ergebnis');
+    }
+
     if (result.isFailure) {
       if (result.error === BEFEHL_ERROR_CODES.NOT_FOUND) {
         throw new NotFoundException(result.error);
@@ -368,6 +380,10 @@ export class BefehlController {
     const command = new KorrigiereBefehlCommand(id, dto.empfaenger, dto.befehlsgeber, dto.erstellerId, dto.auftrag, dto.zeitvorgabe, dto.ereignis, dto.mittel, dto.ziel, dto.weg, dto.befehlsgeberId);
 
     const result = await this.korrigiereBefehlHandler.execute(command);
+
+    if (!result) {
+      throw new InternalServerErrorException('Korrekturbefehl-Erstellung lieferte kein Ergebnis');
+    }
 
     if (result.isFailure) {
       if (result.error === BEFEHL_ERROR_CODES.NOT_FOUND) {


### PR DESCRIPTION
### Motivation
- The Alpha/CI pipeline surfaced runtime `TypeError: Cannot read properties of undefined (reading 'isFailure')` when command handlers returned `undefined`, causing controller code to crash instead of returning deterministic HTTP errors.

### Description
- Add explicit null/undefined guards after `handler.execute()` calls in `BefehlController` to detect missing handler results and throw `InternalServerErrorException` with a clear message. 
- The checks were added for the `create`, `quittieren`, `aendereEmpfaengerStatus`, and `korrigieren` endpoints in `packages/backend/src/modules/befehl/controllers/befehl.controller.ts`. 
- Existing `isFailure` handling (`BadRequestException`/`NotFoundException`) and subsequent `result.value` checks are left intact; the new guards prevent `result.isFailure` from being accessed when `result` is falsy. 
- Change committed with message `🐛(backend): verhindere Absturz bei fehlendem Handler-Result` (file updated: `packages/backend/src/modules/befehl/controllers/befehl.controller.ts`).

### Testing
- Ran the focused controller tests: `pnpm --filter @bluelight-hub/backend test -- src/modules/befehl/controllers/__tests__/befehl.controller.spec.ts` — all tests passed. 
- Linter/type checks for the file: `pnpm --filter @bluelight-hub/backend exec biome check src/modules/befehl/controllers/befehl.controller.ts` — succeeded. 
- Built shared/backend/frontend: `pnpm --filter @bluelight-hub/shared build:ci`, `pnpm --filter @bluelight-hub/backend build`, and `pnpm --filter @bluelight-hub/frontend build` — all succeeded in this environment. 
- Ran architecture/circular checks: `pnpm --filter @bluelight-hub/backend lint:deps:core` — succeeded. 
- Note: repository-wide `pnpm lint:check` still reports pre-existing diagnostics unrelated to this fix, and the local Node version emits an engine warning versus the repo target (`node >=24`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a426697e84832184b3cb63a4a51050)