### PR TITLE
🐛 lint-staged: Markdown-Formatierung fix für Release-Pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
       "oxfmt --write --no-error-on-unmatched-pattern"
     ],
     "**/*.md": [
-      "oxfmt --check --no-error-on-unmatched-pattern"
+      "oxfmt --write --no-error-on-unmatched-pattern"
     ]
   },
   "engines": {


### PR DESCRIPTION
## Summary
- lint-staged prüfte `.md`-Dateien mit `oxfmt --check` statt `oxfmt --write`
- Wenn `semantic-release` die CHANGELOG.md generiert und committet, schlug der pre-commit Hook fehl, weil die Formatierung nicht automatisch korrigiert wurde
- Fix: `--check` → `--write` (analog zu den anderen Dateitypen)

## Test plan
- [ ] Release-Pipeline (`Create Release` Workflow) erfolgreich durchlaufen lassen

🤖 Generated with [Claude Code](https://claude.com/claude-code)