### PR TITLE
✨(backend): Beitrittsanfrage Commands, Query, Controller + Module

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -46,6 +46,7 @@ import { MetricsInterceptor } from '@infrastructure/metrics/metrics.interceptor'
 import { DeprecationInterceptor } from './modules/common/interceptors/deprecation.interceptor';
 import { MonitoringModule } from './modules/monitoring/monitoring.module';
 import { GeoModule } from './modules/geo/geo.module';
+import { EinsatzBeitrittModule } from './modules/einsatz-beitritt/einsatz-beitritt.module';
 
 /**
  * Haupt-Anwendungsmodul der Bluelight Hub Backend-Anwendung
@@ -134,6 +135,7 @@ import { GeoModule } from './modules/geo/geo.module';
     MetricsModule, // Prometheus Metrics (Story 5.6)
     MonitoringModule, // System-Monitoring WebSocket Gateway (Story 5.6)
     GeoModule, // PLZ-Lookup via zippopotam.us (Issue #525)
+    EinsatzBeitrittModule, // Einsatz-Beitrittsanfragen (Issue #98)
   ],
   controllers: [AppController],
   providers: [

--- a/packages/backend/src/application/einsatz-beitritt/commands/create-beitrittsanfrage/__tests__/create-beitrittsanfrage.handler.spec.ts
+++ b/packages/backend/src/application/einsatz-beitritt/commands/create-beitrittsanfrage/__tests__/create-beitrittsanfrage.handler.spec.ts
@@ -1,0 +1,185 @@
+// @ts-nocheck
+import { PrismaService } from '@/infrastructure/database/prisma.service';
+import { EINSATZ_BEITRITTSANFRAGE_REPOSITORY, LOGGER, OUTBOX_REPOSITORY } from '@/infrastructure/di-tokens';
+import { Result } from '@domain/common/result';
+import type { ILogger } from '@domain/ports/i-logger.port';
+import type { IEinsatzBeitrittsanfrageRepository, EinsatzBeitrittsanfrageData } from '@domain/repositories/i-einsatz-beitrittsanfrage.repository';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { CreateBeitrittsanfrageCommand } from '../create-beitrittsanfrage.command';
+import { CreateBeitrittsanfrageHandler } from '../create-beitrittsanfrage.handler';
+
+const TEST_EINSATZ_ID = 'clw3h8x9y0000qwerty00001';
+const TEST_USER_ID = 'clw3h8x9y0000qwerty00002';
+const TEST_ANFRAGE_ID = 'clw3h8x9y0000qwerty00003';
+
+/**
+ * Unit Tests für CreateBeitrittsanfrageHandler.
+ *
+ * Testet Handler-Orchestration gemäß BDD Given-When-Then Pattern.
+ */
+describe('CreateBeitrittsanfrageHandler', () => {
+  let handler: CreateBeitrittsanfrageHandler;
+  let mockAnfrageRepository: jest.Mocked<IEinsatzBeitrittsanfrageRepository>;
+  let mockPrismaService: {
+    $transaction: jest.Mock;
+    einsatz: {
+      findUnique: jest.Mock;
+    };
+  };
+  let mockOutboxRepository: {
+    save: jest.Mock;
+  };
+  let mockLogger: jest.Mocked<ILogger>;
+
+  beforeEach(async () => {
+    mockAnfrageRepository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findOpenByEinsatzAndUser: jest.fn(),
+      findByEinsatz: jest.fn(),
+      resolve: jest.fn(),
+    } as any;
+
+    mockPrismaService = {
+      $transaction: jest.fn().mockImplementation(async (callback) => {
+        const txMock = {};
+        return callback(txMock);
+      }),
+      einsatz: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    mockOutboxRepository = {
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockLogger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as jest.Mocked<ILogger>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateBeitrittsanfrageHandler,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: OUTBOX_REPOSITORY, useValue: mockOutboxRepository },
+        { provide: EINSATZ_BEITRITTSANFRAGE_REPOSITORY, useValue: mockAnfrageRepository },
+        { provide: LOGGER, useValue: mockLogger },
+      ],
+    }).compile();
+
+    handler = module.get<CreateBeitrittsanfrageHandler>(CreateBeitrittsanfrageHandler);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Erfolgsfall', () => {
+    it('sollte Beitrittsanfrage erfolgreich erstellen wenn Einsatz aktiv und keine Duplikate', async () => {
+      // Given
+      const command = CreateBeitrittsanfrageCommand.create(TEST_EINSATZ_ID, TEST_USER_ID).value!;
+      const mockAnfrage: EinsatzBeitrittsanfrageData = {
+        id: TEST_ANFRAGE_ID,
+        einsatzId: TEST_EINSATZ_ID,
+        userId: TEST_USER_ID,
+        status: 'OFFEN',
+        createdAt: new Date(),
+        resolvedAt: null,
+        resolvedBy: null,
+      };
+
+      mockAnfrageRepository.findOpenByEinsatzAndUser.mockResolvedValue(null);
+      mockPrismaService.einsatz.findUnique.mockResolvedValue({
+        id: TEST_EINSATZ_ID,
+        status: 'IN_BEARBEITUNG',
+      });
+      mockAnfrageRepository.save.mockResolvedValue(mockAnfrage);
+
+      // When
+      const result = await handler.execute(command);
+
+      // Then
+      expect(result.isSuccess).toBe(true);
+      expect(result.value).toEqual(mockAnfrage);
+      expect(mockAnfrageRepository.save).toHaveBeenCalledWith({ einsatzId: TEST_EINSATZ_ID, userId: TEST_USER_ID }, {});
+      expect(mockOutboxRepository.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Fehlerfälle', () => {
+    it('sollte fehlschlagen wenn bereits eine offene Anfrage existiert', async () => {
+      // Given
+      const command = CreateBeitrittsanfrageCommand.create(TEST_EINSATZ_ID, TEST_USER_ID).value!;
+      const existingAnfrage: EinsatzBeitrittsanfrageData = {
+        id: 'clw3h8x9y0000qwerty00099',
+        einsatzId: TEST_EINSATZ_ID,
+        userId: TEST_USER_ID,
+        status: 'OFFEN',
+        createdAt: new Date(),
+        resolvedAt: null,
+        resolvedBy: null,
+      };
+
+      mockAnfrageRepository.findOpenByEinsatzAndUser.mockResolvedValue(existingAnfrage);
+
+      // When
+      const result = await handler.execute(command);
+
+      // Then
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('offene Beitrittsanfrage');
+      expect(mockAnfrageRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('sollte fehlschlagen wenn Einsatz nicht existiert', async () => {
+      // Given
+      const command = CreateBeitrittsanfrageCommand.create(TEST_EINSATZ_ID, TEST_USER_ID).value!;
+
+      mockAnfrageRepository.findOpenByEinsatzAndUser.mockResolvedValue(null);
+      mockPrismaService.einsatz.findUnique.mockResolvedValue(null);
+
+      // When
+      const result = await handler.execute(command);
+
+      // Then
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('nicht gefunden');
+    });
+
+    it('sollte fehlschlagen wenn Einsatz nicht IN_BEARBEITUNG ist', async () => {
+      // Given
+      const command = CreateBeitrittsanfrageCommand.create(TEST_EINSATZ_ID, TEST_USER_ID).value!;
+
+      mockAnfrageRepository.findOpenByEinsatzAndUser.mockResolvedValue(null);
+      mockPrismaService.einsatz.findUnique.mockResolvedValue({
+        id: TEST_EINSATZ_ID,
+        status: 'ABGESCHLOSSEN',
+      });
+
+      // When
+      const result = await handler.execute(command);
+
+      // Then
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('aktive Einsätze');
+    });
+  });
+
+  describe('Command-Validierung', () => {
+    it('sollte fehlschlagen wenn einsatzId fehlt', () => {
+      const result = CreateBeitrittsanfrageCommand.create('', TEST_USER_ID);
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('einsatzId');
+    });
+
+    it('sollte fehlschlagen wenn userId fehlt', () => {
+      const result = CreateBeitrittsanfrageCommand.create(TEST_EINSATZ_ID, '');
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('userId');
+    });
+  });
+});

--- a/packages/backend/src/application/einsatz-beitritt/commands/create-beitrittsanfrage/create-beitrittsanfrage.command.ts
+++ b/packages/backend/src/application/einsatz-beitritt/commands/create-beitrittsanfrage/create-beitrittsanfrage.command.ts
@@ -1,0 +1,29 @@
+import { validateRequiredStringResult } from '@application/common/validators/string-validator';
+import { Result } from '@domain/common/result';
+
+/**
+ * Command zum Erstellen einer Beitrittsanfrage für einen Einsatz.
+ *
+ * Eine Einsatzkraft stellt eine Anfrage, einem laufenden Einsatz beizutreten.
+ * Die Anfrage muss von einer Führungskraft genehmigt oder abgelehnt werden.
+ */
+export class CreateBeitrittsanfrageCommand {
+  private constructor(
+    public readonly einsatzId: string,
+    public readonly userId: string,
+  ) {}
+
+  /**
+   * Factory-Methode mit Validierung.
+   * Verwendet Result<T> Pattern für explizite Fehlerbehandlung.
+   */
+  public static create(einsatzId: string, userId: string): Result<CreateBeitrittsanfrageCommand> {
+    const einsatzIdError = validateRequiredStringResult(einsatzId, 'einsatzId');
+    if (einsatzIdError) return Result.fail(einsatzIdError);
+
+    const userIdError = validateRequiredStringResult(userId, 'userId');
+    if (userIdError) return Result.fail(userIdError);
+
+    return Result.ok(new CreateBeitrittsanfrageCommand(einsatzId.trim(), userId.trim()));
+  }
+}

--- a/packages/backend/src/application/einsatz-beitritt/commands/create-beitrittsanfrage/create-beitrittsanfrage.handler.ts
+++ b/packages/backend/src/application/einsatz-beitritt/commands/create-beitrittsanfrage/create-beitrittsanfrage.handler.ts
@@ -1,0 +1,82 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { ILogger } from '@domain/ports/i-logger.port';
+import type { IEinsatzBeitrittsanfrageRepository } from '@domain/repositories/i-einsatz-beitrittsanfrage.repository';
+import { TransactionalCommandHandler } from '@application/common/handlers/transactional-command.handler';
+import { PrismaService } from '@/infrastructure/database/prisma.service';
+import { IOutboxRepository } from '@domain/repositories/i-outbox.repository';
+import type { DomainEvent } from '@domain/common/domain-event';
+import type { TransactionContext } from '@domain/common';
+import { Result } from '@domain/common/result';
+import { EINSATZ_BEITRITTSANFRAGE_REPOSITORY, OUTBOX_REPOSITORY, LOGGER } from '@infrastructure/di-tokens';
+import { EinsatzBeitrittsanfrageErstelltEvent } from '@domain/events/einsatz-beitrittsanfrage-erstellt.event';
+import type { EinsatzBeitrittsanfrageData } from '@domain/repositories/i-einsatz-beitrittsanfrage.repository';
+import type { CreateBeitrittsanfrageCommand } from './create-beitrittsanfrage.command';
+
+/**
+ * Handler für CreateBeitrittsanfrageCommand mit Transactional Outbox Pattern.
+ *
+ * Erstellt eine Beitrittsanfrage für einen Einsatz.
+ *
+ * **Validierungen:**
+ * 1. Keine offene Anfrage für diesen User+Einsatz vorhanden
+ * 2. Einsatz existiert und ist IN_BEARBEITUNG
+ *
+ * **Event Flow:**
+ * - EinsatzBeitrittsanfrageErstelltEvent wird in Outbox persistiert
+ */
+@Injectable()
+export class CreateBeitrittsanfrageHandler extends TransactionalCommandHandler<CreateBeitrittsanfrageCommand, EinsatzBeitrittsanfrageData> {
+  constructor(
+    prisma: PrismaService,
+    @Inject(OUTBOX_REPOSITORY) outboxRepository: IOutboxRepository,
+    @Inject(EINSATZ_BEITRITTSANFRAGE_REPOSITORY)
+    private readonly anfrageRepository: IEinsatzBeitrittsanfrageRepository,
+    @Inject(LOGGER)
+    private readonly logger: ILogger,
+  ) {
+    super(prisma, outboxRepository);
+  }
+
+  protected async executeInTransaction(
+    command: CreateBeitrittsanfrageCommand,
+    tx: TransactionContext,
+  ): Promise<Result<EinsatzBeitrittsanfrageData> | { result: EinsatzBeitrittsanfrageData; events: DomainEvent[] }> {
+    // 1. Prüfe ob bereits eine offene Anfrage existiert
+    const existingAnfrage = await this.anfrageRepository.findOpenByEinsatzAndUser(command.einsatzId, command.userId);
+    if (existingAnfrage) {
+      this.logger.warn('Offene Beitrittsanfrage existiert bereits', {
+        einsatzId: command.einsatzId,
+        userId: command.userId,
+      });
+      return Result.fail('Es existiert bereits eine offene Beitrittsanfrage für diesen Einsatz');
+    }
+
+    // 2. Prüfe ob Einsatz existiert und IN_BEARBEITUNG ist
+    const einsatz = await this.prisma.einsatz.findUnique({
+      where: { id: command.einsatzId },
+      select: { id: true, status: true },
+    });
+
+    if (!einsatz) {
+      return Result.fail(`Einsatz mit ID ${command.einsatzId} nicht gefunden`);
+    }
+
+    if (einsatz.status !== 'IN_BEARBEITUNG') {
+      return Result.fail('Beitrittsanfragen können nur für aktive Einsätze (IN_BEARBEITUNG) gestellt werden');
+    }
+
+    // 3. Anfrage erstellen
+    const anfrage = await this.anfrageRepository.save({ einsatzId: command.einsatzId, userId: command.userId }, tx);
+
+    // 4. Event erstellen
+    const event = new EinsatzBeitrittsanfrageErstelltEvent(anfrage.id, anfrage.einsatzId, anfrage.userId);
+
+    this.logger.log('Beitrittsanfrage erstellt', {
+      anfrageId: anfrage.id,
+      einsatzId: anfrage.einsatzId,
+      userId: anfrage.userId,
+    });
+
+    return { result: anfrage, events: [event] };
+  }
+}

--- a/packages/backend/src/application/einsatz-beitritt/commands/resolve-beitrittsanfrage/__tests__/resolve-beitrittsanfrage.handler.spec.ts
+++ b/packages/backend/src/application/einsatz-beitritt/commands/resolve-beitrittsanfrage/__tests__/resolve-beitrittsanfrage.handler.spec.ts
@@ -1,0 +1,191 @@
+// @ts-nocheck
+import { PrismaService } from '@/infrastructure/database/prisma.service';
+import { EINSATZ_BEITRITTSANFRAGE_REPOSITORY, LOGGER, OUTBOX_REPOSITORY } from '@/infrastructure/di-tokens';
+import type { ILogger } from '@domain/ports/i-logger.port';
+import type { IEinsatzBeitrittsanfrageRepository, EinsatzBeitrittsanfrageData } from '@domain/repositories/i-einsatz-beitrittsanfrage.repository';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { ResolveBeitrittsanfrageCommand } from '../resolve-beitrittsanfrage.command';
+import { ResolveBeitrittsanfrageHandler } from '../resolve-beitrittsanfrage.handler';
+
+const TEST_ANFRAGE_ID = 'clw3h8x9y0000qwerty00001';
+const TEST_EINSATZ_ID = 'clw3h8x9y0000qwerty00002';
+const TEST_USER_ID = 'clw3h8x9y0000qwerty00003';
+const TEST_FK_USER_ID = 'clw3h8x9y0000qwerty00004';
+
+/**
+ * Unit Tests für ResolveBeitrittsanfrageHandler.
+ *
+ * Testet Handler-Orchestration gemäß BDD Given-When-Then Pattern.
+ */
+describe('ResolveBeitrittsanfrageHandler', () => {
+  let handler: ResolveBeitrittsanfrageHandler;
+  let mockAnfrageRepository: jest.Mocked<IEinsatzBeitrittsanfrageRepository>;
+  let mockPrismaService: {
+    $transaction: jest.Mock;
+  };
+  let mockOutboxRepository: {
+    save: jest.Mock;
+  };
+  let mockLogger: jest.Mocked<ILogger>;
+
+  const createOpenAnfrage = (): EinsatzBeitrittsanfrageData => ({
+    id: TEST_ANFRAGE_ID,
+    einsatzId: TEST_EINSATZ_ID,
+    userId: TEST_USER_ID,
+    status: 'OFFEN',
+    createdAt: new Date(),
+    resolvedAt: null,
+    resolvedBy: null,
+  });
+
+  beforeEach(async () => {
+    mockAnfrageRepository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findOpenByEinsatzAndUser: jest.fn(),
+      findByEinsatz: jest.fn(),
+      resolve: jest.fn(),
+    } as any;
+
+    mockPrismaService = {
+      $transaction: jest.fn().mockImplementation(async (callback) => {
+        const txMock = {};
+        return callback(txMock);
+      }),
+    };
+
+    mockOutboxRepository = {
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockLogger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as jest.Mocked<ILogger>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResolveBeitrittsanfrageHandler,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: OUTBOX_REPOSITORY, useValue: mockOutboxRepository },
+        { provide: EINSATZ_BEITRITTSANFRAGE_REPOSITORY, useValue: mockAnfrageRepository },
+        { provide: LOGGER, useValue: mockLogger },
+      ],
+    }).compile();
+
+    handler = module.get<ResolveBeitrittsanfrageHandler>(ResolveBeitrittsanfrageHandler);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Erfolgsfall', () => {
+    it('sollte Beitrittsanfrage erfolgreich genehmigen', async () => {
+      // Given
+      const command = ResolveBeitrittsanfrageCommand.create(TEST_ANFRAGE_ID, 'GENEHMIGT', TEST_FK_USER_ID).value!;
+      const openAnfrage = createOpenAnfrage();
+      const resolvedAnfrage: EinsatzBeitrittsanfrageData = {
+        ...openAnfrage,
+        status: 'GENEHMIGT',
+        resolvedAt: new Date(),
+        resolvedBy: TEST_FK_USER_ID,
+      };
+
+      mockAnfrageRepository.findById.mockResolvedValue(openAnfrage);
+      mockAnfrageRepository.resolve.mockResolvedValue(resolvedAnfrage);
+
+      // When
+      const result = await handler.execute(command);
+
+      // Then
+      expect(result.isSuccess).toBe(true);
+      expect(result.value?.status).toBe('GENEHMIGT');
+      expect(mockAnfrageRepository.resolve).toHaveBeenCalledWith(TEST_ANFRAGE_ID, 'GENEHMIGT', TEST_FK_USER_ID, {});
+      expect(mockOutboxRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('sollte Beitrittsanfrage erfolgreich ablehnen', async () => {
+      // Given
+      const command = ResolveBeitrittsanfrageCommand.create(TEST_ANFRAGE_ID, 'ABGELEHNT', TEST_FK_USER_ID).value!;
+      const openAnfrage = createOpenAnfrage();
+      const resolvedAnfrage: EinsatzBeitrittsanfrageData = {
+        ...openAnfrage,
+        status: 'ABGELEHNT',
+        resolvedAt: new Date(),
+        resolvedBy: TEST_FK_USER_ID,
+      };
+
+      mockAnfrageRepository.findById.mockResolvedValue(openAnfrage);
+      mockAnfrageRepository.resolve.mockResolvedValue(resolvedAnfrage);
+
+      // When
+      const result = await handler.execute(command);
+
+      // Then
+      expect(result.isSuccess).toBe(true);
+      expect(result.value?.status).toBe('ABGELEHNT');
+      expect(mockAnfrageRepository.resolve).toHaveBeenCalledWith(TEST_ANFRAGE_ID, 'ABGELEHNT', TEST_FK_USER_ID, {});
+      expect(mockOutboxRepository.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Fehlerfälle', () => {
+    it('sollte fehlschlagen wenn Anfrage nicht gefunden wird', async () => {
+      // Given
+      const command = ResolveBeitrittsanfrageCommand.create(TEST_ANFRAGE_ID, 'GENEHMIGT', TEST_FK_USER_ID).value!;
+      mockAnfrageRepository.findById.mockResolvedValue(null);
+
+      // When
+      const result = await handler.execute(command);
+
+      // Then
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('nicht gefunden');
+      expect(mockAnfrageRepository.resolve).not.toHaveBeenCalled();
+    });
+
+    it('sollte fehlschlagen wenn Anfrage bereits entschieden wurde', async () => {
+      // Given
+      const command = ResolveBeitrittsanfrageCommand.create(TEST_ANFRAGE_ID, 'GENEHMIGT', TEST_FK_USER_ID).value!;
+      const alreadyResolvedAnfrage: EinsatzBeitrittsanfrageData = {
+        ...createOpenAnfrage(),
+        status: 'GENEHMIGT',
+        resolvedAt: new Date(),
+        resolvedBy: 'clw3h8x9y0000qwerty00099',
+      };
+
+      mockAnfrageRepository.findById.mockResolvedValue(alreadyResolvedAnfrage);
+
+      // When
+      const result = await handler.execute(command);
+
+      // Then
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('bereits entschieden');
+      expect(mockAnfrageRepository.resolve).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Command-Validierung', () => {
+    it('sollte fehlschlagen wenn anfrageId fehlt', () => {
+      const result = ResolveBeitrittsanfrageCommand.create('', 'GENEHMIGT', TEST_FK_USER_ID);
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('anfrageId');
+    });
+
+    it('sollte fehlschlagen wenn decision ungültig ist', () => {
+      const result = ResolveBeitrittsanfrageCommand.create(TEST_ANFRAGE_ID, 'UNGUELTIG', TEST_FK_USER_ID);
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('GENEHMIGT oder ABGELEHNT');
+    });
+
+    it('sollte fehlschlagen wenn resolvedBy fehlt', () => {
+      const result = ResolveBeitrittsanfrageCommand.create(TEST_ANFRAGE_ID, 'GENEHMIGT', '');
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('resolvedBy');
+    });
+  });
+});

--- a/packages/backend/src/application/einsatz-beitritt/commands/resolve-beitrittsanfrage/resolve-beitrittsanfrage.command.ts
+++ b/packages/backend/src/application/einsatz-beitritt/commands/resolve-beitrittsanfrage/resolve-beitrittsanfrage.command.ts
@@ -1,0 +1,33 @@
+import { validateRequiredStringResult } from '@application/common/validators/string-validator';
+import { Result } from '@domain/common/result';
+
+/**
+ * Command zum Entscheiden einer Beitrittsanfrage.
+ *
+ * Eine Führungskraft genehmigt oder lehnt eine Beitrittsanfrage ab.
+ */
+export class ResolveBeitrittsanfrageCommand {
+  private constructor(
+    public readonly anfrageId: string,
+    public readonly decision: 'GENEHMIGT' | 'ABGELEHNT',
+    public readonly resolvedBy: string,
+  ) {}
+
+  /**
+   * Factory-Methode mit Validierung.
+   * Verwendet Result<T> Pattern für explizite Fehlerbehandlung.
+   */
+  public static create(anfrageId: string, decision: string, resolvedBy: string): Result<ResolveBeitrittsanfrageCommand> {
+    const anfrageIdError = validateRequiredStringResult(anfrageId, 'anfrageId');
+    if (anfrageIdError) return Result.fail(anfrageIdError);
+
+    if (decision !== 'GENEHMIGT' && decision !== 'ABGELEHNT') {
+      return Result.fail('Entscheidung muss GENEHMIGT oder ABGELEHNT sein');
+    }
+
+    const resolvedByError = validateRequiredStringResult(resolvedBy, 'resolvedBy');
+    if (resolvedByError) return Result.fail(resolvedByError);
+
+    return Result.ok(new ResolveBeitrittsanfrageCommand(anfrageId.trim(), decision, resolvedBy.trim()));
+  }
+}

--- a/packages/backend/src/application/einsatz-beitritt/commands/resolve-beitrittsanfrage/resolve-beitrittsanfrage.handler.ts
+++ b/packages/backend/src/application/einsatz-beitritt/commands/resolve-beitrittsanfrage/resolve-beitrittsanfrage.handler.ts
@@ -1,0 +1,74 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { ILogger } from '@domain/ports/i-logger.port';
+import type { IEinsatzBeitrittsanfrageRepository } from '@domain/repositories/i-einsatz-beitrittsanfrage.repository';
+import { TransactionalCommandHandler } from '@application/common/handlers/transactional-command.handler';
+import { PrismaService } from '@/infrastructure/database/prisma.service';
+import { IOutboxRepository } from '@domain/repositories/i-outbox.repository';
+import type { DomainEvent } from '@domain/common/domain-event';
+import type { TransactionContext } from '@domain/common';
+import { Result } from '@domain/common/result';
+import { EINSATZ_BEITRITTSANFRAGE_REPOSITORY, OUTBOX_REPOSITORY, LOGGER } from '@infrastructure/di-tokens';
+import { EinsatzBeitrittsanfrageEntschiedenEvent } from '@domain/events/einsatz-beitrittsanfrage-entschieden.event';
+import type { EinsatzBeitrittsanfrageData } from '@domain/repositories/i-einsatz-beitrittsanfrage.repository';
+import type { ResolveBeitrittsanfrageCommand } from './resolve-beitrittsanfrage.command';
+
+/**
+ * Handler für ResolveBeitrittsanfrageCommand mit Transactional Outbox Pattern.
+ *
+ * Entscheidet eine Beitrittsanfrage (GENEHMIGT oder ABGELEHNT).
+ *
+ * **Validierungen:**
+ * 1. Anfrage existiert
+ * 2. Anfrage ist noch OFFEN (nicht bereits entschieden)
+ *
+ * **Event Flow:**
+ * - EinsatzBeitrittsanfrageEntschiedenEvent wird in Outbox persistiert
+ */
+@Injectable()
+export class ResolveBeitrittsanfrageHandler extends TransactionalCommandHandler<ResolveBeitrittsanfrageCommand, EinsatzBeitrittsanfrageData> {
+  constructor(
+    prisma: PrismaService,
+    @Inject(OUTBOX_REPOSITORY) outboxRepository: IOutboxRepository,
+    @Inject(EINSATZ_BEITRITTSANFRAGE_REPOSITORY)
+    private readonly anfrageRepository: IEinsatzBeitrittsanfrageRepository,
+    @Inject(LOGGER)
+    private readonly logger: ILogger,
+  ) {
+    super(prisma, outboxRepository);
+  }
+
+  protected async executeInTransaction(
+    command: ResolveBeitrittsanfrageCommand,
+    tx: TransactionContext,
+  ): Promise<Result<EinsatzBeitrittsanfrageData> | { result: EinsatzBeitrittsanfrageData; events: DomainEvent[] }> {
+    // 1. Anfrage laden
+    const anfrage = await this.anfrageRepository.findById(command.anfrageId);
+    if (!anfrage) {
+      return Result.fail(`Beitrittsanfrage mit ID ${command.anfrageId} nicht gefunden`);
+    }
+
+    // 2. Prüfe ob Anfrage noch OFFEN ist
+    if (anfrage.status !== 'OFFEN') {
+      this.logger.warn('Beitrittsanfrage bereits entschieden', {
+        anfrageId: command.anfrageId,
+        currentStatus: anfrage.status,
+      });
+      return Result.fail('Diese Beitrittsanfrage wurde bereits entschieden');
+    }
+
+    // 3. Anfrage entscheiden
+    const resolvedAnfrage = await this.anfrageRepository.resolve(command.anfrageId, command.decision, command.resolvedBy, tx);
+
+    // 4. Event erstellen
+    const event = new EinsatzBeitrittsanfrageEntschiedenEvent(resolvedAnfrage.id, resolvedAnfrage.einsatzId, resolvedAnfrage.userId, command.decision, command.resolvedBy);
+
+    this.logger.log('Beitrittsanfrage entschieden', {
+      anfrageId: resolvedAnfrage.id,
+      einsatzId: resolvedAnfrage.einsatzId,
+      decision: command.decision,
+      resolvedBy: command.resolvedBy,
+    });
+
+    return { result: resolvedAnfrage, events: [event] };
+  }
+}

--- a/packages/backend/src/application/einsatz-beitritt/dto/beitrittsanfrage.dto.ts
+++ b/packages/backend/src/application/einsatz-beitritt/dto/beitrittsanfrage.dto.ts
@@ -1,0 +1,71 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+
+/**
+ * Response DTO für eine Einsatz-Beitrittsanfrage.
+ */
+export class BeitrittsanfrageResponseDto {
+  @ApiProperty({
+    description: 'Eindeutige ID der Beitrittsanfrage',
+    example: 'clx1234567890abcdefghijk',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'Einsatz-ID',
+    example: 'clx1234567890abcdefghijk',
+  })
+  einsatzId!: string;
+
+  @ApiProperty({
+    description: 'User-ID des Antragstellers',
+    example: 'clx1234567890abcdefghijk',
+  })
+  userId!: string;
+
+  @ApiProperty({
+    description: 'Status der Anfrage',
+    enum: ['OFFEN', 'GENEHMIGT', 'ABGELEHNT'],
+    example: 'OFFEN',
+  })
+  status!: string;
+
+  @ApiProperty({
+    description: 'Erstellungszeitpunkt',
+    example: '2026-03-27T14:00:00.000Z',
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt!: Date;
+
+  @ApiPropertyOptional({
+    description: 'Zeitpunkt der Entscheidung (null wenn noch offen)',
+    example: null,
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+  })
+  resolvedAt?: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'User-ID der entscheidenden Person (null wenn noch offen)',
+    example: null,
+    nullable: true,
+  })
+  resolvedBy?: string | null;
+}
+
+/**
+ * Request DTO zum Entscheiden einer Beitrittsanfrage.
+ */
+export class ResolveBeitrittsanfrageDto {
+  @ApiProperty({
+    description: 'Entscheidung: GENEHMIGT oder ABGELEHNT',
+    enum: ['GENEHMIGT', 'ABGELEHNT'],
+    example: 'GENEHMIGT',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(['GENEHMIGT', 'ABGELEHNT'])
+  decision!: string;
+}

--- a/packages/backend/src/application/einsatz-beitritt/dto/index.ts
+++ b/packages/backend/src/application/einsatz-beitritt/dto/index.ts
@@ -1,0 +1,1 @@
+export { BeitrittsanfrageResponseDto, ResolveBeitrittsanfrageDto } from './beitrittsanfrage.dto';

--- a/packages/backend/src/application/einsatz-beitritt/einsatz-beitritt-application.module.ts
+++ b/packages/backend/src/application/einsatz-beitritt/einsatz-beitritt-application.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@/infrastructure/database/prisma.module';
+import { OutboxModule } from '@infrastructure/outbox/outbox.module';
+import { LOGGER } from '@infrastructure/di-tokens';
+import { NestLoggerAdapter } from '@infrastructure/common/adapters/nest-logger.adapter';
+import { CreateBeitrittsanfrageHandler } from './commands/create-beitrittsanfrage/create-beitrittsanfrage.handler';
+import { ResolveBeitrittsanfrageHandler } from './commands/resolve-beitrittsanfrage/resolve-beitrittsanfrage.handler';
+import { GetBeitrittsanfragenHandler } from './queries/get-beitrittsanfragen/get-beitrittsanfragen.handler';
+
+/**
+ * NestJS-Modul für Application Layer - Einsatz-Beitritt Bounded Context.
+ *
+ * Registriert alle Command- und Query-Handler für Beitrittsanfragen.
+ */
+@Module({
+  imports: [PrismaModule, OutboxModule],
+  providers: [
+    {
+      provide: LOGGER,
+      useFactory: () => new NestLoggerAdapter('EinsatzBeitritt'),
+    },
+    CreateBeitrittsanfrageHandler,
+    ResolveBeitrittsanfrageHandler,
+    GetBeitrittsanfragenHandler,
+  ],
+  exports: [CreateBeitrittsanfrageHandler, ResolveBeitrittsanfrageHandler, GetBeitrittsanfragenHandler],
+})
+export class EinsatzBeitrittApplicationModule {}

--- a/packages/backend/src/application/einsatz-beitritt/queries/get-beitrittsanfragen/get-beitrittsanfragen.handler.ts
+++ b/packages/backend/src/application/einsatz-beitritt/queries/get-beitrittsanfragen/get-beitrittsanfragen.handler.ts
@@ -1,0 +1,44 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Result } from '@domain/common/result';
+import type { ILogger } from '@domain/ports/i-logger.port';
+import type { IEinsatzBeitrittsanfrageRepository, EinsatzBeitrittsanfrageData } from '@domain/repositories/i-einsatz-beitrittsanfrage.repository';
+import { EINSATZ_BEITRITTSANFRAGE_REPOSITORY, LOGGER } from '@infrastructure/di-tokens';
+import type { GetBeitrittsanfragenQuery } from './get-beitrittsanfragen.query';
+
+/**
+ * Handler zum Abrufen aller Beitrittsanfragen eines Einsatzes.
+ *
+ * **CQRS Query-Side Pattern:**
+ * - Read-Only: Ändert niemals Domain State
+ * - Result<T>: Kein Exception-Throwing für vorhersagbare Fehler
+ */
+@Injectable()
+export class GetBeitrittsanfragenHandler {
+  constructor(
+    @Inject(EINSATZ_BEITRITTSANFRAGE_REPOSITORY)
+    private readonly anfrageRepository: IEinsatzBeitrittsanfrageRepository,
+    @Inject(LOGGER)
+    private readonly logger: ILogger,
+  ) {}
+
+  /**
+   * Führt die Query aus und gibt alle Beitrittsanfragen zurück.
+   *
+   * @param query - Validierte Query mit einsatzId und optionalem Status-Filter
+   * @returns Result mit Liste von EinsatzBeitrittsanfrageData
+   */
+  async execute(query: GetBeitrittsanfragenQuery): Promise<Result<EinsatzBeitrittsanfrageData[]>> {
+    try {
+      const anfragen = await this.anfrageRepository.findByEinsatz(query.einsatzId, query.status);
+
+      this.logger.log(`Beitrittsanfragen abgerufen (einsatz: ${query.einsatzId}, count: ${anfragen.length})`, 'GetBeitrittsanfragenHandler');
+
+      return Result.ok<EinsatzBeitrittsanfrageData[]>(anfragen);
+    } catch (error) {
+      this.logger.error(`[GetBeitrittsanfragenHandler] Fehler beim Laden der Beitrittsanfragen für Einsatz ${query.einsatzId}: ${error instanceof Error ? error.stack : String(error)}`);
+
+      const errorMessage = error instanceof Error ? error.message : 'Unerwarteter Fehler beim Laden der Beitrittsanfragen';
+      return Result.fail<EinsatzBeitrittsanfrageData[]>(errorMessage);
+    }
+  }
+}

--- a/packages/backend/src/application/einsatz-beitritt/queries/get-beitrittsanfragen/get-beitrittsanfragen.query.ts
+++ b/packages/backend/src/application/einsatz-beitritt/queries/get-beitrittsanfragen/get-beitrittsanfragen.query.ts
@@ -1,0 +1,28 @@
+import { Result } from '@domain/common/result';
+
+/**
+ * Query zum Abrufen aller Beitrittsanfragen eines Einsatzes.
+ *
+ * Wird von Führungskräften verwendet, um offene und entschiedene
+ * Beitrittsanfragen einzusehen.
+ */
+export class GetBeitrittsanfragenQuery {
+  private constructor(
+    public readonly einsatzId: string,
+    public readonly status?: string,
+  ) {}
+
+  /**
+   * Factory-Methode mit Validierung.
+   *
+   * @param props - Query-Parameter mit einsatzId und optionalem Status-Filter
+   * @returns Result mit Query oder Fehler bei ungültigem einsatzId
+   */
+  static create(props: { einsatzId: string; status?: string }): Result<GetBeitrittsanfragenQuery> {
+    if (!props.einsatzId || props.einsatzId.trim() === '') {
+      return Result.fail<GetBeitrittsanfragenQuery>('einsatzId ist erforderlich');
+    }
+
+    return Result.ok<GetBeitrittsanfragenQuery>(new GetBeitrittsanfragenQuery(props.einsatzId, props.status));
+  }
+}

--- a/packages/backend/src/modules/einsatz-beitritt/controllers/einsatz-beitritt.controller.ts
+++ b/packages/backend/src/modules/einsatz-beitritt/controllers/einsatz-beitritt.controller.ts
@@ -1,0 +1,149 @@
+import { BadRequestException, Body, Controller, Get, NotFoundException, Param, Patch, Post, UseGuards, ValidationPipe } from '@nestjs/common';
+import { ApiBadRequestResponse, ApiBearerAuth, ApiForbiddenResponse, ApiNotFoundResponse, ApiOperation, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '@/modules/auth/guards/jwt-auth.guard';
+import { OperativeRoleGuard } from '@/modules/auth/guards/operative-role.guard';
+import { RequiresOperativeRole } from '@/modules/auth/decorators/operative-roles.decorator';
+import type { ValidatedUser } from '@/modules/auth/strategies/jwt.strategy';
+import { ApiWrappedCreatedResponse, ApiWrappedResponse } from '@/modules/common/decorators/api-wrapped-response.decorator';
+import { BeitrittsanfrageResponseDto, ResolveBeitrittsanfrageDto } from '@/application/einsatz-beitritt/dto';
+import { CreateBeitrittsanfrageCommand } from '@/application/einsatz-beitritt/commands/create-beitrittsanfrage/create-beitrittsanfrage.command';
+import { CreateBeitrittsanfrageHandler } from '@/application/einsatz-beitritt/commands/create-beitrittsanfrage/create-beitrittsanfrage.handler';
+import { ResolveBeitrittsanfrageCommand } from '@/application/einsatz-beitritt/commands/resolve-beitrittsanfrage/resolve-beitrittsanfrage.command';
+import { ResolveBeitrittsanfrageHandler } from '@/application/einsatz-beitritt/commands/resolve-beitrittsanfrage/resolve-beitrittsanfrage.handler';
+import { GetBeitrittsanfragenQuery } from '@/application/einsatz-beitritt/queries/get-beitrittsanfragen/get-beitrittsanfragen.query';
+import { GetBeitrittsanfragenHandler } from '@/application/einsatz-beitritt/queries/get-beitrittsanfragen/get-beitrittsanfragen.handler';
+
+/**
+ * Controller für Einsatz-Beitrittsanfragen.
+ *
+ * Einsatzkräfte können Beitrittsanfragen für Einsätze stellen.
+ * Führungskräfte können diese genehmigen oder ablehnen.
+ */
+@ApiTags('Einsatz Beitritt')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@ApiUnauthorizedResponse({ description: 'Nicht authentifiziert - JWT Token fehlt oder ungültig' })
+@ApiForbiddenResponse({ description: 'Keine Berechtigung - operative Rolle fehlt oder unzureichend' })
+@Controller({
+  path: 'einsatz/:einsatzId/beitrittsanfragen',
+  version: ['alpha', '1'],
+})
+export class EinsatzBeitrittController {
+  constructor(
+    private readonly createHandler: CreateBeitrittsanfrageHandler,
+    private readonly resolveHandler: ResolveBeitrittsanfrageHandler,
+    private readonly getHandler: GetBeitrittsanfragenHandler,
+  ) {}
+
+  /**
+   * Erstellt eine Beitrittsanfrage für einen Einsatz.
+   *
+   * Nur Einsatzkräfte dürfen Beitrittsanfragen stellen.
+   */
+  @Post()
+  @RequiresOperativeRole('EINSATZKRAFT')
+  @UseGuards(OperativeRoleGuard)
+  @ApiOperation({
+    summary: 'Beitrittsanfrage erstellen',
+    description: 'Einsatzkraft stellt eine Anfrage, einem laufenden Einsatz beizutreten.',
+  })
+  @ApiWrappedCreatedResponse(BeitrittsanfrageResponseDto, {
+    description: 'Beitrittsanfrage erfolgreich erstellt',
+  })
+  @ApiBadRequestResponse({ description: 'Validierungsfehler oder Duplikat' })
+  async create(@Param('einsatzId') einsatzId: string, @CurrentUser() user: ValidatedUser): Promise<BeitrittsanfrageResponseDto> {
+    const commandResult = CreateBeitrittsanfrageCommand.create(einsatzId, user.userId);
+    if (commandResult.isFailure || !commandResult.value) {
+      throw new BadRequestException(commandResult.error);
+    }
+
+    const result = await this.createHandler.execute(commandResult.value);
+    if (result.isFailure) {
+      if (result.error?.includes('nicht gefunden')) {
+        throw new NotFoundException(result.error);
+      }
+      throw new BadRequestException(result.error);
+    }
+
+    if (!result.value) {
+      throw new BadRequestException('Beitrittsanfrage konnte nicht erstellt werden');
+    }
+
+    return result.value;
+  }
+
+  /**
+   * Listet alle Beitrittsanfragen für einen Einsatz.
+   *
+   * Nur Führungskräfte dürfen Beitrittsanfragen einsehen.
+   */
+  @Get()
+  @RequiresOperativeRole('FUEHRUNGSKRAFT')
+  @UseGuards(OperativeRoleGuard)
+  @ApiOperation({
+    summary: 'Beitrittsanfragen auflisten',
+    description: 'Führungskraft sieht alle Beitrittsanfragen für einen Einsatz.',
+  })
+  @ApiWrappedResponse(BeitrittsanfrageResponseDto, {
+    isArray: true,
+    description: 'Liste aller Beitrittsanfragen',
+  })
+  @ApiBadRequestResponse({ description: 'Ungültige Einsatz-ID' })
+  async findAll(@Param('einsatzId') einsatzId: string): Promise<BeitrittsanfrageResponseDto[]> {
+    const queryResult = GetBeitrittsanfragenQuery.create({ einsatzId });
+    if (queryResult.isFailure || !queryResult.value) {
+      throw new BadRequestException(queryResult.error);
+    }
+
+    const result = await this.getHandler.execute(queryResult.value);
+    if (result.isFailure) {
+      throw new BadRequestException(result.error);
+    }
+
+    return result.value ?? [];
+  }
+
+  /**
+   * Entscheidet eine Beitrittsanfrage (genehmigen oder ablehnen).
+   *
+   * Nur Führungskräfte dürfen Beitrittsanfragen entscheiden.
+   */
+  @Patch(':anfrageId')
+  @RequiresOperativeRole('FUEHRUNGSKRAFT')
+  @UseGuards(OperativeRoleGuard)
+  @ApiOperation({
+    summary: 'Beitrittsanfrage entscheiden',
+    description: 'Führungskraft genehmigt oder lehnt eine Beitrittsanfrage ab.',
+  })
+  @ApiWrappedResponse(BeitrittsanfrageResponseDto, {
+    description: 'Beitrittsanfrage erfolgreich entschieden',
+  })
+  @ApiBadRequestResponse({ description: 'Validierungsfehler oder bereits entschieden' })
+  @ApiNotFoundResponse({ description: 'Beitrittsanfrage nicht gefunden' })
+  async resolve(
+    @Param('anfrageId') anfrageId: string,
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    dto: ResolveBeitrittsanfrageDto,
+    @CurrentUser() user: ValidatedUser,
+  ): Promise<BeitrittsanfrageResponseDto> {
+    const commandResult = ResolveBeitrittsanfrageCommand.create(anfrageId, dto.decision, user.userId);
+    if (commandResult.isFailure || !commandResult.value) {
+      throw new BadRequestException(commandResult.error);
+    }
+
+    const result = await this.resolveHandler.execute(commandResult.value);
+    if (result.isFailure) {
+      if (result.error?.includes('nicht gefunden')) {
+        throw new NotFoundException(result.error);
+      }
+      throw new BadRequestException(result.error);
+    }
+
+    if (!result.value) {
+      throw new BadRequestException('Beitrittsanfrage konnte nicht entschieden werden');
+    }
+
+    return result.value;
+  }
+}

--- a/packages/backend/src/modules/einsatz-beitritt/einsatz-beitritt.module.ts
+++ b/packages/backend/src/modules/einsatz-beitritt/einsatz-beitritt.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@infrastructure/database/prisma.module';
+import { InfrastructureCommonModule } from '@infrastructure/common.module';
+import { OutboxModule } from '@infrastructure/outbox/outbox.module';
+import { EINSATZ_BEITRITTSANFRAGE_REPOSITORY } from '@infrastructure/di-tokens';
+import { PrismaEinsatzBeitrittsanfrageRepository } from '@infrastructure/database/repositories/prisma-einsatz-beitrittsanfrage.repository';
+import { EinsatzBeitrittApplicationModule } from '@/application/einsatz-beitritt/einsatz-beitritt-application.module';
+import { EinsatzBeitrittController } from './controllers/einsatz-beitritt.controller';
+
+/**
+ * Modul für Einsatz-Beitrittsanfragen (Issue #98).
+ *
+ * Ermöglicht Einsatzkräften das Stellen von Beitrittsanfragen
+ * und Führungskräften deren Genehmigung/Ablehnung.
+ */
+@Module({
+  imports: [PrismaModule, InfrastructureCommonModule, OutboxModule, EinsatzBeitrittApplicationModule],
+  controllers: [EinsatzBeitrittController],
+  providers: [
+    {
+      provide: EINSATZ_BEITRITTSANFRAGE_REPOSITORY,
+      useClass: PrismaEinsatzBeitrittsanfrageRepository,
+    },
+  ],
+  exports: [EINSATZ_BEITRITTSANFRAGE_REPOSITORY],
+})
+export class EinsatzBeitrittModule {}


### PR DESCRIPTION
## Summary
- CreateBeitrittsanfrage (EK fragt an), ResolveBeitrittsanfrage (FK entscheidet)
- GetBeitrittsanfragen Query (offene Anfragen pro Einsatz)
- Controller: POST/GET/PATCH /einsatz/:id/beitrittsanfragen
- 13/13 Tests grün

## Test plan
- [x] Handler Tests (13/13 passing)
- [ ] Integration test nach Merge aller Units

Issue: #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)