### PR TITLE
🩹(ci): make commit-msg hook POSIX-compatible

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 COMMIT_MSG_FILE=$1
 COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")


### PR DESCRIPTION
### Motivation
- Der `semantic-release`-Release-Commit schlug fehl, weil die Husky-Hook in `.husky/commit-msg` Bash-spezifisch war (`set -euo pipefail`) und beim Ausführen mit `/bin/sh` einen Fehler (`Illegal option -o pipefail`) verursachte, daher muss die Hook POSIX-kompatibel gemacht werden.

### Description
- Die Hook wurde auf POSIX-Shell umgestellt durch Austausch des Shebangs zu `#!/usr/bin/env sh` und Ersetzen von `set -euo pipefail` durch das mit `sh` kompatible `set -eu` in ` .husky/commit-msg` (funktionelle Logik der Hook unverändert).

### Testing
- Getestet mit Ausführung der Hook über `printf '🔖(release): 1.0.0-alpha.65 [skip ci]\n\nTest\n' > /tmp/commitmsg.txt && .husky/commit-msg /tmp/commitmsg.txt`, `pnpm exec semantic-release` (Dry-Run) und einem lokalen `git commit` mit `git add .husky/commit-msg && git commit -m "🩹(ci): fix POSIX compatibility of commit-msg hook"`, und alle Prüfungen (DI-Import-Check, Circular-Dependency-Check, Biome lint-staged) liefen erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa71ddbe6483218c0bccee662360db)