### PR TITLE
ci: upload frontend JUnit results to Codecov and restore README coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Run frontend tests with coverage
         env:
           NODE_ENV: test
-        run: pnpm --filter @bluelight-hub/frontend test:cov
+        run: pnpm --filter @bluelight-hub/frontend vitest --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
 
       - uses: actions/upload-artifact@v7
         if: failure()
@@ -240,6 +240,13 @@ jobs:
           flags: frontend
           name: codecov-linux-frontend
           fail_ci_if_error: false
+
+      - name: Upload frontend test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/frontend/test-report.junit.xml
 
   # Lightweight Checks (Lint + Docs, non-blocking)
   lightweight-checks:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # BlueLight Hub
 
-<!-- Coverage temporarily disabled -->
-<!-- [![codecov](https://codecov.io/gh/rubenvitt/bluelight-hub/graph/badge.svg?token=I5Z3C0FSLL)](https://codecov.io/gh/rubenvitt/bluelight-hub) -->
-
 [![GitHub Actions](https://github.com/rubenvitt/bluelight-hub/actions/workflows/ci.yml/badge.svg)](https://github.com/rubenvitt/bluelight-hub/actions/workflows/ci.yml)
-[![doccov](https://backend-docs.bluelight-hub.rubeen.dev/images/coverage-badge-documentation.svg)](https://backend-docs.bluelight-hub.rubeen.dev)
+[![codecov](https://codecov.io/gh/rubenvitt/bluelight-hub/graph/badge.svg?token=I5Z3C0FSLL)](https://codecov.io/gh/rubenvitt/bluelight-hub)
 
 ## Übersicht
 
@@ -12,12 +9,11 @@ BlueLight Hub ist eine moderne Anwendung, die mit einer Monorepo-Struktur entwic
 einem Frontend (Vite/React mit Tauri-Integration) und einem Backend (
 NestJS), die über ein gemeinsames Modul kommunizieren.
 
-<!-- Coverage temporarily disabled -->
-<!-- ## Charts
+## Charts
 
 ### Coverage
 
-![Coverage](https://codecov.io/gh/rubenvitt/bluelight-hub/graphs/sunburst.svg?token=I5Z3C0FSLL) -->
+![Coverage Sunburst](https://codecov.io/gh/rubenvitt/bluelight-hub/graphs/sunburst.svg?token=I5Z3C0FSLL)
 
 ## Projektstruktur
 


### PR DESCRIPTION
### Motivation

- Provide Test Analytics insights to Codecov by uploading JUnit test results from the frontend test run. 
- Re-enable visible coverage indicators in the README by restoring the Codecov badge and embedding a coverage graph.

### Description

- Update the frontend CI test step to run Vitest with coverage and JUnit output via `pnpm --filter @bluelight-hub/frontend vitest --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml` so a JUnit XML is produced at `packages/frontend/test-report.junit.xml`.
- Add `codecov/test-results-action@v1` to the CI job to upload the produced JUnit report to Codecov Test Analytics with `token: ${{ secrets.CODECOV_TOKEN }}` and `files: packages/frontend/test-report.junit.xml`.
- Restore the Codecov coverage badge and a Sunburst coverage graph in `README.md`, removing the outdated second badge.

### Testing

- Verified the changes via a working tree diff inspection with `git diff -- .github/workflows/ci.yml README.md` and by printing affected file sections, which showed the updated test command and upload step (succeeded). 
- Confirmed Vitest is available in the frontend workspace using `pnpm --filter @bluelight-hub/frontend exec vitest --version` (succeeded). 
- Validated the resulting CI workflow snippet and README badge/graph lines by previewing the files with line-numbered output (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e993bf1083218050ee3fd0697d58)