### PR TITLE
🐛(backend): Migration robust machen für einsatz_teilnehmer → einsatz_person

### DIFF
--- a/packages/backend/prisma/migrations/20260224120000_link_teilnehmer_to_einsatz_person/migration.sql
+++ b/packages/backend/prisma/migrations/20260224120000_link_teilnehmer_to_einsatz_person/migration.sql
@@ -1,6 +1,51 @@
 -- AlterTable: Replace funkrufname with einsatz_person_id FK
-ALTER TABLE "einsatz_teilnehmer" DROP COLUMN "funkrufname",
-ADD COLUMN     "einsatz_person_id" TEXT NOT NULL;
+-- WICHTIG: Bestehende Teilnehmer-Daten müssen vor NOT NULL/FK migriert werden.
+ALTER TABLE "einsatz_teilnehmer"
+  ADD COLUMN "einsatz_person_id" TEXT;
+
+-- Backfill: Für jeden bestehenden Teilnehmer eine dedizierte EinsatzPerson-Snapshot-Zeile anlegen.
+-- So bleibt die Migration robust, auch wenn kein passender Datensatz in "einsatz_personen" existiert.
+INSERT INTO "einsatz_personen" (
+  "id",
+  "einsatz_id",
+  "stamm_id",
+  "vorname",
+  "nachname",
+  "funkrufname",
+  "position",
+  "created_at",
+  "updated_at",
+  "created_by",
+  "updated_by"
+)
+SELECT
+  'mig_et_' || et."id" AS "id",
+  et."einsatz_id",
+  NULL AS "stamm_id",
+  'Teilnehmer' AS "vorname",
+  et."funkrufname" AS "nachname",
+  et."funkrufname",
+  NULL AS "position",
+  COALESCE(et."joined_at", CURRENT_TIMESTAMP) AS "created_at",
+  COALESCE(et."joined_at", CURRENT_TIMESTAMP) AS "updated_at",
+  et."user_id" AS "created_by",
+  et."user_id" AS "updated_by"
+FROM "einsatz_teilnehmer" et
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "einsatz_personen" ep
+  WHERE ep."id" = 'mig_et_' || et."id"
+);
+
+-- Teilnehmer auf die neu erzeugten EinsatzPerson-IDs verknüpfen.
+UPDATE "einsatz_teilnehmer" et
+SET "einsatz_person_id" = 'mig_et_' || et."id"
+WHERE et."einsatz_person_id" IS NULL;
+
+-- Erst nach erfolgreichem Backfill NOT NULL erzwingen und Legacy-Spalte entfernen.
+ALTER TABLE "einsatz_teilnehmer"
+  ALTER COLUMN "einsatz_person_id" SET NOT NULL,
+  DROP COLUMN "funkrufname";
 
 -- CreateIndex: Eine Person = max ein Bearbeiter pro Einsatz
 CREATE UNIQUE INDEX "einsatz_teilnehmer_einsatz_id_einsatz_person_id_key" ON "einsatz_teilnehmer"("einsatz_id", "einsatz_person_id");


### PR DESCRIPTION
### Motivation
- Die vorhandene Migration schlug im Deployment mit `P3018 / 23502` fehl, weil eine neue `NOT NULL`-Spalte (`einsatz_person_id`) auf eine Tabelle mit bestehenden NULL-Werten gesetzt wurde.
- Ziel ist, den Restart/Deploy-Pfad so zu reparieren, dass bestehende Daten sicher gemigriert werden und künftige Deploys durchlaufen.

### Description
- Die Migration `packages/backend/prisma/migrations/20260224120000_link_teilnehmer_to_einsatz_person/migration.sql` wurde so angepasst, dass `einsatz_person_id` zunächst nullable hinzugefügt wird anstatt sofort `NOT NULL` zu erzwingen.
- Es wird ein Backfill durchgeführt, der für jeden existierenden `einsatz_teilnehmer` einen Snapshot-Datensatz in `einsatz_personen` anlegt (ID-Präfix `mig_et_`), um fehlende Referenzen sicher zu erzeugen.
- Anschließend werden `einsatz_teilnehmer`-Zeilen auf die neuen `einsatz_person_id`-Werte aktualisiert und erst danach `NOT NULL` gesetzt, die Legacy-Spalte `funkrufname` entfernt sowie Unique-Index und Foreign-Key angelegt.

### Testing
- `pnpm --filter @bluelight-hub/backend check:di:imports` wurde ausgeführt und erfolgreich bestanden.
- `pnpm --filter @bluelight-hub/backend lint:deps:core` wurde ausgeführt und erfolgreich bestanden.
- Ein Versuch, `pnpm --filter @bluelight-hub/backend prisma:deploy` lokal auszuführen, schlug in dieser Umgebung mit `P1001` fehl, da keine lokale DB / `.env` vorhanden ist, daher konnte die Migration hier nicht end-to-end gegen eine DB validiert werden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aebd1b12f48321aa90e749bb898a67)