### PR TITLE
🐛(frontend): Fix auth reload race and preserve redirects

### DIFF
--- a/packages/frontend/src/features/admin/ui/pages/AdminLogin.tsx
+++ b/packages/frontend/src/features/admin/ui/pages/AdminLogin.tsx
@@ -1,7 +1,7 @@
 import { consumeRedirectAfterLogin, useCurrentUser, useAdminLogin } from '@/features/auth';
 import { useSystemHealth } from '@/features/system/api/use-system-health';
 import { getApiErrorMessage } from '@/shared/lib/errors/apiErrorHandler';
-import { getRedirectFromSearch, sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
+import { getRedirectFromSearch, navigateToInternalRedirect, sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
 import { Alert } from '@/shared/ui/atoms/alert.atom';
 import { Button } from '@/shared/ui/atoms/button.atom';
 import { FormField } from '@/shared/ui/atoms/form-field.atom';
@@ -12,7 +12,7 @@ import { AuthFooter } from '@/shared/ui/molecules/auth-footer.molecule';
 import { LogoWithIndicator } from '@/shared/ui/molecules/logo-with-indicator.molecule';
 import { PasswordInput } from '@/shared/ui/molecules/password-input.molecule';
 import { useForm } from '@tanstack/react-form';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useRouter } from '@tanstack/react-router';
 import { AuthLayout } from '@/shared/ui/templates/AuthLayout';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { PiWarning } from 'react-icons/pi';
@@ -25,6 +25,7 @@ const adminLoginSchema = z.object({
 
 export function AdminLogin() {
   const navigate = useNavigate();
+  const router = useRouter();
   const { user, isLoading, isAdminAuthenticated, adminStatus } = useCurrentUser();
   const loginAdmin = useAdminLogin();
   const { connectionMode, version } = useSystemHealth();
@@ -108,7 +109,7 @@ export function AdminLogin() {
       // If user has an active admin session, redirect to dashboard
       if (user && isAdminAuthenticated) {
         const redirectTarget = resolveRedirectTarget('/admin/dashboard');
-        void navigate({ to: redirectTarget as never, replace: true });
+        navigateToInternalRedirect(router, redirectTarget, { replace: true });
       }
       // If user is not logged in at all, redirect to auth
       else if (!user) {
@@ -129,7 +130,7 @@ export function AdminLogin() {
       }
       // User is logged in but not admin authenticated - stay on this page
     }
-  }, [user, hasCheckedAuth, isAdminAuthenticated, adminStatus?.adminSetupAvailable, navigate, resolveRedirectTarget]);
+  }, [user, hasCheckedAuth, isAdminAuthenticated, adminStatus?.adminSetupAvailable, navigate, router, resolveRedirectTarget]);
 
   // Don't render the form until we've checked authentication
   // This prevents flashing of the form before redirect

--- a/packages/frontend/src/features/admin/ui/pages/AdminLogin.tsx
+++ b/packages/frontend/src/features/admin/ui/pages/AdminLogin.tsx
@@ -1,6 +1,7 @@
-import { useCurrentUser, useAdminLogin } from '@/features/auth';
+import { consumeRedirectAfterLogin, useCurrentUser, useAdminLogin } from '@/features/auth';
 import { useSystemHealth } from '@/features/system/api/use-system-health';
 import { getApiErrorMessage } from '@/shared/lib/errors/apiErrorHandler';
+import { getRedirectFromSearch, sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
 import { Alert } from '@/shared/ui/atoms/alert.atom';
 import { Button } from '@/shared/ui/atoms/button.atom';
 import { FormField } from '@/shared/ui/atoms/form-field.atom';
@@ -13,7 +14,7 @@ import { PasswordInput } from '@/shared/ui/molecules/password-input.molecule';
 import { useForm } from '@tanstack/react-form';
 import { useNavigate } from '@tanstack/react-router';
 import { AuthLayout } from '@/shared/ui/templates/AuthLayout';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { PiWarning } from 'react-icons/pi';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -30,6 +31,29 @@ export function AdminLogin() {
   const [hasCheckedAuth, setHasCheckedAuth] = useState(false);
   const [shouldShake, setShouldShake] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
+  const redirectTargetRef = useRef<string | null>(null);
+
+  const resolveRedirectTarget = useCallback((fallbackTarget: string): string => {
+    if (redirectTargetRef.current) {
+      return redirectTargetRef.current;
+    }
+
+    const redirectFromSearch = getRedirectFromSearch(window.location.search);
+    if (redirectFromSearch) {
+      consumeRedirectAfterLogin();
+      redirectTargetRef.current = redirectFromSearch;
+      return redirectFromSearch;
+    }
+
+    const redirectFromStore = sanitizeInternalRedirectPath(consumeRedirectAfterLogin());
+    if (redirectFromStore) {
+      redirectTargetRef.current = redirectFromStore;
+      return redirectFromStore;
+    }
+
+    redirectTargetRef.current = fallbackTarget;
+    return fallbackTarget;
+  }, []);
 
   const form = useForm({
     defaultValues: {
@@ -48,7 +72,6 @@ export function AdminLogin() {
             toast.success('Anmeldung erfolgreich', {
               description: 'Sie wurden erfolgreich als Administrator angemeldet.',
             });
-            await navigate({ to: '/admin/dashboard' });
           },
           onError: async (error: Error) => {
             const message = await getApiErrorMessage(error, 'Ein unerwarteter Fehler ist aufgetreten.', 'adminLogin');
@@ -84,19 +107,29 @@ export function AdminLogin() {
     if (hasCheckedAuth) {
       // If user has an active admin session, redirect to dashboard
       if (user && isAdminAuthenticated) {
-        void navigate({ to: '/admin/dashboard' });
+        const redirectTarget = resolveRedirectTarget('/admin/dashboard');
+        void navigate({ to: redirectTarget as never, replace: true });
       }
       // If user is not logged in at all, redirect to auth
       else if (!user) {
-        void navigate({ to: '/auth' });
+        const redirectTarget = getRedirectFromSearch(window.location.search) ?? sanitizeInternalRedirectPath(consumeRedirectAfterLogin());
+        void navigate({
+          to: '/auth',
+          search: redirectTarget
+            ? {
+                redirect: redirectTarget,
+              }
+            : undefined,
+          replace: true,
+        });
       }
       // If user needs to set up admin password, redirect to setup
       else if (user && adminStatus?.adminSetupAvailable) {
-        void navigate({ to: '/admin/setup' });
+        void navigate({ to: '/admin/setup', replace: true });
       }
       // User is logged in but not admin authenticated - stay on this page
     }
-  }, [user, hasCheckedAuth, isAdminAuthenticated, adminStatus?.adminSetupAvailable, navigate]);
+  }, [user, hasCheckedAuth, isAdminAuthenticated, adminStatus?.adminSetupAvailable, navigate, resolveRedirectTarget]);
 
   // Don't render the form until we've checked authentication
   // This prevents flashing of the form before redirect

--- a/packages/frontend/src/features/auth/api/__tests__/use-current-user.spec.tsx
+++ b/packages/frontend/src/features/auth/api/__tests__/use-current-user.spec.tsx
@@ -1,0 +1,156 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseQuery = vi.fn();
+const mockUseStore = vi.fn();
+
+const serverState = {
+  isHydrated: false,
+  activeServerId: null as string | null,
+};
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+}));
+
+vi.mock('@tanstack/react-store', () => ({
+  useStore: (...args: unknown[]) => mockUseStore(...args),
+}));
+
+vi.mock('@/features/server/stores/server.store', () => ({
+  serverStore: {},
+}));
+
+vi.mock('@/shared', () => ({
+  api: {
+    auth: () => ({
+      authControllerCheckAuthRaw: vi.fn(),
+      authControllerGetAdminStatusRaw: vi.fn(),
+    }),
+  },
+}));
+
+import { useCurrentUser } from '../use-current-user';
+
+const createAuthQueryResult = (overrides: Record<string, unknown> = {}) => ({
+  data: undefined,
+  isPending: false,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  ...overrides,
+});
+
+const createAdminQueryResult = (overrides: Record<string, unknown> = {}) => ({
+  data: undefined,
+  isPending: false,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  isFetched: false,
+  ...overrides,
+});
+
+function mockQueryPair(authResult: Record<string, unknown>, adminResult: Record<string, unknown>) {
+  mockUseQuery.mockReset();
+  mockUseQuery.mockImplementationOnce(() => createAuthQueryResult(authResult));
+  mockUseQuery.mockImplementationOnce(() => createAdminQueryResult(adminResult));
+}
+
+describe('useCurrentUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serverState.isHydrated = false;
+    serverState.activeServerId = null;
+
+    mockUseStore.mockImplementation((_store: unknown, selector: (state: typeof serverState) => unknown) => selector(serverState));
+  });
+
+  it('liefert pending, wenn der Server-Store noch nicht bereit ist', () => {
+    mockQueryPair({}, {});
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current.authStatus).toBe('pending');
+    expect(result.current.adminSessionStatus).toBe('pending');
+    expect(result.current.isResolved).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('liefert authenticated und admin authenticated bei erfolgreicher Session', () => {
+    serverState.isHydrated = true;
+    serverState.activeServerId = 'server-1';
+
+    mockQueryPair(
+      {
+        data: {
+          authenticated: true,
+          isAdminAuthenticated: true,
+          user: {
+            id: 'user-1',
+            username: 'admin',
+            role: 'ADMIN',
+          },
+        },
+      },
+      {
+        isFetched: true,
+        data: {
+          adminSetupAvailable: false,
+        },
+      },
+    );
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current.authStatus).toBe('authenticated');
+    expect(result.current.adminSessionStatus).toBe('authenticated');
+    expect(result.current.isResolved).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.user?.id).toBe('user-1');
+    expect(result.current.adminStatus).toEqual({ adminSetupAvailable: false });
+  });
+
+  it('liefert unauthenticated sobald Auth-Check aufgelöst und kein User vorhanden ist', () => {
+    serverState.isHydrated = true;
+    serverState.activeServerId = 'server-1';
+
+    mockQueryPair(
+      {
+        data: {
+          authenticated: false,
+          isAdminAuthenticated: false,
+          user: null,
+        },
+      },
+      {},
+    );
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current.authStatus).toBe('unauthenticated');
+    expect(result.current.adminSessionStatus).toBe('unauthenticated');
+    expect(result.current.isResolved).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('bleibt pending solange der Auth-Check noch läuft, obwohl der Server bereits bereit ist', () => {
+    serverState.isHydrated = true;
+    serverState.activeServerId = 'server-1';
+
+    mockQueryPair(
+      {
+        isPending: true,
+      },
+      {},
+    );
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current.authStatus).toBe('pending');
+    expect(result.current.adminSessionStatus).toBe('pending');
+    expect(result.current.isResolved).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/packages/frontend/src/features/auth/api/__tests__/use-current-user.spec.tsx
+++ b/packages/frontend/src/features/auth/api/__tests__/use-current-user.spec.tsx
@@ -66,7 +66,7 @@ describe('useCurrentUser', () => {
     mockUseStore.mockImplementation((_store: unknown, selector: (state: typeof serverState) => unknown) => selector(serverState));
   });
 
-  it('liefert pending, wenn der Server-Store noch nicht bereit ist', () => {
+  it('liefert pending, wenn die Server-Hydration noch läuft', () => {
     mockQueryPair({}, {});
 
     const { result } = renderHook(() => useCurrentUser());
@@ -75,6 +75,33 @@ describe('useCurrentUser', () => {
     expect(result.current.adminSessionStatus).toBe('pending');
     expect(result.current.isResolved).toBe(false);
     expect(result.current.isLoading).toBe(true);
+  });
+
+  it('liefert unauthenticated, wenn hydriert aber kein aktiver Server gesetzt ist', () => {
+    serverState.isHydrated = true;
+    serverState.activeServerId = null;
+
+    mockQueryPair(
+      {
+        data: {
+          authenticated: true,
+          isAdminAuthenticated: true,
+          user: {
+            id: 'stale-user',
+            username: 'stale',
+            role: 'ADMIN',
+          },
+        },
+      },
+      {},
+    );
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current.authStatus).toBe('unauthenticated');
+    expect(result.current.adminSessionStatus).toBe('unauthenticated');
+    expect(result.current.isResolved).toBe(true);
+    expect(result.current.isLoading).toBe(false);
   });
 
   it('liefert authenticated und admin authenticated bei erfolgreicher Session', () => {

--- a/packages/frontend/src/features/auth/api/use-current-user.ts
+++ b/packages/frontend/src/features/auth/api/use-current-user.ts
@@ -48,7 +48,8 @@ export const useCurrentUser = () => {
   // Verhindert Race Condition: API-Call → 401 Token Error → Redirect zu /server/setup
   const isHydrated = useStore(serverStore, (state) => state.isHydrated);
   const activeServerId = useStore(serverStore, (state) => state.activeServerId);
-  const isServerReady = isHydrated && activeServerId !== null;
+  const hasActiveServer = activeServerId !== null;
+  const isServerReady = isHydrated && hasActiveServer;
 
   const authCheckQuery = useQuery({
     queryKey: AUTH_KEYS.auth.queries.authCheck,
@@ -77,8 +78,13 @@ export const useCurrentUser = () => {
   // authCheckQuery.data ist jetzt direkt AuthCheckResponse (nicht gewrappt)
   const authData = authCheckQuery.data;
 
-  // Admin-Status nur für eingeloggte Admins abfragen
-  const isAdminRole = !!authData?.user?.role && ['ADMIN', 'SUPER_ADMIN'].includes(authData.user.role);
+  const isAuthPending = !isHydrated || (hasActiveServer && authCheckQuery.isPending);
+
+  const authStatus: AuthStatus = isAuthPending ? 'pending' : !hasActiveServer ? 'unauthenticated' : authData?.authenticated && !!authData.user ? 'authenticated' : 'unauthenticated';
+
+  // Nur bei bestätigter Authentifizierung als Admin evaluieren
+  const isAdminRole = authStatus === 'authenticated' && !!authData?.user?.role && ['ADMIN', 'SUPER_ADMIN'].includes(authData.user.role);
+  const isAdminAuthenticated = authStatus === 'authenticated' ? authData?.isAdminAuthenticated === true : false;
 
   const adminStatusQuery = useQuery({
     queryKey: AUTH_KEYS.auth.queries.adminStatus,
@@ -96,11 +102,7 @@ export const useCurrentUser = () => {
     enabled: isAdminRole,
   });
 
-  const isAuthPending = !isServerReady || authCheckQuery.isPending;
-
-  const authStatus: AuthStatus = isAuthPending ? 'pending' : authData?.authenticated && !!authData.user ? 'authenticated' : 'unauthenticated';
-
-  const adminSessionStatus: AdminSessionStatus = authStatus === 'pending' ? 'pending' : authData?.isAdminAuthenticated ? 'authenticated' : 'unauthenticated';
+  const adminSessionStatus: AdminSessionStatus = authStatus === 'pending' ? 'pending' : isAdminAuthenticated ? 'authenticated' : 'unauthenticated';
 
   const isResolved = authStatus !== 'pending';
 
@@ -131,21 +133,22 @@ export const useCurrentUser = () => {
     /**
      * Aktuell eingeloggter Benutzer (null wenn nicht eingeloggt)
      */
-    user: authData?.user,
+    user: authStatus === 'authenticated' ? authData?.user : null,
 
     /**
      * Ist der Benutzer als Admin authentifiziert?
      */
-    isAdminAuthenticated: authData?.isAdminAuthenticated,
+    isAdminAuthenticated,
 
     /**
      * Admin-Status (Setup verfügbar, etc.)
      */
-    adminStatus: adminStatusQuery.isFetched
-      ? {
-          adminSetupAvailable: adminStatusQuery.data?.adminSetupAvailable,
-        }
-      : undefined,
+    adminStatus:
+      isAdminRole && adminStatusQuery.isFetched
+        ? {
+            adminSetupAvailable: adminStatusQuery.data?.adminSetupAvailable,
+          }
+        : undefined,
 
     /**
      * Raw Query-Objekt für erweiterte Verwendung

--- a/packages/frontend/src/features/auth/api/use-current-user.ts
+++ b/packages/frontend/src/features/auth/api/use-current-user.ts
@@ -40,6 +40,9 @@ interface AuthCheckResponse {
   isAdminAuthenticated?: boolean;
 }
 
+export type AuthStatus = 'pending' | 'authenticated' | 'unauthenticated';
+export type AdminSessionStatus = 'pending' | 'authenticated' | 'unauthenticated';
+
 export const useCurrentUser = () => {
   // Warte auf Server-Store-Hydration bevor API-Calls gemacht werden
   // Verhindert Race Condition: API-Call → 401 Token Error → Redirect zu /server/setup
@@ -75,7 +78,7 @@ export const useCurrentUser = () => {
   const authData = authCheckQuery.data;
 
   // Admin-Status nur für eingeloggte Admins abfragen
-  const isAdmin = !!authData?.user && authData.user.role?.includes('ADMIN');
+  const isAdminRole = !!authData?.user?.role && ['ADMIN', 'SUPER_ADMIN'].includes(authData.user.role);
 
   const adminStatusQuery = useQuery({
     queryKey: AUTH_KEYS.auth.queries.adminStatus,
@@ -86,18 +89,44 @@ export const useCurrentUser = () => {
       return json as { adminSetupAvailable?: boolean };
     },
     staleTime: milliseconds({ seconds: 30 }),
-    refetchInterval: isAdmin ? milliseconds({ seconds: 30 }) : false,
+    refetchInterval: isAdminRole ? milliseconds({ seconds: 30 }) : false,
     throwOnError: false,
     refetchOnWindowFocus: true,
     retry: false,
-    enabled: isAdmin,
+    enabled: isAdminRole,
   });
+
+  const isAuthPending = !isServerReady || authCheckQuery.isPending;
+
+  const authStatus: AuthStatus = isAuthPending ? 'pending' : authData?.authenticated && !!authData.user ? 'authenticated' : 'unauthenticated';
+
+  const adminSessionStatus: AdminSessionStatus = authStatus === 'pending' ? 'pending' : authData?.isAdminAuthenticated ? 'authenticated' : 'unauthenticated';
+
+  const isResolved = authStatus !== 'pending';
+
+  // isLoading bleibt für bestehende Consumer kompatibel
+  const isLoading = isAuthPending || (isAdminRole && adminStatusQuery.isPending);
 
   return {
     /**
      * Loading-State (AuthCheck oder AdminStatus lädt)
      */
-    isLoading: authCheckQuery.isLoading || adminStatusQuery.isLoading,
+    isLoading,
+
+    /**
+     * Eindeutiger Auth-Status für Guard-Entscheidungen
+     */
+    authStatus,
+
+    /**
+     * Eindeutiger Admin-Session-Status
+     */
+    adminSessionStatus,
+
+    /**
+     * true sobald Auth-Status nicht mehr pending ist
+     */
+    isResolved,
 
     /**
      * Aktuell eingeloggter Benutzer (null wenn nicht eingeloggt)
@@ -142,13 +171,13 @@ export const useCurrentUser = () => {
  * ```
  */
 export const useAdminAuth = () => {
-  const { user, isAdminAuthenticated, isLoading } = useCurrentUser();
+  const { user, isAdminAuthenticated, isLoading, authStatus, adminSessionStatus, isResolved } = useCurrentUser();
 
-  // isAdmin prüft sowohl Admin-Auth als auch die Rolle
-  const isAdmin = isAdminAuthenticated && user?.role && ['ADMIN', 'SUPER_ADMIN'].includes(user.role);
+  // isAdmin prüft sowohl Admin-Session als auch die Rolle
+  const isAdmin = adminSessionStatus === 'authenticated' && !!user?.role && ['ADMIN', 'SUPER_ADMIN'].includes(user.role);
 
   // hasAdminSession prüft nur ob Admin-Token vorhanden ist (unabhängig von der Rolle)
-  const hasAdminSession = isAdminAuthenticated;
+  const hasAdminSession = adminSessionStatus === 'authenticated';
 
   return {
     /**
@@ -170,6 +199,21 @@ export const useAdminAuth = () => {
      * Loading-State
      */
     isLoading,
+
+    /**
+     * Eindeutiger Auth-Status
+     */
+    authStatus,
+
+    /**
+     * Eindeutiger Admin-Session-Status
+     */
+    adminSessionStatus,
+
+    /**
+     * true sobald Auth-Status aufgeloest ist
+     */
+    isResolved,
 
     /**
      * Aktueller User

--- a/packages/frontend/src/features/auth/guards/__tests__/app-guard.spec.tsx
+++ b/packages/frontend/src/features/auth/guards/__tests__/app-guard.spec.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseCurrentUser = vi.fn();
+const mockNavigate = vi.fn();
+const mockUseLocation = vi.fn();
+const mockSetRedirectAfterLogin = vi.fn();
+
+vi.mock('@/features/auth', () => ({
+  useCurrentUser: (...args: unknown[]) => mockUseCurrentUser(...args),
+}));
+
+vi.mock('@/features/auth/stores/auth.store', () => ({
+  setRedirectAfterLogin: (...args: unknown[]) => mockSetRedirectAfterLogin(...args),
+}));
+
+vi.mock('@/features/auth/ui', () => ({
+  AuthLoading: () => <div data-testid="auth-loading">loading</div>,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Outlet: () => <div data-testid="guard-outlet">outlet</div>,
+  useRouter: () => ({
+    navigate: mockNavigate,
+  }),
+  useLocation: (...args: unknown[]) => mockUseLocation(...args),
+}));
+
+import { AppGuard } from '../app-guard';
+
+describe('AppGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLocation.mockReturnValue({ pathname: '/app/einsatz/42' });
+    window.history.pushState({}, '', '/app/einsatz/42?tab=lagekarte#karte');
+  });
+
+  it('redirectet nicht im pending Status', () => {
+    mockUseCurrentUser.mockReturnValue({
+      authStatus: 'pending',
+      user: undefined,
+    });
+
+    render(<AppGuard />);
+
+    expect(screen.getByTestId('auth-loading')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockSetRedirectAfterLogin).not.toHaveBeenCalled();
+  });
+
+  it('redirectet bei unauthenticated zu /auth und übergibt das Ziel', async () => {
+    mockUseCurrentUser.mockReturnValue({
+      authStatus: 'unauthenticated',
+      user: null,
+    });
+
+    render(<AppGuard />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/auth',
+        search: {
+          redirect: '/app/einsatz/42?tab=lagekarte#karte',
+        },
+        replace: true,
+      });
+    });
+
+    expect(mockSetRedirectAfterLogin).toHaveBeenCalledWith('/app/einsatz/42?tab=lagekarte#karte');
+    expect(screen.getByTestId('auth-loading')).toBeInTheDocument();
+  });
+
+  it('rendert Outlet für authentifizierte Nutzer', () => {
+    mockUseCurrentUser.mockReturnValue({
+      authStatus: 'authenticated',
+      user: {
+        id: 'user-1',
+      },
+    });
+
+    render(<AppGuard />);
+
+    expect(screen.getByTestId('guard-outlet')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/features/auth/guards/app-guard.tsx
+++ b/packages/frontend/src/features/auth/guards/app-guard.tsx
@@ -1,25 +1,37 @@
 import { useCurrentUser } from '@/features/auth';
+import { setRedirectAfterLogin } from '@/features/auth/stores/auth.store';
+import { getCurrentPathWithQueryAndHash, sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
 import { AuthLoading } from '@/features/auth/ui';
-import { Outlet, useRouter } from '@tanstack/react-router';
-import { useEffect } from 'react';
+import { Outlet, useLocation, useRouter } from '@tanstack/react-router';
+import { useEffect, useMemo } from 'react';
 
 export function AppGuard() {
-  const { isLoading, user } = useCurrentUser();
+  const { authStatus, user } = useCurrentUser();
   const { navigate } = useRouter();
+  const location = useLocation();
+
+  const redirectTarget = useMemo(() => {
+    return sanitizeInternalRedirectPath(getCurrentPathWithQueryAndHash(location.pathname)) ?? '/';
+  }, [location.pathname]);
 
   useEffect(() => {
-    if (!isLoading && !user) {
+    if (authStatus === 'unauthenticated') {
+      setRedirectAfterLogin(redirectTarget);
       void navigate({
         to: '/auth',
+        search: {
+          redirect: redirectTarget,
+        },
+        replace: true,
       });
     }
-  }, [isLoading, user, navigate]);
+  }, [authStatus, navigate, redirectTarget]);
 
-  if (isLoading) {
+  if (authStatus === 'pending') {
     return <AuthLoading />;
   }
 
-  if (!user) {
+  if (authStatus === 'unauthenticated' || !user) {
     return <AuthLoading />;
   }
 

--- a/packages/frontend/src/features/auth/stores/auth.store.ts
+++ b/packages/frontend/src/features/auth/stores/auth.store.ts
@@ -88,6 +88,17 @@ export const setRedirectAfterLogin = (url?: string) => {
 };
 
 /**
+ * Helper: Redirect-URL lesen und direkt verbrauchen
+ *
+ * Gibt den gespeicherten Redirect-Pfad zurueck und leert ihn anschliessend.
+ */
+export const consumeRedirectAfterLogin = (): string | undefined => {
+  const redirectPath = authStore.state.redirectAfterLogin;
+  setRedirectAfterLogin(undefined);
+  return redirectPath;
+};
+
+/**
  * Helper: Store zurücksetzen (z.B. bei Logout)
  */
 export const resetAuthStore = () => {

--- a/packages/frontend/src/features/auth/ui/organisms/LoginWindow.tsx
+++ b/packages/frontend/src/features/auth/ui/organisms/LoginWindow.tsx
@@ -1,10 +1,11 @@
-import { AUTH_KEYS, useCurrentUser, useUnifiedAuth, useLogout } from '@/features/auth';
+import { AUTH_KEYS, consumeRedirectAfterLogin, useCurrentUser, useUnifiedAuth, useLogout } from '@/features/auth';
 import { useRequireServer, useServerList, useActiveServer, useServerListHealth } from '@/features/server/hooks';
 import { setActiveServer, removeServer } from '@/features/server/stores/server.store';
 import { serverStore } from '@/features/server/stores/server.store';
 import { ServerSelector } from '@/features/server/ui/molecules';
 import { getIndicatorStatus, STATUS_DOT_COLORS, STATUS_LABELS, useSystemHealth, useSystemVersion } from '@/features/system';
 import { getApiErrorMessage } from '@/shared/lib/errors/apiErrorHandler';
+import { getRedirectFromSearch, sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
 import { Heading } from '@/shared/ui/atoms/heading.atom';
 import { Spinner } from '@/shared/ui/atoms/spinner.atom';
 import { Text } from '@/shared/ui/atoms/text.atom';
@@ -17,7 +18,7 @@ import type { AuthRequestDto } from '@/shared';
 import { useNavigate } from '@tanstack/react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useStore } from '@tanstack/react-store';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { UnifiedAuthForm } from './UnifiedAuthForm';
 
@@ -51,8 +52,9 @@ export function LoginWindow(_props: Props) {
   const [isDeleting, setIsDeleting] = useState(false);
   // Issue 7 Fix: Loading-State beim Server-Wechsel um Race Conditions zu verhindern
   const [isSwitching, setIsSwitching] = useState(false);
+  const redirectTargetRef = useRef<string | null>(null);
 
-  const { user, isLoading } = useCurrentUser();
+  const { user, authStatus } = useCurrentUser();
   const unifiedAuth = useUnifiedAuth();
   const logout = useLogout();
 
@@ -182,6 +184,28 @@ export function LoginWindow(_props: Props) {
     setServerToDelete(null);
   }, []);
 
+  const resolveRedirectTarget = useCallback((fallbackTarget: string): string => {
+    if (redirectTargetRef.current) {
+      return redirectTargetRef.current;
+    }
+
+    const redirectFromSearch = getRedirectFromSearch(window.location.search);
+    if (redirectFromSearch) {
+      consumeRedirectAfterLogin();
+      redirectTargetRef.current = redirectFromSearch;
+      return redirectFromSearch;
+    }
+
+    const redirectFromStore = sanitizeInternalRedirectPath(consumeRedirectAfterLogin());
+    if (redirectFromStore) {
+      redirectTargetRef.current = redirectFromStore;
+      return redirectFromStore;
+    }
+
+    redirectTargetRef.current = fallbackTarget;
+    return fallbackTarget;
+  }, []);
+
   const handleAuth = useCallback(
     (authData: AuthRequestDto) => {
       unifiedAuth.mutate(authData, {
@@ -197,8 +221,6 @@ export function LoginWindow(_props: Props) {
           await queryClient.refetchQueries({
             queryKey: AUTH_KEYS.auth.queries.authCheck,
           });
-
-          await navigate({ to: '/' });
         },
         onError: async (error: Error) => {
           const message = await getApiErrorMessage(error, 'Ein unerwarteter Fehler ist aufgetreten.', 'userAuth');
@@ -209,14 +231,15 @@ export function LoginWindow(_props: Props) {
         },
       });
     },
-    [unifiedAuth, navigate, queryClient],
+    [unifiedAuth, queryClient],
   );
 
   useEffect(() => {
-    if (!isLoading && user) {
-      void navigate({ to: '/' });
+    if (authStatus === 'authenticated' && user) {
+      const redirectTarget = resolveRedirectTarget('/');
+      void navigate({ to: redirectTarget as never, replace: true });
     }
-  }, [isLoading, user, navigate]);
+  }, [authStatus, user, navigate, resolveRedirectTarget]);
 
   // Early Returns NACH allen Hooks
   // H7: Loading-State während Server-Store Hydration ODER wenn kein Server (Redirect pending)

--- a/packages/frontend/src/features/auth/ui/organisms/LoginWindow.tsx
+++ b/packages/frontend/src/features/auth/ui/organisms/LoginWindow.tsx
@@ -5,7 +5,7 @@ import { serverStore } from '@/features/server/stores/server.store';
 import { ServerSelector } from '@/features/server/ui/molecules';
 import { getIndicatorStatus, STATUS_DOT_COLORS, STATUS_LABELS, useSystemHealth, useSystemVersion } from '@/features/system';
 import { getApiErrorMessage } from '@/shared/lib/errors/apiErrorHandler';
-import { getRedirectFromSearch, sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
+import { getRedirectFromSearch, navigateToInternalRedirect, sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
 import { Heading } from '@/shared/ui/atoms/heading.atom';
 import { Spinner } from '@/shared/ui/atoms/spinner.atom';
 import { Text } from '@/shared/ui/atoms/text.atom';
@@ -15,7 +15,7 @@ import { LogoWithIndicator } from '@/shared/ui/molecules/logo-with-indicator.mol
 import { Dialog } from '@/shared/ui/molecules/dialog.molecule';
 import { AuthLayout } from '@/shared/ui/templates/AuthLayout';
 import type { AuthRequestDto } from '@/shared';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useRouter } from '@tanstack/react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useStore } from '@tanstack/react-store';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -33,6 +33,7 @@ export type Props = Record<string, never>;
  */
 export function LoginWindow(_props: Props) {
   const navigate = useNavigate();
+  const router = useRouter();
   const queryClient = useQueryClient();
 
   // Server-Guard: Redirect zu /server/setup wenn kein Server konfiguriert
@@ -237,9 +238,9 @@ export function LoginWindow(_props: Props) {
   useEffect(() => {
     if (authStatus === 'authenticated' && user) {
       const redirectTarget = resolveRedirectTarget('/');
-      void navigate({ to: redirectTarget as never, replace: true });
+      navigateToInternalRedirect(router, redirectTarget, { replace: true });
     }
-  }, [authStatus, user, navigate, resolveRedirectTarget]);
+  }, [authStatus, user, router, resolveRedirectTarget]);
 
   // Early Returns NACH allen Hooks
   // H7: Loading-State während Server-Store Hydration ODER wenn kein Server (Redirect pending)

--- a/packages/frontend/src/features/auth/ui/organisms/__tests__/LoginWindow.test.tsx
+++ b/packages/frontend/src/features/auth/ui/organisms/__tests__/LoginWindow.test.tsx
@@ -16,6 +16,10 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 // Store-Mock muss VOR dem Import der Komponente definiert werden
 const mockConnectionStatus = new Map<string, string>();
+const mockNavigate = vi.fn();
+const mockRouterHistoryReplace = vi.fn();
+const mockRouterHistoryPush = vi.fn();
+const mockRouterHistoryFlush = vi.fn();
 
 // Mock @tanstack/react-store mit Store-Klasse
 vi.mock('@tanstack/react-store', () => ({
@@ -30,7 +34,8 @@ vi.mock('@tanstack/react-store', () => ({
 // Mock alle Hooks
 vi.mock('@/features/auth', () => ({
   AUTH_KEYS: { auth: { queries: { authCheck: ['auth', 'check'] } } },
-  useCurrentUser: vi.fn(() => ({ user: null, isLoading: false })),
+  consumeRedirectAfterLogin: vi.fn(() => undefined),
+  useCurrentUser: vi.fn(() => ({ user: null, authStatus: 'unauthenticated', isLoading: false })),
   useUnifiedAuth: () => ({ mutate: vi.fn(), isPending: false, error: null }),
   useLogout: vi.fn(() => ({ mutateAsync: vi.fn().mockResolvedValue(undefined), isPending: false })),
 }));
@@ -62,7 +67,14 @@ vi.mock('@/shared/lib/errors/apiErrorHandler', () => ({
 }));
 
 vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mockNavigate,
+  useRouter: () => ({
+    history: {
+      replace: mockRouterHistoryReplace,
+      push: mockRouterHistoryPush,
+      flush: mockRouterHistoryFlush,
+    },
+  }),
 }));
 
 // Mock für QueryClient - wird in Tests überschrieben
@@ -182,7 +194,7 @@ import { LoginWindow } from '../LoginWindow';
 // Import mocks to control
 import { useRequireServer, useServerList, useActiveServer } from '@/features/server/hooks';
 import { setActiveServer } from '@/features/server/stores/server.store';
-import { useLogout, useCurrentUser } from '@/features/auth';
+import { consumeRedirectAfterLogin, useLogout, useCurrentUser } from '@/features/auth';
 import { toast } from 'sonner';
 import type { ServerConfig } from '@/features/server/types/server-config';
 
@@ -192,6 +204,7 @@ const mockUseActiveServer = vi.mocked(useActiveServer);
 const mockSetActiveServer = vi.mocked(setActiveServer);
 const mockUseLogout = vi.mocked(useLogout);
 const mockUseCurrentUser = vi.mocked(useCurrentUser);
+const mockConsumeRedirectAfterLogin = vi.mocked(consumeRedirectAfterLogin);
 
 /**
  * Factory für Mock-Server
@@ -218,6 +231,13 @@ describe('LoginWindow', () => {
     });
     mockUseServerList.mockReturnValue([createMockServer()]);
     mockUseActiveServer.mockReturnValue(createMockServer());
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      authStatus: 'unauthenticated',
+      isLoading: false,
+    });
+    mockConsumeRedirectAfterLogin.mockReturnValue(undefined);
+    window.history.replaceState({}, '', '/auth');
   });
 
   // =====================================================
@@ -438,6 +458,30 @@ describe('LoginWindow', () => {
 
       // Then
       expect(screen.getByTestId('auth-footer')).toBeInTheDocument();
+    });
+  });
+
+  describe('Redirect Navigation', () => {
+    it('should preserve query and hash when redirecting after successful authentication', async () => {
+      const singleServer = createMockServer();
+      mockUseServerList.mockReturnValue([singleServer]);
+      mockUseActiveServer.mockReturnValue(singleServer);
+      mockUseCurrentUser.mockReturnValue({
+        user: { id: 'user-1' },
+        authStatus: 'authenticated',
+        isLoading: false,
+      });
+      window.history.pushState({}, '', '/auth?redirect=%2Fapp%2Feinsatz%2F42%3Ftab%3Dlagekarte%23karte');
+
+      render(<LoginWindow />);
+
+      await vi.waitFor(() => {
+        expect(mockRouterHistoryReplace).toHaveBeenCalledWith('/app/einsatz/42?tab=lagekarte#karte');
+      });
+
+      expect(mockRouterHistoryPush).not.toHaveBeenCalled();
+      expect(mockRouterHistoryFlush).toHaveBeenCalled();
+      expect(mockConsumeRedirectAfterLogin).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/frontend/src/routes/admin-login.tsx
+++ b/packages/frontend/src/routes/admin-login.tsx
@@ -1,11 +1,20 @@
 import { Spinner } from '@/shared/ui/atoms/spinner.atom.tsx';
 import { createFileRoute } from '@tanstack/react-router';
+import { sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
 import { lazy, Suspense } from 'react';
+import { z } from 'zod';
 
 const AdminLogin = lazy(() => import('@/features/admin/ui').then((m) => ({ default: m.AdminLogin })));
+const searchSchema = z.object({
+  redirect: z
+    .string()
+    .optional()
+    .transform((value) => sanitizeInternalRedirectPath(value)),
+});
 
 // Separate Route für Admin-Login, die das AdminLayout umgeht
 export const Route = createFileRoute('/admin-login')({
+  validateSearch: searchSchema,
   component: () => (
     <Suspense
       fallback={

--- a/packages/frontend/src/routes/auth.tsx
+++ b/packages/frontend/src/routes/auth.tsx
@@ -1,13 +1,23 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { LoginWindow } from '@/features/auth/ui';
+import { sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
 import { isSetupRedirectInProgress, setSetupRedirectInProgress } from '@/shared/lib/server-access-token';
 import { serverStore } from '@/features/server/stores/server.store';
+import { z } from 'zod';
+
+const searchSchema = z.object({
+  redirect: z
+    .string()
+    .optional()
+    .transform((value) => sanitizeInternalRedirectPath(value)),
+});
 
 // DEBUG: Module load log
 console.log('[auth.tsx] Module loaded at', new Date().toISOString());
 
 export const Route = createFileRoute('/auth')({
   component: LoginWindow,
+  validateSearch: searchSchema,
 
   /**
    * beforeLoad Guard:

--- a/packages/frontend/src/shared/api/fetchWithRefresh.ts
+++ b/packages/frontend/src/shared/api/fetchWithRefresh.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/shared/lib/logger';
+import { redirectWithRouter } from '@/shared/lib/navigation/router-redirect';
 import { clearServerAccessToken, getServerAccessToken, isSetupRedirectInProgress, isTokenErrorMessage, setSetupRedirectInProgress } from '@/shared/lib/server-access-token';
 import { AuthApi, Configuration } from '@/shared';
 import { getBaseUrl } from './api';
@@ -150,11 +151,8 @@ async function isServerNotSetupError(response: Response): Promise<boolean> {
  * Nutzt zentrales Flag um mehrfache Redirects bei parallelen Requests zu verhindern.
  */
 function handleServerNotSetup(): void {
-  console.log('[handleServerNotSetup] Called!', { currentPath: window.location.pathname });
-
   // Vermeide mehrfache Redirects bei parallelen Requests
   if (isSetupRedirectInProgress()) {
-    console.log('[handleServerNotSetup] Already in progress, skipping');
     return;
   }
   // Flag SOFORT setzen um Race Conditions zu verhindern
@@ -162,16 +160,17 @@ function handleServerNotSetup(): void {
 
   // Nicht redirecten wenn wir bereits auf der Setup-Seite sind
   if (window.location.pathname.startsWith('/server/setup')) {
-    console.log('[handleServerNotSetup] Already on setup page, skipping');
     setSetupRedirectInProgress(false);
     return;
   }
 
   // Clear old token - backend was reset, old token is invalid
   clearServerAccessToken();
-  console.log('[handleServerNotSetup] Redirecting to /server/setup');
   logger.info('Server requires setup, clearing old token and redirecting to /server/setup');
-  window.location.href = '/server/setup';
+  void redirectWithRouter({
+    to: '/server/setup',
+    replace: true,
+  });
 }
 
 /**
@@ -197,7 +196,11 @@ function handleInvalidServerToken(): void {
 
   clearServerAccessToken();
   logger.info('Invalid server token, redirecting to /server/manage');
-  window.location.href = '/server/manage?reason=token-invalid';
+  void redirectWithRouter({
+    to: '/server/manage',
+    search: { reason: 'token-invalid' },
+    replace: true,
+  });
 }
 
 /**

--- a/packages/frontend/src/shared/lib/errors/error-handler.ts
+++ b/packages/frontend/src/shared/lib/errors/error-handler.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/shared/lib/logger';
+import { getCurrentPathWithQueryAndHash, redirectWithRouter, sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
 import { isSetupRedirectInProgress } from '@/shared/lib/server-access-token';
 import type { FetchError, ResponseError } from '@/shared';
 import { toast } from 'sonner';
@@ -264,6 +265,7 @@ export async function handleQueryError(error: unknown, _query?: unknown): Promis
       // Check if we're on pages that handle auth themselves
       const isOnAuthPage = window.location.pathname.startsWith('/auth');
       const isOnServerSetup = window.location.pathname.startsWith('/server/setup');
+      const redirectTarget = sanitizeInternalRedirectPath(getCurrentPathWithQueryAndHash()) ?? '/';
 
       // On server setup page, don't redirect - the page handles token errors itself
       if (isOnServerSetup) {
@@ -282,7 +284,11 @@ export async function handleQueryError(error: unknown, _query?: unknown): Promis
           // Delay redirect to avoid race conditions with other failing queries
           setTimeout(() => {
             if (!tokenRefreshQueue.getIsRefreshing()) {
-              window.location.href = '/auth';
+              void redirectWithRouter({
+                to: '/auth',
+                search: { redirect: redirectTarget },
+                replace: true,
+              });
             }
           }, 100);
         }
@@ -306,7 +312,11 @@ export async function handleQueryError(error: unknown, _query?: unknown): Promis
 
       // Small delay to let the toast show
       setTimeout(() => {
-        window.location.href = '/auth';
+        void redirectWithRouter({
+          to: '/auth',
+          search: { redirect: redirectTarget },
+          replace: true,
+        });
       }, 500);
       return;
     }

--- a/packages/frontend/src/shared/lib/index.ts
+++ b/packages/frontend/src/shared/lib/index.ts
@@ -16,6 +16,9 @@ export * from './url.util';
 // Error Handling
 export * from './errors';
 
+// Navigation Utilities
+export * from './navigation/router-redirect';
+
 // Storage Utilities
 export * from './storage';
 

--- a/packages/frontend/src/shared/lib/navigation/__tests__/router-redirect.spec.ts
+++ b/packages/frontend/src/shared/lib/navigation/__tests__/router-redirect.spec.ts
@@ -14,6 +14,12 @@ const { mockRouterNavigate } = vi.hoisted(() => ({
   mockRouterNavigate: vi.fn(),
 }));
 
+const { mockRouterHistoryReplace, mockRouterHistoryPush, mockRouterHistoryFlush } = vi.hoisted(() => ({
+  mockRouterHistoryReplace: vi.fn(),
+  mockRouterHistoryPush: vi.fn(),
+  mockRouterHistoryFlush: vi.fn(),
+}));
+
 vi.mock('@/shared/lib/logger', () => ({
   logger: mockLogger,
 }));
@@ -21,6 +27,11 @@ vi.mock('@/shared/lib/logger', () => ({
 vi.mock('@/main', () => ({
   router: {
     navigate: (...args: unknown[]) => mockRouterNavigate(...args),
+    history: {
+      replace: (...args: unknown[]) => mockRouterHistoryReplace(...args),
+      push: (...args: unknown[]) => mockRouterHistoryPush(...args),
+      flush: (...args: unknown[]) => mockRouterHistoryFlush(...args),
+    },
   },
 }));
 
@@ -64,6 +75,24 @@ describe('router-redirect', () => {
       replace: true,
     });
     expect(window.location.href).toBe('/start');
+  });
+
+  it('erhält Query und Hash bei vollständigen Redirect-Zielen über Router-History', () => {
+    routerRedirect.navigateToInternalRedirect(
+      {
+        history: {
+          replace: mockRouterHistoryReplace,
+          push: mockRouterHistoryPush,
+          flush: mockRouterHistoryFlush,
+        },
+      },
+      '/app/einsatz/42?tab=lagekarte#karte',
+      { replace: true },
+    );
+
+    expect(mockRouterHistoryReplace).toHaveBeenCalledWith('/app/einsatz/42?tab=lagekarte#karte');
+    expect(mockRouterHistoryPush).not.toHaveBeenCalled();
+    expect(mockRouterHistoryFlush).toHaveBeenCalled();
   });
 
   it('fällt bei fehlendem Router kontrolliert auf window.location.href zurück', async () => {

--- a/packages/frontend/src/shared/lib/navigation/__tests__/router-redirect.spec.ts
+++ b/packages/frontend/src/shared/lib/navigation/__tests__/router-redirect.spec.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as routerRedirect from '../router-redirect';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const { mockRouterNavigate } = vi.hoisted(() => ({
+  mockRouterNavigate: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+vi.mock('@/main', () => ({
+  router: {
+    navigate: (...args: unknown[]) => mockRouterNavigate(...args),
+  },
+}));
+
+describe('router-redirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        pathname: '/start',
+        search: '',
+        hash: '',
+        href: '/start',
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('validiert Redirect-Ziele ausschließlich als interne Pfade', () => {
+    expect(routerRedirect.sanitizeInternalRedirectPath('/app/einsatz/42?tab=lage#karte')).toBe('/app/einsatz/42?tab=lage#karte');
+    expect(routerRedirect.sanitizeInternalRedirectPath('https://example.com')).toBeUndefined();
+    expect(routerRedirect.sanitizeInternalRedirectPath('//example.com')).toBeUndefined();
+    expect(routerRedirect.sanitizeInternalRedirectPath('admin/dashboard')).toBeUndefined();
+  });
+
+  it('nutzt Soft-Navigation über den Router, wenn verfügbar', async () => {
+    mockRouterNavigate.mockResolvedValue(undefined);
+
+    await routerRedirect.redirectWithRouter({
+      to: '/auth',
+      search: { redirect: '/app/einsatz/42' },
+      replace: true,
+    });
+
+    expect(mockRouterNavigate).toHaveBeenCalledWith({
+      to: '/auth',
+      search: { redirect: '/app/einsatz/42' },
+      replace: true,
+    });
+    expect(window.location.href).toBe('/start');
+  });
+
+  it('fällt bei fehlendem Router kontrolliert auf window.location.href zurück', async () => {
+    mockRouterNavigate.mockRejectedValueOnce(new Error('router unavailable'));
+
+    await routerRedirect.redirectWithRouter({
+      to: '/server/manage',
+      search: { reason: 'token-invalid' },
+      replace: true,
+    });
+
+    expect(window.location.href).toBe('/server/manage?reason=token-invalid');
+  });
+
+  it('blockiert unsichere Redirect-Ziele komplett', async () => {
+    await routerRedirect.redirectWithRouter({
+      to: 'https://evil.example',
+      replace: true,
+    });
+
+    expect(mockRouterNavigate).not.toHaveBeenCalled();
+    expect(window.location.href).toBe('/start');
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/shared/lib/navigation/router-redirect.ts
+++ b/packages/frontend/src/shared/lib/navigation/router-redirect.ts
@@ -8,6 +8,18 @@ export interface RouterRedirectOptions {
   replace?: boolean;
 }
 
+export interface RouterHistoryRedirectOptions {
+  replace?: boolean;
+}
+
+export interface RouterHistoryRedirectTarget {
+  history: {
+    push: (path: string) => void;
+    replace: (path: string) => void;
+    flush?: () => void;
+  };
+}
+
 const PROTOCOL_PREFIX_REGEX = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
 /**
@@ -81,6 +93,32 @@ function buildFallbackHref(to: string, search?: RedirectSearch): string {
   const [pathAndQuery, hash = ''] = to.split('#', 2);
   const separator = pathAndQuery.includes('?') ? '&' : '?';
   return `${pathAndQuery}${separator}${queryString}${hash ? `#${hash}` : ''}`;
+}
+
+/**
+ * Navigiert ein bereits aufgelöstes internes Redirect-Ziel exakt inklusive Query und Hash.
+ */
+export function navigateToInternalRedirect(router: RouterHistoryRedirectTarget, target: string, options: RouterHistoryRedirectOptions = {}): void {
+  const safeTarget = sanitizeInternalRedirectPath(target);
+  if (!safeTarget) {
+    logger.warn('Unsicheres Redirect-Ziel blockiert', { to: target });
+    return;
+  }
+
+  try {
+    if (options.replace ?? true) {
+      router.history.replace(safeTarget);
+    } else {
+      router.history.push(safeTarget);
+    }
+    router.history.flush?.();
+  } catch (error) {
+    logger.warn('Redirect über Router-History fehlgeschlagen, verwende Hard-Redirect-Fallback', { to: safeTarget, error });
+
+    if (typeof window !== 'undefined') {
+      window.location.href = safeTarget;
+    }
+  }
 }
 
 /**

--- a/packages/frontend/src/shared/lib/navigation/router-redirect.ts
+++ b/packages/frontend/src/shared/lib/navigation/router-redirect.ts
@@ -1,0 +1,130 @@
+import { logger } from '@/shared/lib/logger';
+
+type RedirectSearch = Record<string, unknown>;
+
+export interface RouterRedirectOptions {
+  to: string;
+  search?: RedirectSearch;
+  replace?: boolean;
+}
+
+const PROTOCOL_PREFIX_REGEX = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+
+/**
+ * Erlaubt nur interne Redirect-Ziele, um Open-Redirects zu verhindern.
+ */
+export function sanitizeInternalRedirectPath(path: string | null | undefined): string | undefined {
+  if (typeof path !== 'string') {
+    return undefined;
+  }
+
+  const trimmedPath = path.trim();
+  if (!trimmedPath || !trimmedPath.startsWith('/')) {
+    return undefined;
+  }
+
+  // Blockiert Protokoll-relative/externe Ziele wie //evil.com
+  if (trimmedPath.startsWith('//')) {
+    return undefined;
+  }
+
+  // Zusätzliche Absicherung gegen protokollartige Präfixe
+  if (PROTOCOL_PREFIX_REGEX.test(trimmedPath)) {
+    return undefined;
+  }
+
+  return trimmedPath;
+}
+
+export function getCurrentPathWithQueryAndHash(fallbackPathname = '/'): string {
+  if (typeof window === 'undefined') {
+    return fallbackPathname;
+  }
+
+  const pathname = window.location.pathname || fallbackPathname;
+  return `${pathname}${window.location.search}${window.location.hash}`;
+}
+
+export function getRedirectFromSearch(search: string): string | undefined {
+  const params = new URLSearchParams(search);
+  return sanitizeInternalRedirectPath(params.get('redirect'));
+}
+
+function buildFallbackHref(to: string, search?: RedirectSearch): string {
+  if (!search) {
+    return to;
+  }
+
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(search)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (entry !== undefined && entry !== null) {
+          params.append(key, String(entry));
+        }
+      }
+      continue;
+    }
+
+    params.set(key, String(value));
+  }
+
+  const queryString = params.toString();
+  if (!queryString) {
+    return to;
+  }
+
+  const [pathAndQuery, hash = ''] = to.split('#', 2);
+  const separator = pathAndQuery.includes('?') ? '&' : '?';
+  return `${pathAndQuery}${separator}${queryString}${hash ? `#${hash}` : ''}`;
+}
+
+/**
+ * Exportiert für Tests, damit Dynamic-Import-Verhalten mockbar ist.
+ */
+export async function loadAppRouter(): Promise<{
+  navigate: (options: { to: string; search?: RedirectSearch; replace?: boolean }) => Promise<unknown> | unknown;
+} | null> {
+  try {
+    const module = await import('@/main');
+    return module.router as {
+      navigate: (options: { to: string; search?: RedirectSearch; replace?: boolean }) => Promise<unknown> | unknown;
+    };
+  } catch (error) {
+    logger.debug('Router konnte für Soft-Redirect nicht geladen werden', { error });
+    return null;
+  }
+}
+
+/**
+ * Führt bevorzugt Soft-Navigation über den Router aus.
+ * Bei Fehlern wird kontrolliert auf window.location.href zurückgefallen.
+ */
+export async function redirectWithRouter({ to, search, replace = true }: RouterRedirectOptions): Promise<void> {
+  const safeTarget = sanitizeInternalRedirectPath(to);
+  if (!safeTarget) {
+    logger.warn('Unsicheres Redirect-Ziel blockiert', { to });
+    return;
+  }
+
+  try {
+    const router = await loadAppRouter();
+    if (router) {
+      await router.navigate({
+        to: safeTarget,
+        search,
+        replace,
+      });
+      return;
+    }
+  } catch (error) {
+    logger.warn('Soft-Redirect fehlgeschlagen, verwende Hard-Redirect-Fallback', { to: safeTarget, error });
+  }
+
+  const fallbackHref = buildFallbackHref(safeTarget, search);
+  window.location.href = fallbackHref;
+}

--- a/packages/frontend/src/shared/ui/templates/AdminLayout.tsx
+++ b/packages/frontend/src/shared/ui/templates/AdminLayout.tsx
@@ -1,4 +1,6 @@
-import { useCurrentUser, useAdminAuth } from '@/features/auth';
+import { useCurrentUser } from '@/features/auth';
+import { setRedirectAfterLogin } from '@/features/auth/stores/auth.store';
+import { getCurrentPathWithQueryAndHash, sanitizeInternalRedirectPath } from '@/shared/lib/navigation/router-redirect';
 import { logger } from '@/shared/lib/logger';
 import { CloseButton } from '@/shared/ui/atoms/close-button.atom';
 import { Container } from '@/shared/ui/atoms/container.atom';
@@ -19,12 +21,15 @@ import { PiArrowLeft } from 'react-icons/pi';
 export function AdminLayout() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user } = useCurrentUser();
-  const { hasAdminSession, isLoading } = useAdminAuth();
+  const { user, authStatus, adminSessionStatus } = useCurrentUser();
+
+  const redirectTarget = useMemo(() => {
+    return sanitizeInternalRedirectPath(getCurrentPathWithQueryAndHash(location.pathname)) ?? '/';
+  }, [location.pathname]);
 
   // Prüfe Admin-Authentifizierung
   useEffect(() => {
-    if (isLoading) return;
+    if (authStatus === 'pending' || adminSessionStatus === 'pending') return;
 
     const isSetupPage = location.pathname.includes('/admin/setup');
 
@@ -32,7 +37,9 @@ export function AdminLayout() {
       return;
     }
 
-    if (!hasAdminSession) {
+    if (adminSessionStatus !== 'authenticated') {
+      setRedirectAfterLogin(redirectTarget);
+
       const handleNoAdminSession = async () => {
         if (isTauri()) {
           const { isInAdminWindow } = await import('@/services/windowService');
@@ -55,16 +62,28 @@ export function AdminLayout() {
         // Wir sind im Hauptfenster oder Browser
         if (user) {
           // Benutzer eingeloggt aber keine Admin-Session - zu Admin-Login
-          void navigate({ to: '/admin-login' });
+          void navigate({
+            to: '/admin-login',
+            search: {
+              redirect: redirectTarget,
+            },
+            replace: true,
+          });
         } else {
-          // Kein Benutzer eingeloggt - zur Startseite
-          void navigate({ to: '/' });
+          // Kein Benutzer eingeloggt - zu Login mit Redirect-Ziel
+          void navigate({
+            to: '/auth',
+            search: {
+              redirect: redirectTarget,
+            },
+            replace: true,
+          });
         }
       };
 
       void handleNoAdminSession();
     }
-  }, [isLoading, hasAdminSession, user, location.pathname, navigate]);
+  }, [authStatus, adminSessionStatus, user, location.pathname, navigate, redirectTarget]);
 
   // Hole Meta-Daten aus der aktuellen Route
   const routerState = useRouterState();
@@ -105,6 +124,7 @@ export function AdminLayout() {
   }, [navigate]);
 
   const matchRoute = useMatchRoute();
+  const isGuardPending = authStatus === 'pending' || adminSessionStatus === 'pending';
 
   return (
     <Container maxWidth="6xl" className="px-0 py-8">
@@ -131,7 +151,7 @@ export function AdminLayout() {
 
         {/* Content der jeweiligen Admin-Seite */}
         <div>
-          {isLoading ? (
+          {isGuardPending ? (
             <div className="flex flex-col items-center gap-4 py-12">
               <Spinner size="xl" />
               <p className="text-gray-600 text-lg dark:text-gray-400">Authentifizierung wird geprüft...</p>

--- a/packages/frontend/src/shared/ui/templates/__tests__/AdminLayout.spec.tsx
+++ b/packages/frontend/src/shared/ui/templates/__tests__/AdminLayout.spec.tsx
@@ -1,0 +1,183 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseCurrentUser = vi.fn();
+const mockSetRedirectAfterLogin = vi.fn();
+const mockNavigate = vi.fn();
+const mockUseLocation = vi.fn();
+const mockIsTauri = vi.fn();
+const mockIsInAdminWindow = vi.fn();
+const mockCloseWindow = vi.fn();
+
+vi.mock('@/features/auth', () => ({
+  useCurrentUser: (...args: unknown[]) => mockUseCurrentUser(...args),
+}));
+
+vi.mock('@/features/auth/stores/auth.store', () => ({
+  setRedirectAfterLogin: (...args: unknown[]) => mockSetRedirectAfterLogin(...args),
+}));
+
+vi.mock('@/shared/lib/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Outlet: () => <div data-testid="admin-outlet">outlet</div>,
+  useLocation: (...args: unknown[]) => mockUseLocation(...args),
+  useMatchRoute: () => () => false,
+  useNavigate: () => mockNavigate,
+  useRouterState: () => ({
+    matches: [{ meta: [{ title: 'Admin-Bereich' }] }],
+  }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: (...args: unknown[]) => mockIsTauri(...args),
+}));
+
+vi.mock('@/services/windowService', () => ({
+  isInAdminWindow: (...args: unknown[]) => mockIsInAdminWindow(...args),
+}));
+
+vi.mock('@tauri-apps/api/webviewWindow', () => ({
+  getCurrentWebviewWindow: () => ({
+    close: (...args: unknown[]) => mockCloseWindow(...args),
+  }),
+}));
+
+vi.mock('@/shared/ui/atoms/close-button.atom', () => ({
+  CloseButton: ({ onClick }: { onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      close
+    </button>
+  ),
+}));
+
+vi.mock('@/shared/ui/atoms/container.atom', () => ({
+  Container: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/shared/ui/atoms/heading.atom', () => ({
+  Heading: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock('@/shared/ui/atoms/icon-button.atom', () => ({
+  IconButton: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
+}));
+
+vi.mock('@/shared/ui/atoms/spinner.atom', () => ({
+  Spinner: () => <div data-testid="admin-spinner">spinner</div>,
+}));
+
+import { AdminLayout } from '../AdminLayout';
+
+describe('AdminLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLocation.mockReturnValue({ pathname: '/admin/dashboard' });
+    mockIsTauri.mockReturnValue(false);
+    mockIsInAdminWindow.mockResolvedValue(false);
+    mockCloseWindow.mockResolvedValue(undefined);
+    window.history.pushState({}, '', '/admin/dashboard?tab=users#section');
+  });
+
+  it('führt im pending Status keinen Redirect aus', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      authStatus: 'pending',
+      adminSessionStatus: 'pending',
+    });
+
+    render(<AdminLayout />);
+
+    expect(screen.getByTestId('admin-spinner')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('redirectet eingeloggte User ohne Admin-Session zu /admin-login mit Redirect-Ziel', async () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: { id: 'user-1' },
+      authStatus: 'authenticated',
+      adminSessionStatus: 'unauthenticated',
+    });
+
+    render(<AdminLayout />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/admin-login',
+        search: {
+          redirect: '/admin/dashboard?tab=users#section',
+        },
+        replace: true,
+      });
+    });
+
+    expect(mockSetRedirectAfterLogin).toHaveBeenCalledWith('/admin/dashboard?tab=users#section');
+  });
+
+  it('redirectet anonyme User zu /auth mit Redirect-Ziel', async () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      authStatus: 'unauthenticated',
+      adminSessionStatus: 'unauthenticated',
+    });
+
+    render(<AdminLayout />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/auth',
+        search: {
+          redirect: '/admin/dashboard?tab=users#section',
+        },
+        replace: true,
+      });
+    });
+  });
+
+  it('überspringt Redirects auf der Setup-Route', async () => {
+    mockUseLocation.mockReturnValue({ pathname: '/admin/setup' });
+    window.history.pushState({}, '', '/admin/setup?step=1');
+
+    mockUseCurrentUser.mockReturnValue({
+      user: { id: 'user-1' },
+      authStatus: 'authenticated',
+      adminSessionStatus: 'unauthenticated',
+    });
+
+    render(<AdminLayout />);
+
+    await waitFor(() => {
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    expect(mockSetRedirectAfterLogin).not.toHaveBeenCalled();
+  });
+
+  it('schließt im Tauri-Adminfenster ohne Session das Fenster statt zu navigieren', async () => {
+    mockIsTauri.mockReturnValue(true);
+    mockIsInAdminWindow.mockResolvedValue(true);
+
+    mockUseCurrentUser.mockReturnValue({
+      user: { id: 'user-1' },
+      authStatus: 'authenticated',
+      adminSessionStatus: 'unauthenticated',
+    });
+
+    render(<AdminLayout />);
+
+    await waitFor(() => {
+      expect(mockCloseWindow).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/check-commit-range.mjs
+++ b/scripts/check-commit-range.mjs
@@ -63,6 +63,14 @@ function readCommitSubject(sha) {
   return runGit(['log', '--format=%s', '-n', '1', sha]);
 }
 
+function readCommitAuthor(sha) {
+  return runGit(['log', '--format=%an', '-n', '1', sha]);
+}
+
+function isDependabotCommit(sha) {
+  return readCommitAuthor(sha) === 'dependabot[bot]';
+}
+
 function isReleaseCommitSubject(subject) {
   return RELEASE_SUBJECT_PATTERN.test(subject.trim());
 }
@@ -80,8 +88,14 @@ async function main() {
 
   const invalidCommits = [];
   let releaseCommitCount = 0;
+  let dependabotCommitCount = 0;
 
   for (const sha of shas) {
+    if (isDependabotCommit(sha)) {
+      dependabotCommitCount += 1;
+      continue;
+    }
+
     const message = readCommitMessage(sha);
     const subject = readCommitSubject(sha);
     const isReleaseCommit = isReleaseCommitSubject(subject);
@@ -111,6 +125,10 @@ async function main() {
     }
 
     process.exit(1);
+  }
+
+  if (dependabotCommitCount > 0) {
+    console.log(`ℹ️ ${dependabotCommitCount} Dependabot-Commit(s) übersprungen.`);
   }
 
   if (releaseCommitCount > 0) {


### PR DESCRIPTION
## Summary

- Stabilize auth/admin navigation on reload by separating pending vs unauthenticated guard states.
- Preserve internal redirect targets through `/auth` and `/admin-login` roundtrips.
- Replace auth/setup hard redirects with router-first soft redirects plus safe fallback.

## Changes

- Frontend: Added explicit auth status model, guard timing fixes, redirect utilities, and login redirect roundtrip handling.
- Frontend tests: Added regression coverage for `useCurrentUser`, `AppGuard`, `AdminLayout`, and router redirect fallback behavior.
- Shared/Config: Include existing branch commit that updates commit-range validation to skip Dependabot commits.

## Test plan

- [x] `pnpm --filter @bluelight-hub/frontend exec vitest run src/features/auth/api/__tests__/use-current-user.spec.tsx src/features/auth/guards/__tests__/app-guard.spec.tsx src/shared/ui/templates/__tests__/AdminLayout.spec.tsx src/shared/lib/navigation/__tests__/router-redirect.spec.ts src/features/auth/ui/organisms/__tests__/LoginWindow.test.tsx`
- [x] `pnpm --filter @bluelight-hub/frontend test -- --run`

🤖 Generated with Codex

Closes #457