### PR TITLE
🔒(backend): Harden CORS and PNA origin handling policy

### DIFF
--- a/packages/backend/src/infrastructure/config/private-network-access.middleware.spec.ts
+++ b/packages/backend/src/infrastructure/config/private-network-access.middleware.spec.ts
@@ -1,0 +1,78 @@
+import type { Request, Response } from 'express';
+import { createPrivateNetworkAccessMiddleware } from './private-network-access.middleware';
+
+const createRequest = (method: string, headers: Request['headers']): Request =>
+  ({
+    method,
+    headers,
+  }) as Request;
+
+const createResponse = (): Response =>
+  ({
+    header: jest.fn().mockReturnThis(),
+    vary: jest.fn().mockReturnThis(),
+  }) as unknown as Response;
+
+describe('createPrivateNetworkAccessMiddleware', () => {
+  it('sets PNA header for allowed private-network preflight', () => {
+    const middleware = createPrivateNetworkAccessMiddleware((origin) => origin === 'http://localhost:5173');
+    const req = createRequest('OPTIONS', {
+      origin: 'http://localhost:5173',
+      'access-control-request-private-network': 'true',
+    });
+    const res = createResponse();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(res.header).toHaveBeenCalledWith('Access-Control-Allow-Private-Network', 'true');
+    expect(res.vary).toHaveBeenCalledWith('Access-Control-Request-Private-Network');
+    expect(res.header).not.toHaveBeenCalledWith('Access-Control-Allow-Origin', expect.any(String));
+    expect(res.header).not.toHaveBeenCalledWith('Access-Control-Allow-Credentials', expect.any(String));
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not set PNA header when origin is not allowed', () => {
+    const middleware = createPrivateNetworkAccessMiddleware(() => false);
+    const req = createRequest('OPTIONS', {
+      origin: 'https://evil.example',
+      'access-control-request-private-network': 'true',
+    });
+    const res = createResponse();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(res.header).not.toHaveBeenCalledWith('Access-Control-Allow-Private-Network', 'true');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-preflight requests', () => {
+    const middleware = createPrivateNetworkAccessMiddleware(() => true);
+    const req = createRequest('GET', {
+      origin: 'http://localhost:5173',
+      'access-control-request-private-network': 'true',
+    });
+    const res = createResponse();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(res.header).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores OPTIONS without private-network request header', () => {
+    const middleware = createPrivateNetworkAccessMiddleware(() => true);
+    const req = createRequest('OPTIONS', {
+      origin: 'http://localhost:5173',
+    });
+    const res = createResponse();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(res.header).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/infrastructure/config/private-network-access.middleware.ts
+++ b/packages/backend/src/infrastructure/config/private-network-access.middleware.ts
@@ -1,0 +1,42 @@
+import type { NextFunction, Request, Response } from 'express';
+
+export type OriginAllowPolicy = (origin: string | undefined) => boolean;
+
+const readHeaderValue = (value: string | string[] | undefined): string | undefined => {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+};
+
+const isPrivateNetworkPreflight = (req: Request): boolean => {
+  if (req.method !== 'OPTIONS') {
+    return false;
+  }
+
+  const requestPrivateNetworkHeader = readHeaderValue(req.headers['access-control-request-private-network']);
+  return requestPrivateNetworkHeader?.toLowerCase() === 'true';
+};
+
+/**
+ * Setzt PNA-Response-Header nur für gültige PNA-Preflights.
+ * Die Origin-Freigabe selbst bleibt vollständig in der zentralen CORS-Policy.
+ */
+export const createPrivateNetworkAccessMiddleware =
+  (isOriginAllowed: OriginAllowPolicy) =>
+  (req: Request, res: Response, next: NextFunction): void => {
+    if (!isPrivateNetworkPreflight(req)) {
+      next();
+      return;
+    }
+
+    const origin = readHeaderValue(req.headers.origin);
+    if (!isOriginAllowed(origin)) {
+      next();
+      return;
+    }
+
+    res.header('Access-Control-Allow-Private-Network', 'true');
+    res.vary('Access-Control-Request-Private-Network');
+    next();
+  };

--- a/packages/backend/src/infrastructure/config/security.config.spec.ts
+++ b/packages/backend/src/infrastructure/config/security.config.spec.ts
@@ -1,0 +1,76 @@
+import { corsOriginHandler, isCorsOriginAllowed } from './security.config';
+
+const invokeCorsOriginHandler = (origin: string | undefined): Promise<boolean | undefined> =>
+  new Promise((resolve, reject) => {
+    corsOriginHandler(origin, (err, allow) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(allow);
+    });
+  });
+
+describe('security.config CORS origin policy', () => {
+  const originalAllowedOrigins = process.env.ALLOWED_ORIGINS;
+  const originalAllowedOriginPatterns = process.env.ALLOWED_ORIGIN_PATTERNS;
+
+  beforeEach(() => {
+    delete process.env.ALLOWED_ORIGINS;
+    delete process.env.ALLOWED_ORIGIN_PATTERNS;
+  });
+
+  afterAll(() => {
+    if (originalAllowedOrigins === undefined) {
+      delete process.env.ALLOWED_ORIGINS;
+    } else {
+      process.env.ALLOWED_ORIGINS = originalAllowedOrigins;
+    }
+
+    if (originalAllowedOriginPatterns === undefined) {
+      delete process.env.ALLOWED_ORIGIN_PATTERNS;
+    } else {
+      process.env.ALLOWED_ORIGIN_PATTERNS = originalAllowedOriginPatterns;
+    }
+  });
+
+  it('allows localhost origins by default', () => {
+    expect(isCorsOriginAllowed('http://localhost:5173')).toBe(true);
+    expect(isCorsOriginAllowed('http://127.0.0.1:3000')).toBe(true);
+  });
+
+  it('blocks unknown external origins by default', () => {
+    expect(isCorsOriginAllowed('https://evil.example')).toBe(false);
+  });
+
+  it('allows explicitly configured origins', () => {
+    process.env.ALLOWED_ORIGINS = 'https://app.example.com,https://admin.example.com';
+
+    expect(isCorsOriginAllowed('https://app.example.com')).toBe(true);
+    expect(isCorsOriginAllowed('https://admin.example.com')).toBe(true);
+  });
+
+  it('allows configured regex patterns', () => {
+    process.env.ALLOWED_ORIGIN_PATTERNS = '^https://[\\w-]+\\.bluelight-hub-app\\.pages\\.dev$';
+
+    expect(isCorsOriginAllowed('https://preview-123.bluelight-hub-app.pages.dev')).toBe(true);
+  });
+
+  it('allows all origins with wildcard ALLOWED_ORIGINS', () => {
+    process.env.ALLOWED_ORIGINS = '*';
+
+    expect(isCorsOriginAllowed('https://arbitrary.example')).toBe(true);
+  });
+
+  it('allows requests without Origin header', () => {
+    expect(isCorsOriginAllowed(undefined)).toBe(true);
+  });
+
+  it('corsOriginHandler delegates to shared policy', async () => {
+    const allowed = await invokeCorsOriginHandler('http://localhost:4173');
+    const denied = await invokeCorsOriginHandler('https://evil.example');
+
+    expect(allowed).toBe(true);
+    expect(denied).toBe(false);
+  });
+});

--- a/packages/backend/src/infrastructure/config/security.config.ts
+++ b/packages/backend/src/infrastructure/config/security.config.ts
@@ -66,44 +66,37 @@ export const helmetConfig: HelmetOptions = {
  * @constant
  */
 /**
- * Dynamische Origin-Validierung für Tauri, Development und konfigurierbare Patterns
+ * Dynamische Origin-Validierung für Tauri, Development und konfigurierbare Patterns.
+ * Diese Policy ist der zentrale Entscheidungsort für CORS und PNA.
  *
  * Unterstützte Umgebungsvariablen:
  * - ALLOWED_ORIGINS: Komma-separierte Liste expliziter Origins
  *   Beispiel: "https://example.com,https://app.example.com"
  * - ALLOWED_ORIGIN_PATTERNS: Komma-separierte Liste von Regex-Patterns
- *   Beispiel: "[\w-]+\.bluelight-hub-app\.pages\.dev$,[\w-]+\.vercel\.app$"
+ *   Beispiel: "[\\w-]+\\.bluelight-hub-app\\.pages\\.dev$,[\\w-]+\\.vercel\\.app$"
  * - Wildcard "*" in ALLOWED_ORIGINS erlaubt alle Origins (NUR für Entwicklung!)
  */
-const corsOriginHandler = (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
-  // Standard-Patterns für Tauri und Development
-  const builtInPatterns = [
-    /^https?:\/\/localhost(:\d+)?$/, // localhost mit beliebigem Port
-    /^https?:\/\/127\.0\.0\.1(:\d+)?$/, // 127.0.0.1 mit beliebigem Port
-    /^tauri:\/\/localhost/, // Tauri v1
-    /^https:\/\/tauri\.localhost/, // Tauri v2
-    /^https?:\/\/\[::1\](:\d+)?$/, // IPv6 localhost
-  ];
+const builtInOriginPatterns = [
+  /^https?:\/\/localhost(:\d+)?$/, // localhost mit beliebigem Port
+  /^https?:\/\/127\.0\.0\.1(:\d+)?$/, // 127.0.0.1 mit beliebigem Port
+  /^tauri:\/\/localhost/, // Tauri v1
+  /^https:\/\/tauri\.localhost/, // Tauri v2
+  /^https?:\/\/\[::1\](:\d+)?$/, // IPv6 localhost
+];
 
-  // Zusätzliche explizite Origins aus Umgebungsvariablen
-  const envOrigins =
-    process.env.ALLOWED_ORIGINS?.split(',')
-      .map((s) => s.trim())
-      .filter(Boolean) || [];
+const readAllowedOrigins = (): string[] =>
+  process.env.ALLOWED_ORIGINS?.split(',')
+    .map((s) => s.trim())
+    .filter(Boolean) || [];
 
-  // Wildcard-Check: "*" erlaubt alle Origins
-  if (envOrigins.includes('*')) {
-    callback(null, true);
-    return;
-  }
-
-  // Zusätzliche Patterns aus Umgebungsvariablen (Regex-Strings)
-  const envPatternStrings =
+const readAllowedOriginPatterns = (): RegExp[] => {
+  const patternStrings =
     process.env.ALLOWED_ORIGIN_PATTERNS?.split(',')
       .map((s) => s.trim())
       .filter(Boolean) || [];
+
   const envPatterns: RegExp[] = [];
-  for (const patternStr of envPatternStrings) {
+  for (const patternStr of patternStrings) {
     try {
       envPatterns.push(new RegExp(patternStr));
     } catch {
@@ -111,13 +104,32 @@ const corsOriginHandler = (origin: string | undefined, callback: (err: Error | n
     }
   }
 
-  // Alle Patterns kombinieren
-  const allPatterns = [...builtInPatterns, ...envPatterns];
+  return envPatterns;
+};
 
-  // Prüfe ob Origin erlaubt ist
-  const isAllowed = !origin || envOrigins.includes(origin) || allPatterns.some((pattern) => pattern.test(origin));
+export const isCorsOriginAllowed = (origin: string | undefined): boolean => {
+  const envOrigins = readAllowedOrigins();
 
-  callback(null, isAllowed);
+  // Wildcard-Check: "*" erlaubt alle Origins
+  if (envOrigins.includes('*')) {
+    return true;
+  }
+
+  // Kein Origin-Header bedeutet typischerweise same-origin oder server-to-server.
+  if (!origin) {
+    return true;
+  }
+
+  if (envOrigins.includes(origin)) {
+    return true;
+  }
+
+  const allPatterns = [...builtInOriginPatterns, ...readAllowedOriginPatterns()];
+  return allPatterns.some((pattern) => pattern.test(origin));
+};
+
+export const corsOriginHandler = (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+  callback(null, isCorsOriginAllowed(origin));
 };
 
 export const corsConfig = {

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -3,7 +3,6 @@ import type { HttpsOptions } from '@nestjs/common/interfaces/external/https-opti
 import { ConfigService } from '@nestjs/config';
 import { NestFactory, Reflector } from '@nestjs/core';
 import type { NestExpressApplication } from '@nestjs/platform-express';
-import type { Request, Response, NextFunction } from 'express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import helmet from 'helmet';
@@ -14,7 +13,8 @@ import { validateInsecureMode } from './infrastructure/config/bootstrap-validati
 import { HealthModule } from './infrastructure/health/health.module';
 import { PerformanceInterceptor } from './infrastructure/http/interceptors/performance.interceptor';
 import { TransformInterceptor } from './infrastructure/http/interceptors/transform.interceptor';
-import { corsConfig, helmetConfig } from './infrastructure/config/security.config';
+import { createPrivateNetworkAccessMiddleware } from './infrastructure/config/private-network-access.middleware';
+import { corsConfig, helmetConfig, isCorsOriginAllowed } from './infrastructure/config/security.config';
 import { BefehlModule } from './modules/befehl/befehl.module';
 import { EinsatzModule } from './modules/einsatz/einsatz.module';
 
@@ -74,37 +74,9 @@ async function bootstrap() {
 
   app.set('trust proxy', trustProxy);
 
-  // PNA (Private Network Access) Header for Cloudflare Pages -> Localhost connection
-  // Robust implementation handling Preflight (OPTIONS) manually to satisfy strict browser PNA policies
-  // PLATZIERUNG: MUSS zwingend vor BodyParser und anderer Middleware stehen!
-  app.use((req: Request, res: Response, next: NextFunction) => {
-    const origin = req.headers.origin;
-
-    // 1. Erlaube den spezifischen Origin (WICHTIG: Kein '*' erlaubt bei PNA!)
-    // Wir reflektieren hier den Origin, wenn vorhanden.
-    // Sicherheit: In Produktion sollte hier idealerweise gegen eine Whitelist geprüft werden (siehe corsConfig),
-    // aber für den PNA-Fix (Dev/Preview -> Localhost) ist Reflected Origin oft notwendig.
-    if (origin) {
-      res.header('Access-Control-Allow-Origin', origin);
-    }
-
-    // 2. PNA Header setzen - das Kernstück für Localhost-Zugriff von Public
-    res.header('Access-Control-Allow-Private-Network', 'true');
-
-    // 3. Credentials erlauben (Cookies, Auth Header etc.)
-    res.header('Access-Control-Allow-Credentials', 'true');
-
-    // 4. Preflight (OPTIONS) direkt behandeln und beenden
-    if (req.method === 'OPTIONS') {
-      res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, DELETE, PATCH, OPTIONS');
-      res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With, X-Server-Access-Token');
-      // Wichtig: Den Preflight hier direkt mit 204 beenden, damit keine weitere Logik stört
-      res.status(204).send();
-      return;
-    }
-
-    next();
-  });
+  // PNA-Header werden nur für valide Private-Network-Preflights gesetzt.
+  // Die eigentliche Origin-Freigabe bleibt zentral in der CORS-Policy (isCorsOriginAllowed + enableCors).
+  app.use(createPrivateNetworkAccessMiddleware(isCorsOriginAllowed));
 
   app.enableVersioning({
     type: VersioningType.URI,
@@ -206,7 +178,8 @@ X-Server-Access-Token: <plaintext_token>
   app.useBodyParser('json', { limit: '10mb' });
   app.useBodyParser('urlencoded', { limit: '10mb', extended: true });
 
-  // Configure CORS based on environment
+  // Configure CORS based on environment.
+  // Security rationale: Access-Control-Allow-Origin and credentials handling are emitted only by this central CORS config.
 
   const corsOptions = isProduction ? corsConfig.production : corsConfig.development;
   app.enableCors(corsOptions);


### PR DESCRIPTION
Closes #482

## Summary

- remove insecure origin reflection and credential header emission from bootstrap PNA handling
- keep Private Network Access support while delegating allow/deny decisions to one central origin policy
- add focused tests for allowed and blocked origins plus PNA preflight behavior

## Changes

- Frontend: no changes
- Backend: add dedicated private-network-access middleware and wire it in bootstrap
- Shared/Config: extract reusable `isCorsOriginAllowed` policy and cover it with unit tests

## Test plan

- [x] `pnpm --filter @bluelight-hub/backend exec jest src/infrastructure/config/security.config.spec.ts src/infrastructure/config/private-network-access.middleware.spec.ts`
- [ ] optionally run full backend unit test suite

🤖 Generated with Codex