### PR TITLE
🐛(backend): Register invite_code Events im Outbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ pnpm --filter @bluelight-hub/backend check:arch  # Circular Dependencies
 
 - Frontend: `localhost:3090`
 - Backend API + Swagger UI: `localhost:3091/api`
+- PostgreSQL läuft im Docker-Container `bluelight-hub-postgres` auf Port `3092`
+- Kein `psql` lokal installiert — DB-Zugriff via `docker exec bluelight-hub-postgres psql -U bluelight -d bluelight-hub -c "..."`
 
 ## Commit Format
 

--- a/packages/backend/src/__tests__/architecture-rules.spec.ts
+++ b/packages/backend/src/__tests__/architecture-rules.spec.ts
@@ -192,10 +192,6 @@ describe('Architecture Rules', () => {
       'server_access_token.revoked',
       'server_access_token.reactivated',
       'server_access_token.rotated',
-      // Invite Code Events - noch kein Outbox Consumer
-      'invite_code.created',
-      'invite_code.used',
-      'invite_code.revoked',
       // Server Config Events - noch kein Outbox Consumer
       'server_config.migrated_to_secure',
       // User Events die noch fehlen

--- a/packages/backend/src/infrastructure/outbox/__tests__/event-deserializer.spec.ts
+++ b/packages/backend/src/infrastructure/outbox/__tests__/event-deserializer.spec.ts
@@ -2275,7 +2275,8 @@ describe('EventDeserializer', () => {
       // + BefehlAnonymisiert + BefehlGeloescht + AufbewahrungsKonfigurationGeaendert (Story 5.5)
       // + SystemWarnung (Story 5.6) + EintragKorrigiert (Issue #554)
       // + OperativeRolleChanged + StammpersonAssigned + BeitrittsanfrageErstellt + BeitrittsanfrageEntschieden (Issue #98)
-      expect(supportedTypes).toHaveLength(79);
+      // + InviteCodeCreated + InviteCodeUsed + InviteCodeRevoked (Issue #98)
+      expect(supportedTypes).toHaveLength(82);
       expect(supportedTypes).toContain('einsatz.created');
       expect(supportedTypes).toContain('etb.created');
       expect(supportedTypes).toContain('lagekarte.created');
@@ -2295,6 +2296,10 @@ describe('EventDeserializer', () => {
       expect(supportedTypes).toContain('rolle.geaendert');
       // System Monitoring (Story 5.6)
       expect(supportedTypes).toContain('system.warnung');
+      // Invite Code Events (Issue #98)
+      expect(supportedTypes).toContain('invite_code.created');
+      expect(supportedTypes).toContain('invite_code.used');
+      expect(supportedTypes).toContain('invite_code.revoked');
     });
   });
 

--- a/packages/backend/src/infrastructure/outbox/event-deserializer.ts
+++ b/packages/backend/src/infrastructure/outbox/event-deserializer.ts
@@ -32,6 +32,11 @@ import { UserRoleChangedEvent } from '@domain/events/user-role-changed.event';
 import { PermissionGrantedEvent } from '@domain/events/permission-granted.event';
 import { PermissionRevokedEvent } from '@domain/events/permission-revoked.event';
 
+// Invite Code Events
+import { InviteCodeCreatedEvent } from '@domain/events/invite-code-created.event';
+import { InviteCodeUsedEvent } from '@domain/events/invite-code-used.event';
+import { InviteCodeRevokedEvent } from '@domain/events/invite-code-revoked.event';
+
 // EinsatzPerson Events
 import { EinsatzPersonHinzugefuegtEvent } from '@domain/kraefte/events/einsatz-person-hinzugefuegt.event';
 import { PersonZuFahrzeugZugewiesenEvent } from '@domain/kraefte/events/person-zu-fahrzeug-zugewiesen.event';
@@ -142,6 +147,7 @@ import { EinsatzId } from '@domain/value-objects/einsatz-id';
 import { EtbId } from '@domain/value-objects/etb-id';
 import { EintragId } from '@domain/value-objects/eintrag-id';
 import { ErinnerungId } from '@domain/value-objects/erinnerung-id';
+import { InviteCodeId } from '@domain/value-objects/invite-code-id';
 import { ErinnerungsvorlageId } from '@domain/erinnerungsvorlage/value-objects/erinnerungsvorlage-id';
 import { NotizId } from '@domain/notiz/value-objects/notiz-id';
 import { LagekarteId } from '@domain/value-objects/lagekarte-id';
@@ -259,6 +265,11 @@ export class EventDeserializer {
       // ===== ROLLEN BESETZUNG EVENTS =====
       ['rollen_besetzung.besetzt', this.deserializeRolleBesetzt.bind(this)],
       ['rollen_besetzung.freigegeben', this.deserializeRolleFreigegeben.bind(this)],
+
+      // ===== INVITE CODE EVENTS =====
+      ['invite_code.created', deserializeInviteCodeCreated],
+      ['invite_code.used', deserializeInviteCodeUsed],
+      ['invite_code.revoked', deserializeInviteCodeRevoked],
 
       // ===== ERINNERUNG EVENTS =====
       ['erinnerung.erstellt', this.deserializeErinnerungErstellt.bind(this)],
@@ -2021,6 +2032,35 @@ function deserializeStammpersonAssigned(payload: Record<string, unknown>, aggreg
 }
 
 // ===== BEITRITTSANFRAGE DESERIALIZERS (Issue #98) =====
+
+// ===== INVITE CODE DESERIALIZERS =====
+
+function deserializeInviteCodeCreated(payload: Record<string, unknown>): Result<DomainEvent> {
+  const inviteCodeIdResult = InviteCodeId.create(payload.inviteCodeId as string);
+  if (inviteCodeIdResult.isFailure) {
+    return Result.fail<DomainEvent>(`Ungültige inviteCodeId: ${inviteCodeIdResult.error}`);
+  }
+
+  const event = new InviteCodeCreatedEvent(
+    inviteCodeIdResult.value!,
+    payload.codeMasked as string,
+    new Date(payload.expiresAt as string),
+    payload.maxUses as number,
+    payload.createdById as string,
+    (payload.label as string | null) ?? null,
+  );
+  return Result.ok<DomainEvent>(event);
+}
+
+function deserializeInviteCodeUsed(payload: Record<string, unknown>): Result<DomainEvent> {
+  const event = new InviteCodeUsedEvent(payload.inviteCodeId as string, payload.code as string, new Date(payload.usedAt as string), payload.newUseCount as number);
+  return Result.ok<DomainEvent>(event);
+}
+
+function deserializeInviteCodeRevoked(payload: Record<string, unknown>): Result<DomainEvent> {
+  const event = new InviteCodeRevokedEvent(payload.inviteCodeId as string, payload.codeMasked as string, new Date(payload.revokedAt as string), payload.revokedById as string);
+  return Result.ok<DomainEvent>(event);
+}
 
 function deserializeBeitrittsanfrageErstellt(payload: Record<string, unknown>, aggregateId?: string): Result<DomainEvent> {
   const event = new EinsatzBeitrittsanfrageErstelltEvent(payload.anfrageId as string, payload.einsatzId as string, payload.userId as string, aggregateId);

--- a/packages/backend/src/infrastructure/outbox/event-serializer.ts
+++ b/packages/backend/src/infrastructure/outbox/event-serializer.ts
@@ -38,6 +38,7 @@ import type { RolleFreigegeben } from '@domain/kraefte/events/rolle-freigegeben.
 import type { RollenDefinitionCreatedEvent } from '@domain/kraefte/events/rollen-definition-created.event';
 import type { RollenDefinitionUpdatedEvent } from '@domain/kraefte/events/rollen-definition-updated.event';
 import type { InviteCodeCreatedEvent } from '@domain/events/invite-code-created.event';
+import type { InviteCodeUsedEvent } from '@domain/events/invite-code-used.event';
 import type { InviteCodeRevokedEvent } from '@domain/events/invite-code-revoked.event';
 import type { ServerAccessTokenCreatedEvent } from '@domain/events/server-access-token-created.event';
 import type { ServerAccessTokenRevokedEvent } from '@domain/events/server-access-token-revoked.event';
@@ -282,6 +283,8 @@ export class EventSerializer {
       // ===== INVITE CODE EVENTS =====
       case 'invite_code.created':
         return this.serializeInviteCodeCreated(event as unknown as InviteCodeCreatedEvent);
+      case 'invite_code.used':
+        return this.serializeInviteCodeUsed(event as unknown as InviteCodeUsedEvent);
       case 'invite_code.revoked':
         return this.serializeInviteCodeRevoked(event as unknown as InviteCodeRevokedEvent);
 
@@ -830,6 +833,15 @@ export class EventSerializer {
       maxUses: event.maxUses, // Already primitive number
       createdById: event.createdById, // Already primitive string
       label: event.label, // string | null
+    };
+  }
+
+  private serializeInviteCodeUsed(event: InviteCodeUsedEvent): Record<string, unknown> {
+    return {
+      inviteCodeId: event.inviteCodeId, // Already primitive string
+      code: event.code,
+      usedAt: event.usedAt.toISOString(),
+      newUseCount: event.newUseCount,
     };
   }
 


### PR DESCRIPTION
## Summary

- `invite_code.created`, `invite_code.used` und `invite_code.revoked` waren in `EVENT_NAMES` definiert, aber nicht im EventSerializer/EventDeserializer registriert
- Führte zu `Unknown event type: invite_code.revoked` Runtime-Fehlern wenn Invite-Codes widerrufen wurden
- Korrupte FAILED Events wurden aus der Dev-DB bereinigt (siehe #601)

## Changes

**Backend:**
- `event-deserializer.ts`: 3 Invite-Code Event-Typen mit Deserializer-Funktionen registriert
- `event-serializer.ts`: Fehlenden `invite_code.used` Case im Switch ergänzt
- `architecture-rules.spec.ts`: Invite-Code Events aus `knownMissingEvents` entfernt
- `event-deserializer.spec.ts`: Event-Count von 79 → 82, neue Assertions

**Config:**
- `CLAUDE.md`: PostgreSQL Docker-Zugriff dokumentiert

## Test plan

- [x] 134/134 Event Serializer/Deserializer/Roundtrip Tests bestehen
- [x] 7/7 Architektur-Tests bestehen
- [ ] Manuell: Invite-Code erstellen, verwenden und widerrufen — Events erscheinen als PUBLISHED in der Outbox

Closes #601 (teilweise — DB-Bereinigung erledigt, Integrationstests noch offen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)