### PR TITLE
🐛(fullstack): Fix einsatzort [object Object] und JSON-Anzeige (#610)

### DIFF
--- a/packages/backend/src/application/einsatz/queries/get-active-einsaetze-with-counts/get-active-einsaetze-with-counts.handler.ts
+++ b/packages/backend/src/application/einsatz/queries/get-active-einsaetze-with-counts/get-active-einsaetze-with-counts.handler.ts
@@ -116,17 +116,34 @@ export class GetActiveEinsaetzeWithCountsQueryHandler implements IQueryHandler<G
         nummer: e.nummer,
         alarmstichwort: e.alarmstichwort ?? '', // null � empty string f�r API
         status: e.status as EinsatzListItemDto['status'],
-        einsatzort: e.einsatzort ? { ort: e.einsatzort } : undefined,
+        einsatzort: e.einsatzort ? GetActiveEinsaetzeWithCountsQueryHandler.parseEinsatzort(e.einsatzort) : undefined,
         createdAt: e.createdAt,
         etbEintraegeCount: e.einsatztagebuch?._count?.eintraege ?? 0,
         poisCount: e.lagekarte?._count?.pois ?? 0,
       }));
 
       return Result.ok(dtos);
-    } catch (error) {
+    } catch (error: unknown) {
       // Structured Logging f�r Produktions-Debugging
-      this.logger.error('Unerwarteter Fehler beim Laden aktiver Eins�tze mit Counts', error instanceof Error ? error.stack : String(error));
-      return Result.fail('Fehler beim Laden der Eins�tze');
+      this.logger.error('Unerwarteter Fehler beim Laden aktiver Einsätze mit Counts', error instanceof Error ? error.stack : String(error));
+      return Result.fail('Fehler beim Laden der Einsätze');
     }
+  }
+
+  /**
+   * Parsed den einsatzort-String aus der DB (JSON oder Plain-Text) zu { ort: string }.
+   * Die DB speichert Adressen als JSON-String (z.B. '{"ort":"München"}').
+   * Ältere Einträge oder E2E-Tests können Plain-Text enthalten (z.B. 'Test-Ort').
+   */
+  private static parseEinsatzort(raw: string): { ort: string } {
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === 'object' && parsed !== null && typeof parsed.ort === 'string') {
+        return { ort: parsed.ort };
+      }
+    } catch {
+      // Kein JSON → Plain-Text als ort verwenden
+    }
+    return { ort: raw };
   }
 }

--- a/packages/frontend/src/features/einsatz/ui/molecules/EinsatzInfoCard.tsx
+++ b/packages/frontend/src/features/einsatz/ui/molecules/EinsatzInfoCard.tsx
@@ -1,5 +1,6 @@
 import { EinsatzCompletenessBar } from '@/features/einsatz/ui/molecules/einsatz-completeness-bar.molecule';
 import { EinsatzStatusBadge } from '@/features/einsatz/ui/molecules/einsatz-status-badge.molecule';
+import { formatAddress } from '@/shared/lib/addressFormatter';
 import { formatNatoDateTime } from '@/shared/lib/dateFormatter';
 import { Textarea } from '@/shared/ui/atoms/textarea.atom';
 import type { EinsatzResponseDto } from '@/shared';
@@ -47,7 +48,7 @@ export function EinsatzInfoCard({ einsatz, isArchived, isEditing, form }: Einsat
           <PiMapPinIcon className="mt-1 h-5 w-5 text-text-muted" />
           <div className="flex-1">
             <p className="text-sm font-medium text-text-secondary">Einsatzort</p>
-            <p className="text-sm text-text-primary">{einsatz.einsatzort || 'Nicht angegeben'}</p>
+            <p className="text-sm text-text-primary">{einsatz.einsatzort ? formatAddress(einsatz.einsatzort) : 'Nicht angegeben'}</p>
           </div>
         </div>
         <div className="flex items-start space-x-2">

--- a/packages/frontend/src/features/einsatz/ui/molecules/EinsatzListItem.tsx
+++ b/packages/frontend/src/features/einsatz/ui/molecules/EinsatzListItem.tsx
@@ -1,5 +1,6 @@
 import { EinsatzStatus, EinsatzStatusBadge } from '@/features/einsatz/ui/molecules/einsatz-status-badge.molecule';
 import { useActiveEinsatz } from '@/features/einsatz';
+import { formatAddress } from '@/shared/lib/addressFormatter';
 import { formatNatoDateTime } from '@/shared/lib/dateFormatter';
 import type { EinsatzListItemDto, EinsatzResponseDto } from '@/shared';
 import { Badge } from '@/shared/ui/atoms/badge.atom';
@@ -13,7 +14,7 @@ interface EinsatzListItemProps {
 export const EinsatzListItem = ({ einsatz }: EinsatzListItemProps) => {
   const { activeEinsatz } = useActiveEinsatz();
   const isCurrentlyActive = activeEinsatz?.id === einsatz.id;
-  const einsatzortLabel = [einsatz.einsatzort?.strasse, einsatz.einsatzort?.ort].filter(Boolean).join(', ');
+  const einsatzortLabel = einsatz.einsatzort ? formatAddress(einsatz.einsatzort) : '';
 
   // Extract counts if available (present in EinsatzListItemDto)
   const etbEintraegeCount = 'etbEintraegeCount' in einsatz ? einsatz.etbEintraegeCount : undefined;

--- a/packages/frontend/src/features/einsatz/ui/organisms/SecondaryRoleDashboard.tsx
+++ b/packages/frontend/src/features/einsatz/ui/organisms/SecondaryRoleDashboard.tsx
@@ -1,3 +1,4 @@
+import { formatAddress } from '@/shared/lib/addressFormatter';
 import type { MeineEinsatzRolleDtoRolleEnum } from '@bluelight-hub/shared/client';
 import { useEinsatzDetails } from '@/features/einsatz';
 import { useUnquittierteBefehleCount } from '@/features/befehl';
@@ -96,7 +97,7 @@ export function SecondaryRoleDashboard({ einsatzId, rolle }: SecondaryRoleDashbo
             <dt className="text-body-sm text-text-secondary">Einsatzort</dt>
             <dd className="mt-1 flex items-center gap-1 font-medium text-text-primary">
               <PiMapPin className="h-4 w-4 text-text-muted" aria-hidden="true" />
-              {einsatz.einsatzort || '—'}
+              {einsatz.einsatzort ? formatAddress(einsatz.einsatzort) : '—'}
             </dd>
           </div>
           <div>

--- a/packages/frontend/src/features/einsatz/ui/organisms/SingleEinsatzDashboard.tsx
+++ b/packages/frontend/src/features/einsatz/ui/organisms/SingleEinsatzDashboard.tsx
@@ -1,3 +1,4 @@
+import { formatAddress } from '@/shared/lib/addressFormatter';
 import { useUserNames } from '@/features/auth/api/use-users';
 import { FMS_STATUS_LABELS, useActiveEinsatz, useEinsatzDetails, useEinsatzFahrzeuge } from '@/features/einsatz';
 import { isWorkspaceRouteAccessible } from '@/features/workspace';
@@ -84,21 +85,6 @@ function parseDate(value: Date | string | null | undefined): Date | null {
 
   const parsed = value instanceof Date ? value : new Date(value);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
-}
-
-function formatEinsatzort(einsatzort: DashboardEinsatz['einsatzort']): string {
-  if (!einsatzort) {
-    return 'Ort wird nachgereicht';
-  }
-
-  if (typeof einsatzort === 'string') {
-    return einsatzort;
-  }
-
-  const street = [einsatzort.strasse, einsatzort.hausnummer].filter(Boolean).join(' ');
-  const locality = [einsatzort.plz, einsatzort.ort].filter(Boolean).join(' ');
-
-  return [street, locality].filter(Boolean).join(', ');
 }
 
 function getEinsatzDisplayName(einsatz: DashboardEinsatz): string {
@@ -449,7 +435,7 @@ export function SingleEinsatzDashboard() {
 
   const startTime = getEinsatzStartTime(einsatz);
   const einsatzName = getEinsatzDisplayName(einsatz);
-  const einsatzort = formatEinsatzort(einsatz.einsatzort);
+  const einsatzort = formatAddress(einsatz.einsatzort);
   const duration = formatDistanceToNow(startTime, { locale: de, addSuffix: false });
   const latestEntry = etbEntries.at(-1);
   const pois = Array.isArray(lagekarte?.pois) ? (lagekarte.pois as Array<Record<string, unknown>>) : [];

--- a/packages/frontend/src/shared/lib/addressFormatter.ts
+++ b/packages/frontend/src/shared/lib/addressFormatter.ts
@@ -1,0 +1,32 @@
+/**
+ * Adress-Objekt mit optionalen Feldern.
+ * Kompatibel mit AddressDto (vollständig) und EinsatzListItemDtoEinsatzort (nur ort).
+ */
+interface AddressLike {
+  strasse?: string;
+  hausnummer?: string;
+  plz?: string;
+  ort?: string;
+}
+
+/**
+ * Formatiert ein Adress-Objekt als lesbare Adresse.
+ * Unterstützt AddressDto, {ort: string}, object und String-Eingaben.
+ * Beispiel: "Musterstraße 42, 80331 München"
+ */
+export function formatAddress(address: AddressLike | string | null | undefined): string {
+  if (!address) {
+    return 'Ort wird nachgereicht';
+  }
+
+  if (typeof address === 'string') {
+    return address;
+  }
+
+  const addr = address as AddressLike;
+  const street = [addr.strasse, addr.hausnummer].filter(Boolean).join(' ');
+  const locality = [addr.plz, addr.ort].filter(Boolean).join(' ');
+
+  const formatted = [street, locality].filter(Boolean).join(', ');
+  return formatted || 'Ort wird nachgereicht';
+}

--- a/packages/frontend/src/shared/ui/templates/SingleEinsatzLayout.tsx
+++ b/packages/frontend/src/shared/ui/templates/SingleEinsatzLayout.tsx
@@ -1,3 +1,4 @@
+import { formatAddress } from '@/shared/lib/addressFormatter';
 import { useCurrentUser } from '@/features/auth';
 import { useBefehlNotifications, useBefehlWebSocket, useMissedBefehlAlerts, useUnquittierteBefehleCount } from '@/features/befehl';
 import { useMyEinsatzRolle } from '@/features/befehl/api/use-my-einsatz-rolle';
@@ -442,7 +443,7 @@ export function SingleEinsatzLayout({ className }: SingleEinsatzLayoutProps) {
           subtitle: einsatz?.alarmstichwort ? (
             <>
               {einsatz.alarmstichwort}
-              {einsatz.einsatzort && ` • ${einsatz.einsatzort}`}
+              {einsatz.einsatzort && ` • ${formatAddress(einsatz.einsatzort)}`}
             </>
           ) : undefined,
           backAction: {


### PR DESCRIPTION
## Summary

- Einsatzort wurde als `[object Object]` (ContextBar) bzw. als roher JSON-String `{"ort":"..."}` (Einsatzliste) angezeigt
- Root Cause: Backend-Listen-Endpunkt hat JSON-serialisierte Adressen nicht geparst; Frontend hat Adress-Objekte direkt als Strings interpoliert
- Shared `formatAddress()` Utility erstellt, alle 5 betroffenen Frontend-Stellen + 1 Backend-Handler gefixt

## Changes

**Backend**
- `get-active-einsaetze-with-counts.handler.ts`: Neue `parseEinsatzort()` Methode — parsed JSON-Strings aus der DB korrekt, Fallback auf Plain-Text für ältere Einträge

**Frontend**
- `addressFormatter.ts`: Neue Shared-Utility `formatAddress()` — unterstützt AddressDto, {ort}, string und null
- `SingleEinsatzLayout.tsx`: ContextBar nutzt `formatAddress()` statt direkter String-Interpolation
- `SingleEinsatzDashboard.tsx`: Lokale `formatEinsatzort()` durch Shared-Utility ersetzt
- `EinsatzListItem.tsx`: Fragile `?.strasse`/`?.ort` Zugriffe durch `formatAddress()` ersetzt
- `EinsatzInfoCard.tsx`: Direkte Object-Ausgabe durch `formatAddress()` ersetzt
- `SecondaryRoleDashboard.tsx`: Direkte Object-Ausgabe durch `formatAddress()` ersetzt

## Test plan

- [ ] Einsatz mit gesetztem Einsatzort öffnen → ContextBar zeigt lesbare Adresse (z.B. "29525 Uelzen")
- [ ] Einsatz-Dashboard (Kanban) prüfen → Kein JSON, keine `[object Object]` Anzeige
- [ ] Einsatz ohne Einsatzort → "Ort wird nachgereicht" / "Nicht angegeben"
- [ ] Backend-Tests: 22/22 `get-active-einsaetze-with-counts` bestanden
- [ ] Frontend-Tests: 3853/3853 bestanden

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)