### PR TITLE
fix(tauri): use rodio 0.22 DeviceSinkBuilder in sound module

### DIFF
--- a/packages/frontend/src-tauri/src/sound.rs
+++ b/packages/frontend/src-tauri/src/sound.rs
@@ -8,7 +8,7 @@
 
 use rodio::source::{SineWave, Source};
 use rodio::mixer::Mixer;
-use rodio::{Decoder, OutputStreamBuilder, Sink};
+use rodio::{Decoder, DeviceSinkBuilder, Sink};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
@@ -158,7 +158,7 @@ fn play_sound_internal(
     // Sound in separatem Thread abspielen um nicht zu blockieren
     thread::spawn(move || {
         // OutputStream muss im gleichen Thread wie Sink leben
-        let stream = match OutputStreamBuilder::open_default_stream() {
+        let stream = match DeviceSinkBuilder::open_default_sink() {
             Ok(stream) => stream,
             Err(e) => {
                 log::error!("Konnte Audio-Output nicht initialisieren: {}", e);
@@ -232,7 +232,7 @@ pub fn test_audio(app_handle: AppHandle) -> Result<String, String> {
     log::info!("Audio-Test gestartet");
 
     // Audio-System prüfen
-    let audio_available = match OutputStreamBuilder::open_default_stream() {
+    let audio_available = match DeviceSinkBuilder::open_default_sink() {
         Ok(_) => {
             log::info!("Audio-System verfügbar");
             true


### PR DESCRIPTION
### Motivation
- `rodio = "0.22.1"` renamed the old stream/sink API and the pre-0.22 symbols in `packages/frontend/src-tauri/src/sound.rs` would break `src-tauri` builds once Cargo resolves the new crate version.

### Description
- Replace the import and usages of the old API by changing `use rodio::{..., OutputStreamBuilder, ...}` to `use rodio::{..., DeviceSinkBuilder, ...}` and update `OutputStreamBuilder::open_default_stream()` to `DeviceSinkBuilder::open_default_sink()` in `play_sound_internal` and `test_audio` in `packages/frontend/src-tauri/src/sound.rs`.

### Testing
- Verified the replacements with `rg` to confirm no remaining references to the old symbols; ran `cargo check` in `packages/frontend/src-tauri`, which aborted during native dependency configuration because the system `glib-2.0` development files are missing in this environment and not because of the rodio API change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a441d791508321bf2dc99aa2a1e1f0)