### PR TITLE
🐛(etb): Remove standalone ETB lock, auto-lock on close

### DIFF
--- a/packages/frontend/src/shared/ui/templates/SingleEinsatzLayout.tsx
+++ b/packages/frontend/src/shared/ui/templates/SingleEinsatzLayout.tsx
@@ -2,6 +2,7 @@ import { useCurrentUser } from '@/features/auth';
 import { useBefehlNotifications, useBefehlWebSocket, useMissedBefehlAlerts, useUnquittierteBefehleCount } from '@/features/befehl';
 import { useMyEinsatzRolle } from '@/features/befehl/api/use-my-einsatz-rolle';
 import { EINSATZ_QUERY_KEYS, EinsatzRolleProvider, useActiveEinsatz, useEinsatzDetails, useMyEinsatzTeilnahme } from '@/features/einsatz';
+import { ETB_QUERY_KEYS } from '@/features/etb';
 import { EinsatzStatusBadge } from '@/features/einsatz/ui/molecules/einsatz-status-badge.molecule';
 import { EinsatzSwitcher } from '@/features/einsatz/ui/molecules/EinsatzSwitcher.molecule';
 import { ModuleOverviewCard } from '@/features/einsatz/ui/molecules/ModuleOverviewCard';
@@ -312,6 +313,7 @@ export function SingleEinsatzLayout({ className }: SingleEinsatzLayoutProps) {
         queryClient.invalidateQueries({ queryKey: EINSATZ_QUERY_KEYS.detailsCombined(einsatzId) }),
         queryClient.invalidateQueries({ queryKey: EINSATZ_QUERY_KEYS.lists() }),
         queryClient.invalidateQueries({ queryKey: EINSATZ_QUERY_KEYS.activeWithCounts() }),
+        queryClient.invalidateQueries({ queryKey: ETB_QUERY_KEYS.byEinsatz(einsatzId) }),
       ]);
       // Navigate back to overview
       await router.navigate({ to: '/app/einsaetze' });

--- a/packages/frontend/src/shared/ui/templates/__tests__/SingleEinsatzLayout.hotkeys.spec.tsx
+++ b/packages/frontend/src/shared/ui/templates/__tests__/SingleEinsatzLayout.hotkeys.spec.tsx
@@ -244,19 +244,18 @@ vi.mock('@/features/workspace', async () => {
   };
 });
 
-vi.mock('@/shared', () => ({
-  api: {
-    einsatz: () => ({
-      einsatzControllerStartVAlpha: vi.fn(),
-      einsatzControllerCompleteVAlpha: vi.fn(),
-    }),
-  },
-  EinsatzDtoStatusEnum: {
-    Angelegt: 'Angelegt',
-    Abgeschlossen: 'Abgeschlossen',
-    Archiviert: 'Archiviert',
-  },
-}));
+vi.mock('@/shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared')>();
+  return {
+    ...actual,
+    api: {
+      einsatz: () => ({
+        einsatzControllerStartVAlpha: vi.fn(),
+        einsatzControllerCompleteVAlpha: vi.fn(),
+      }),
+    },
+  };
+});
 
 vi.mock('@/shared/ui/organisms/command-palette', () => ({
   CommandPalette: ({ modules, open }: { modules: Array<{ name: string; subPages: Array<{ name: string; disabled?: boolean; disabledReason?: string }> }>; open: boolean }) =>


### PR DESCRIPTION
## Summary

- Removes the standalone ETB lock/unlock UI and backend endpoint — ETB now locks automatically when an Einsatz is completed
- Fixes timing bug where ETB remained editable for up to 30s after Einsatz completion (stale React Query cache)
- Enforces ETB entry immutability with correction entries instead of edits/deletes

## Changes

**Backend**
- Synchronous ETB lock in the same transaction as Einsatz completion (`complete-einsatz.handler.ts`)
- Removed standalone `lock-etb` and `update-eintrag` commands
- Added `add-korrektur-eintrag` command for immutable correction entries
- Added `EtbEinsatzCompletedHandler` as async fallback safety net
- New DB migration for correction entry schema

**Frontend**
- Removed ETB lock/unlock button and related UI
- Added ETB query cache invalidation on Einsatz completion (`SingleEinsatzLayout.tsx`)
- Replaced edit/delete UI with correction entry workflow

**Shared**
- Regenerated API client to reflect removed/added endpoints

## Test plan

- [ ] Einsatz erstellen, ETB-Einträge anlegen
- [ ] Einsatz beenden → ETB ist sofort gesperrt (kein 30s Delay)
- [ ] Nach Navigation zurück zum ETB: Sperrhinweis wird angezeigt
- [ ] Korrektureinträge können erstellt werden
- [ ] Bestehende Einträge können nicht mehr bearbeitet/gelöscht werden

🤖 Generated with [Claude Code](https://claude.com/claude-code)