### PR TITLE
🐛(backend): reject inactive vehicle types in temporary capture

### DIFF
--- a/packages/backend/src/application/kraefte/einsatz-fahrzeuge/commands/erfasse-temporales-fahrzeug/__tests__/erfasse-temporales-fahrzeug.handler.spec.ts
+++ b/packages/backend/src/application/kraefte/einsatz-fahrzeuge/commands/erfasse-temporales-fahrzeug/__tests__/erfasse-temporales-fahrzeug.handler.spec.ts
@@ -236,7 +236,7 @@ describe('ErfasseTemporalesFahrzeugHandler', () => {
       expect(mockEinsatzFahrzeugRepository.save).not.toHaveBeenCalled();
     });
 
-    it('sollte fehlschlagen wenn Fahrzeugtyp inaktiv ist (AC3 - Missing Validation)', async () => {
+    it('sollte fehlschlagen wenn Fahrzeugtyp inaktiv ist (AC3)', async () => {
       // Given (Arrange)
       // Erstelle einen inaktiven Fahrzeugtyp
       const inactiveFahrzeugtyp = Fahrzeugtyp.reconstitute({
@@ -264,13 +264,10 @@ describe('ErfasseTemporalesFahrzeugHandler', () => {
       const result = await handler.execute(command);
 
       // Then (Assert)
-      // TODO: Dieser Test sollte fehlschlagen, tut es aber NICHT!
-      // Der Handler prüft aktuell nicht ob Fahrzeugtyp aktiv ist (siehe JSDoc Line 39).
-      // Erwartetes Verhalten: result.isFailure sollte true sein
-      // Aktuelles Verhalten: Handler akzeptiert inaktive Fahrzeugtypen
-      expect(result.isSuccess).toBe(true); // FIXME: sollte false sein wenn Validierung implementiert ist
-      // expect(result.error).toContain('FAHRZEUGTYP_INACTIVE'); // TODO: Error Code noch nicht definiert
-      // expect(mockEinsatzFahrzeugRepository.save).not.toHaveBeenCalled();
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain(EINSATZ_FAHRZEUG_ERROR_CODES.FAHRZEUGTYP_INACTIVE);
+      expect(result.error).toContain('inaktiv');
+      expect(mockEinsatzFahrzeugRepository.save).not.toHaveBeenCalled();
     });
 
     it('sollte fehlschlagen bei Duplikat-Funkrufname (AC2)', async () => {

--- a/packages/backend/src/application/kraefte/einsatz-fahrzeuge/commands/erfasse-temporales-fahrzeug/erfasse-temporales-fahrzeug.handler.ts
+++ b/packages/backend/src/application/kraefte/einsatz-fahrzeuge/commands/erfasse-temporales-fahrzeug/erfasse-temporales-fahrzeug.handler.ts
@@ -33,7 +33,7 @@ import type { ErfasseTemporalesFahrzeugCommand } from './erfasse-temporales-fahr
  *
  * **AC3 - Fahrzeugtyp-Validierung:**
  * - Lädt Fahrzeugtyp per fahrzeugtypId
- * - Prüft ob Fahrzeugtyp existiert (aktiv/inaktiv Status wird nicht geprüft)
+ * - Prüft ob Fahrzeugtyp existiert und aktiv ist
  *
  * **AC4 - Atomare Event-Persistierung (Outbox Pattern):**
  * - TransactionalCommandHandler sichert atomare Persistierung
@@ -85,6 +85,9 @@ export class ErfasseTemporalesFahrzeugHandler extends TransactionalCommandHandle
       return Result.fail(EinsatzFahrzeugError.format(EINSATZ_FAHRZEUG_ERROR_CODES.FAHRZEUGTYP_NOT_FOUND, `Fahrzeugtyp mit ID '${command.fahrzeugtypId}' nicht gefunden`));
     }
     const fahrzeugtyp = fahrzeugtypResult.value;
+    if (!fahrzeugtyp.istAktiv) {
+      return Result.fail(EinsatzFahrzeugError.format(EINSATZ_FAHRZEUG_ERROR_CODES.FAHRZEUGTYP_INACTIVE, `Fahrzeugtyp '${fahrzeugtyp.bezeichnung}' ist inaktiv und kann nicht verwendet werden`));
+    }
 
     // 3. Duplikat-Check: Funkrufname bereits im Einsatz? (AC2)
     const existsResult = await this.einsatzFahrzeugRepository.existsByEinsatzIdAndFunkrufname(command.einsatzId, command.funkrufname, tx);

--- a/packages/backend/src/domain/kraefte/common/einsatz-fahrzeug-error-codes.ts
+++ b/packages/backend/src/domain/kraefte/common/einsatz-fahrzeug-error-codes.ts
@@ -37,6 +37,8 @@ export const EINSATZ_FAHRZEUG_ERROR_CODES = {
   EINSATZ_NOT_FOUND: 'EINSATZ_FAHRZEUG_EINSATZ_NOT_FOUND',
   /** Referenzierter Fahrzeugtyp nicht gefunden */
   FAHRZEUGTYP_NOT_FOUND: 'EINSATZ_FAHRZEUG_FAHRZEUGTYP_NOT_FOUND',
+  /** Referenzierter Fahrzeugtyp ist inaktiv */
+  FAHRZEUGTYP_INACTIVE: 'EINSATZ_FAHRZEUG_FAHRZEUGTYP_INACTIVE',
   /** EinsatzFahrzeug nicht gefunden */
   NOT_FOUND: 'EINSATZ_FAHRZEUG_NOT_FOUND',
   /** Allgemeiner Validierungsfehler */

--- a/packages/backend/src/modules/kraefte/controllers/einsatz-fahrzeuge.controller.ts
+++ b/packages/backend/src/modules/kraefte/controllers/einsatz-fahrzeuge.controller.ts
@@ -291,7 +291,7 @@ export class EinsatzFahrzeugeController {
   @ApiOperation({ summary: 'Temporäres Fahrzeug für Einsatz erfassen' })
   @ApiParam({ name: 'einsatzId', type: String, format: 'cuid', description: 'Einsatz-ID (CUID)' })
   @ApiWrappedCreatedResponse(EinsatzFahrzeugDto, { description: 'Temporäres Fahrzeug erfolgreich erfasst' })
-  @ApiBadRequestResponse({ description: 'Validierungsfehler (z.B. ungültiger Funkrufname)' })
+  @ApiBadRequestResponse({ description: 'Validierungsfehler (z.B. ungültiger Funkrufname oder inaktiver Fahrzeugtyp)' })
   @ApiNotFoundResponse({ description: 'Fahrzeugtyp nicht gefunden' })
   @ApiConflictResponse({ description: 'Fahrzeug mit diesem Funkrufnamen bereits im Einsatz erfasst' })
   async erfasseTemporales(@Param('einsatzId', ParseCuidPipe) einsatzId: string, @CurrentUser() user: ValidatedUser, @Body() dto: ErfasseTemporalesFahrzeugDto): Promise<EinsatzFahrzeugDto> {
@@ -329,6 +329,9 @@ export class EinsatzFahrzeugeController {
       }
       if (EinsatzFahrzeugError.hasCode(error, EINSATZ_FAHRZEUG_ERROR_CODES.FAHRZEUGTYP_NOT_FOUND)) {
         throw new NotFoundException(EinsatzFahrzeugError.extractMessage(error));
+      }
+      if (EinsatzFahrzeugError.hasCode(error, EINSATZ_FAHRZEUG_ERROR_CODES.FAHRZEUGTYP_INACTIVE)) {
+        throw new BadRequestException(EinsatzFahrzeugError.extractMessage(error));
       }
 
       // Generic error


### PR DESCRIPTION
## Summary

- Reject inactive vehicle types when capturing temporary vehicles.
- Add an explicit inactive-vehicle-type error code and handler validation.
- Align temporary-capture controller error mapping for the new failure mode.
- Closes #487.

## Changes

- Frontend: none.
- Backend: enforce `fahrzeugtyp.istAktiv` in temporary capture, add `EINSATZ_FAHRZEUG_FAHRZEUGTYP_INACTIVE`, update controller mapping and API bad-request description, and switch the TODO/FIXME unit test to the expected failure path.
- Shared/Config: none.

## Test plan

- [x] `pnpm --filter @bluelight-hub/backend prisma:generate`
- [x] `pnpm --filter @bluelight-hub/backend exec jest src/application/kraefte/einsatz-fahrzeuge/commands/erfasse-temporales-fahrzeug/__tests__/erfasse-temporales-fahrzeug.handler.spec.ts`

🤖 Generated with Codex