### PR TITLE
✨(frontend): Lagekarte Zeichenwerkzeuge, Schraffur-Editor & OSM-Markierung (#637)

### DIFF
--- a/docs/superpowers/plans/2026-04-08-hatch-editor.md
+++ b/docs/superpowers/plans/2026-04-08-hatch-editor.md
@@ -1,0 +1,957 @@
+# Erweiterter Schraffur-Editor — Implementierungsplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Schraffurmuster auf der Lagekarte detailliert konfigurierbar machen — Mustertyp, Abstand, Strichstärke und Farbe — mit dynamischer Canvas-Generierung und data-driven MapLibre `fill-pattern`.
+
+**Architecture:** Das alte `FillPattern` String-Enum wird durch ein `HatchConfig`-Objekt ersetzt. Pattern-Images werden dynamisch per Canvas erzeugt und on-demand auf der Map registriert. Die 8 hardcoded Hatch-Layer werden auf 2 data-driven Layer reduziert (MapLibre v5 unterstützt data-driven `fill-pattern`). Die UI bekommt eine Aufklapp-Sektion "Anpassen..." unter den Muster-Buttons.
+
+**Tech Stack:** React 19, MapLibre GL v5.22.0, MapboxDraw v1.5.1, Tailwind CSS, Canvas API
+
+**Hinweis zu Tests:** Canvas-basierte Pattern-Generierung und MapboxDraw-Integration sind schwer unit-testbar. Verifikation erfolgt über TypeScript-Compilation und manuellen Browser-Test. Jeder Task endet mit `pnpm --filter @bluelight-hub/frontend exec tsc --noEmit`.
+
+**Spec:** `docs/superpowers/specs/2026-04-08-hatch-editor-design.md`
+
+---
+
+### File Structure
+
+| Datei | Aktion | Verantwortung |
+|-------|--------|---------------|
+| `packages/frontend/src/features/lagekarte/drawing/types.ts` | Modify | `HatchConfig` Interface, `DrawingStyle.hatch` ersetzt `fillPattern` |
+| `packages/frontend/src/features/lagekarte/drawing/hatch-patterns.ts` | Rewrite | Parametrische Image-Generierung, `ensureHatchImage()`, Migration |
+| `packages/frontend/src/features/lagekarte/drawing/draw-styles.ts` | Modify | 8 Hatch-Layer → 2 data-driven Layer |
+| `packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx` | Modify | Aufklapp-Sektion mit Slidern + Farbauswahl |
+| `packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx` | Modify | Hatch-Config lesen/schreiben, Image-Registrierung, Migration |
+| `packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts` | Modify | `hatch` + `fillPattern` auf neue Features setzen |
+
+---
+
+### Task 1: Typen-Refactoring (types.ts)
+
+**Files:**
+- Modify: `packages/frontend/src/features/lagekarte/drawing/types.ts`
+
+- [ ] **Step 1: HatchConfig und HatchType hinzufügen, FillPattern + fillPattern ersetzen**
+
+Ersetze den gesamten Inhalt von `types.ts`:
+
+```typescript
+/**
+ * Typen für die Lagekarte-Zeichenwerkzeuge
+ *
+ * Gemeinsame Typen für Draw-Modi, Styles und Feature-Properties.
+ */
+
+/** Verfügbare Zeichenmodi */
+export type DrawMode = 'idle' | 'select' | 'draw_point' | 'draw_line_string' | 'draw_polygon' | 'draw_freehand' | 'draw_text' | 'osm_mark';
+
+/** Status einer OSM-Markierung */
+export type OsmMarkierungStatus = 'betroffen' | 'gesperrt' | 'evakuiert';
+
+/** Verfügbare Schraffur-Mustertypen */
+export type HatchType = 'none' | 'diagonal' | 'cross' | 'horizontal' | 'vertical';
+
+/** Konfiguration für Schraffurmuster */
+export interface HatchConfig {
+  /** Mustertyp */
+  type: HatchType;
+  /** Kachel-Größe / Linienabstand in Pixel (6–32) */
+  spacing: number;
+  /** Strichstärke der Schraffurlinien in Pixel (0.5–4) */
+  width: number;
+  /** Linienfarbe als Hex-String. Leer = Randfarbe des Features übernehmen */
+  color: string;
+}
+
+/** Standard-Schraffur-Konfiguration */
+export const DEFAULT_HATCH: HatchConfig = {
+  type: 'none',
+  spacing: 12,
+  width: 1.5,
+  color: '',
+};
+
+/** Stil-Eigenschaften für Zeichnungsobjekte */
+export interface DrawingStyle {
+  /** Linienfarbe (Hex) */
+  color: string;
+  /** Linien-Deckkraft (0–1) */
+  opacity: number;
+  /** Linienstärke in Pixel */
+  strokeWidth: number;
+  /** Strichmuster, z.B. '5,5' — Hinweis: Nicht data-driven per Feature unterstützt (MapboxDraw-Limitation) */
+  strokeDasharray?: string;
+  /** Füllfarbe (Hex) */
+  fillColor: string;
+  /** Füll-Deckkraft (0–1) */
+  fillOpacity: number;
+  /** Schraffur-Konfiguration */
+  hatch: HatchConfig;
+}
+
+/** Standard-Stil für neue Zeichnungen */
+export const DEFAULT_DRAWING_STYLE: DrawingStyle = {
+  color: '#3b82f6',
+  opacity: 1,
+  strokeWidth: 2,
+  fillColor: '#3b82f6',
+  fillOpacity: 0.2,
+  hatch: { ...DEFAULT_HATCH },
+};
+
+/** Properties eines gezeichneten GeoJSON-Features */
+export interface DrawFeatureProperties {
+  /** Stil-Überschreibung für dieses Feature */
+  drawingStyle?: DrawingStyle;
+  /** Beschriftung (für Text-Features) */
+  label?: string;
+  /** Typ des Features */
+  featureType: 'drawing' | 'osm_marking';
+  /** OSM-Feature-ID (nur für OSM-Markierungen) */
+  osmFeatureId?: string;
+  /** OSM-Layer-ID (nur für OSM-Markierungen) */
+  osmLayerId?: string;
+  /** Markierungsstatus (nur für OSM-Markierungen) */
+  osmStatus?: OsmMarkierungStatus;
+}
+
+/** Farbzuordnung für OSM-Markierungsstatus */
+export const OSM_MARKING_COLORS: Record<OsmMarkierungStatus, string> = {
+  betroffen: '#fbbf24',
+  gesperrt: '#ef4444',
+  evakuiert: '#a855f7',
+};
+```
+
+- [ ] **Step 2: TypeScript-Fehler prüfen (es werden Fehler erwartet — andere Dateien referenzieren noch FillPattern)**
+
+Run: `pnpm --filter @bluelight-hub/frontend exec tsc --noEmit 2>&1 | head -30`
+
+Expected: Fehler in `DrawStylePanel.molecule.tsx`, `LagekarteView.tsx` (Referenzen auf `FillPattern`, `fillPattern`). Das ist korrekt — wird in späteren Tasks gefixt.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/drawing/types.ts
+git commit -m "♻️(frontend): HatchConfig ersetzt FillPattern in Drawing-Typen (#637)"
+```
+
+---
+
+### Task 2: Parametrische Pattern-Generierung (hatch-patterns.ts)
+
+**Files:**
+- Rewrite: `packages/frontend/src/features/lagekarte/drawing/hatch-patterns.ts`
+
+- [ ] **Step 1: hatch-patterns.ts komplett neu schreiben**
+
+Ersetze den gesamten Inhalt:
+
+```typescript
+/**
+ * Dynamische Schraffurmuster-Generierung für die Lagekarte
+ *
+ * Erzeugt parametrisierte Canvas-basierte Schraffurmuster und registriert
+ * sie on-demand auf der MapLibre-Instanz. Jede Parameterkombination
+ * (Typ, Abstand, Stärke, Farbe) erzeugt ein eigenes Image.
+ */
+
+import type { Map as MaplibreMap } from 'maplibre-gl';
+import type { HatchConfig, HatchType } from './types';
+
+/**
+ * Erzeugt einen deterministischen Image-Namen aus der Hatch-Konfiguration.
+ *
+ * Format: `hatch-{type}-{spacing}-{width}-{colorHex}`
+ * Der colorHex ist die aufgelöste Farbe (nach Fallback auf Randfarbe).
+ */
+export function buildHatchImageName(type: HatchType, spacing: number, width: number, resolvedColor: string): string {
+  const hex = resolvedColor.replace('#', '');
+  return `hatch-${type}-${spacing}-${width}-${hex}`;
+}
+
+/**
+ * Erzeugt ein nahtlos kachelbares Canvas-Pattern als ImageData.
+ *
+ * @param type - Mustertyp (diagonal, cross, horizontal, vertical)
+ * @param spacing - Kachel-Größe in Pixel (bestimmt Linienabstand)
+ * @param width - Strichstärke in Pixel
+ * @param color - CSS-Farbwert für die Schraffurlinien
+ */
+export function createHatchImage(type: HatchType, spacing: number, width: number, color: string): ImageData {
+  const canvas = document.createElement('canvas');
+  canvas.width = spacing;
+  canvas.height = spacing;
+  const ctx = canvas.getContext('2d')!;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = width;
+
+  switch (type) {
+    case 'diagonal':
+      drawDiagonal(ctx, spacing);
+      break;
+    case 'cross':
+      drawDiagonal(ctx, spacing);
+      drawReverseDiagonal(ctx, spacing);
+      break;
+    case 'horizontal':
+      drawHorizontal(ctx, spacing);
+      break;
+    case 'vertical':
+      drawVertical(ctx, spacing);
+      break;
+    default:
+      break;
+  }
+
+  return ctx.getImageData(0, 0, spacing, spacing);
+}
+
+/** Diagonale Linien (/) mit Wrap für nahtloses Kacheln */
+function drawDiagonal(ctx: CanvasRenderingContext2D, size: number): void {
+  for (const offset of [-size, 0, size]) {
+    ctx.beginPath();
+    ctx.moveTo(offset, size);
+    ctx.lineTo(size + offset, 0);
+    ctx.stroke();
+  }
+}
+
+/** Umgekehrte Diagonale (\) mit Wrap für nahtloses Kacheln */
+function drawReverseDiagonal(ctx: CanvasRenderingContext2D, size: number): void {
+  for (const offset of [-size, 0, size]) {
+    ctx.beginPath();
+    ctx.moveTo(offset, 0);
+    ctx.lineTo(size + offset, size);
+    ctx.stroke();
+  }
+}
+
+/** Horizontale Linien mit gleichmäßigem Abstand */
+function drawHorizontal(ctx: CanvasRenderingContext2D, size: number): void {
+  const half = size / 2;
+  for (let y = half / 2; y < size; y += half) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(size, y);
+    ctx.stroke();
+  }
+}
+
+/** Vertikale Linien mit gleichmäßigem Abstand */
+function drawVertical(ctx: CanvasRenderingContext2D, size: number): void {
+  const half = size / 2;
+  for (let x = half / 2; x < size; x += half) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, size);
+    ctx.stroke();
+  }
+}
+
+/** Set registrierter Image-Namen (für Re-Registrierung bei Style-Wechsel) */
+const registeredImages = new Set<string>();
+
+/**
+ * Stellt sicher, dass ein Hatch-Image auf der Map registriert ist.
+ * Erzeugt es bei Bedarf per Canvas und gibt den Image-Namen zurück.
+ *
+ * @param map - MapLibre-Map-Instanz
+ * @param config - Hatch-Konfiguration
+ * @param fallbackColor - Randfarbe des Features (Fallback wenn config.color leer)
+ * @returns Image-Name für fill-pattern, oder '' wenn type === 'none'
+ */
+export function ensureHatchImage(map: MaplibreMap | undefined, config: HatchConfig, fallbackColor: string): string {
+  if (!map || config.type === 'none') return '';
+
+  const resolvedColor = config.color || fallbackColor;
+  const name = buildHatchImageName(config.type, config.spacing, config.width, resolvedColor);
+
+  if (!map.hasImage(name)) {
+    map.addImage(name, createHatchImage(config.type, config.spacing, config.width, resolvedColor));
+    registeredImages.add(name);
+  }
+
+  return name;
+}
+
+/**
+ * Re-registriert alle bekannten Hatch-Images nach einem Style-Wechsel.
+ * style.load entfernt alle Images — diese Funktion stellt sie wieder her.
+ *
+ * Wird von LagekarteView beim style.load Event aufgerufen.
+ */
+export function reregisterHatchImages(map: MaplibreMap | undefined): void {
+  if (!map) return;
+
+  for (const name of registeredImages) {
+    if (map.hasImage(name)) continue;
+
+    // Image-Name parsen: hatch-{type}-{spacing}-{width}-{hex}
+    const parts = name.split('-');
+    if (parts.length < 5) continue;
+    const type = parts[1] as HatchType;
+    const spacing = Number(parts[2]);
+    const width = Number(parts[3]);
+    const hex = `#${parts.slice(4).join('-')}`;
+
+    map.addImage(name, createHatchImage(type, spacing, width, hex));
+  }
+}
+
+/**
+ * Migriert einen alten FillPattern-String (z.B. 'hatch-diagonal') zu einem HatchConfig.
+ * Gibt null zurück wenn der Wert bereits ein neues Format ist oder 'none'.
+ */
+export function migrateLegacyFillPattern(fillPattern: string): HatchConfig | null {
+  const legacyTypes = ['hatch-diagonal', 'hatch-cross', 'hatch-horizontal', 'hatch-vertical'];
+  if (!legacyTypes.includes(fillPattern)) return null;
+
+  const type = fillPattern.replace('hatch-', '') as HatchType;
+  return { type, spacing: 12, width: 1.5, color: '' };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/drawing/hatch-patterns.ts
+git commit -m "♻️(frontend): Parametrische Hatch-Pattern-Generierung (#637)"
+```
+
+---
+
+### Task 3: Draw-Styles vereinfachen (draw-styles.ts)
+
+**Files:**
+- Modify: `packages/frontend/src/features/lagekarte/drawing/draw-styles.ts`
+
+- [ ] **Step 1: 8 Hatch-Layer durch 2 data-driven Layer ersetzen**
+
+Ersetze die 8 Hatch-Layer (Zeilen 31–83, `gl-draw-polygon-hatch-diagonal-inactive` bis `gl-draw-polygon-hatch-vertical-active`) durch genau 2 Layer. Der neue Block kommt direkt nach dem `gl-draw-polygon-fill-active` Layer (nach Zeile 30):
+
+Lösche die alten 8 Hatch-Layer und den Kommentar `// Polygon-Schraffur: Diagonal (inaktiv)` bis einschließlich `paint: { 'fill-pattern': 'hatch-vertical', 'fill-opacity': ... },` und ersetze durch:
+
+```javascript
+  // Polygon-Schraffur (inaktiv) — data-driven fill-pattern, ein Layer für alle Muster
+  {
+    id: 'gl-draw-polygon-hatch-inactive',
+    type: 'fill',
+    filter: ['all', ['==', 'active', 'false'], ['==', '$type', 'Polygon'], ['!=', 'mode', 'static'], ['has', 'user_fillPattern'], ['!=', ['get', 'user_fillPattern'], '']],
+    paint: {
+      'fill-pattern': ['get', 'user_fillPattern'],
+      'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.2],
+    },
+  },
+  // Polygon-Schraffur (aktiv)
+  {
+    id: 'gl-draw-polygon-hatch-active',
+    type: 'fill',
+    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon'], ['has', 'user_fillPattern'], ['!=', ['get', 'user_fillPattern'], '']],
+    paint: {
+      'fill-pattern': ['get', 'user_fillPattern'],
+      'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.2],
+    },
+  },
+```
+
+Entferne auch den obsoleten Kommentar `// Separate Layer pro Muster nötig, da fill-pattern in MapLibre nicht data-driven ist`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/drawing/draw-styles.ts
+git commit -m "♻️(frontend): 8 Hatch-Layer → 2 data-driven Layer (#637)"
+```
+
+---
+
+### Task 4: DrawStylePanel UI (DrawStylePanel.molecule.tsx)
+
+**Files:**
+- Modify: `packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx`
+
+- [ ] **Step 1: Kompletten Inhalt der Datei ersetzen**
+
+```typescript
+/**
+ * DrawStylePanel - Stil-Editor für selektierte Zeichnungsobjekte
+ *
+ * Schwebendes Panel rechts neben der Toolbar. Ermöglicht das Ändern von
+ * Farbe, Linienstärke, Füllung und Schraffur für das aktuell ausgewählte Feature.
+ */
+
+import { useState } from 'react';
+import { cn } from '@/shared/ui/cn';
+import type { DrawingStyle, HatchConfig, HatchType } from '../../drawing/types';
+import { DEFAULT_HATCH } from '../../drawing/types';
+
+/** Props für die DrawStylePanel-Komponente */
+export interface DrawStylePanelProps {
+  /** Aktueller Stil des selektierten Features */
+  style: DrawingStyle;
+  /** Stil ändern */
+  onStyleChange: (style: Partial<DrawingStyle>) => void;
+  /** Ob das Panel sichtbar ist */
+  isVisible: boolean;
+  /** Optionales Label (für Text-Features) */
+  label?: string;
+  /** Label ändern */
+  onLabelChange?: (label: string) => void;
+  /** Geometrie-Typ des selektierten Features (steuert sichtbare Optionen) */
+  geometryType?: string;
+}
+
+/** Vordefinierte Farben für die Farbauswahl */
+const COLOR_SWATCHES = [
+  { value: '#ef4444', label: 'Rot' },
+  { value: '#f97316', label: 'Orange' },
+  { value: '#eab308', label: 'Gelb' },
+  { value: '#22c55e', label: 'Grün' },
+  { value: '#3b82f6', label: 'Blau' },
+  { value: '#8b5cf6', label: 'Lila' },
+  { value: '#ec4899', label: 'Pink' },
+  { value: '#1e293b', label: 'Dunkel' },
+] as const;
+
+/** Optionen für Linienstärke */
+const STROKE_WIDTH_OPTIONS = [
+  { value: 1, label: 'Dünn' },
+  { value: 2, label: 'Mittel' },
+  { value: 4, label: 'Dick' },
+] as const;
+
+/** Optionen für Schraffurmuster */
+const HATCH_TYPE_OPTIONS: { value: HatchType; label: string }[] = [
+  { value: 'none', label: 'Keine' },
+  { value: 'diagonal', label: 'Diagonal' },
+  { value: 'cross', label: 'Kreuz' },
+  { value: 'horizontal', label: 'Horizontal' },
+  { value: 'vertical', label: 'Vertikal' },
+];
+
+/** Gemeinsame Toggle-Button-Styles */
+const toggleBase = 'rounded px-2.5 py-1 text-xs font-medium transition-colors duration-100 focus-visible:shadow-focus-ring focus-visible:outline-none';
+
+/** SVG-Icon für Schraffurmuster-Vorschau */
+function PatternIcon({ type }: { type: HatchType }) {
+  const s = 14;
+  const stroke = 'currentColor';
+  const sw = 1.5;
+
+  if (type === 'none') {
+    return (
+      <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+        <line x1={1} y1={1} x2={s - 1} y2={s - 1} stroke={stroke} strokeWidth={sw} strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  if (type === 'diagonal') {
+    return (
+      <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+        <line x1={0} y1={s} x2={s} y2={0} stroke={stroke} strokeWidth={sw} />
+        <line x1={-4} y1={s - 4} x2={s - 4} y2={-4} stroke={stroke} strokeWidth={sw} />
+        <line x1={4} y1={s + 4} x2={s + 4} y2={4} stroke={stroke} strokeWidth={sw} />
+      </svg>
+    );
+  }
+
+  if (type === 'cross') {
+    return (
+      <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+        <line x1={0} y1={s} x2={s} y2={0} stroke={stroke} strokeWidth={sw} />
+        <line x1={0} y1={0} x2={s} y2={s} stroke={stroke} strokeWidth={sw} />
+      </svg>
+    );
+  }
+
+  if (type === 'horizontal') {
+    return (
+      <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+        <line x1={0} y1={4} x2={s} y2={4} stroke={stroke} strokeWidth={sw} />
+        <line x1={0} y1={10} x2={s} y2={10} stroke={stroke} strokeWidth={sw} />
+      </svg>
+    );
+  }
+
+  // vertical
+  return (
+    <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+      <line x1={4} y1={0} x2={4} y2={s} stroke={stroke} strokeWidth={sw} />
+      <line x1={10} y1={0} x2={10} y2={s} stroke={stroke} strokeWidth={sw} />
+    </svg>
+  );
+}
+
+export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabelChange, geometryType }: DrawStylePanelProps) {
+  const [hatchExpanded, setHatchExpanded] = useState(false);
+
+  if (!isVisible) return null;
+
+  const isPoint = geometryType === 'Point';
+  const showStrokeWidth = !isPoint;
+  const showFill = !isPoint;
+  const hatch = style.hatch ?? DEFAULT_HATCH;
+  const hasHatch = hatch.type !== 'none';
+
+  /** Hatch-Config partiell ändern */
+  const updateHatch = (partial: Partial<HatchConfig>) => {
+    onStyleChange({ hatch: { ...hatch, ...partial } });
+  };
+
+  return (
+    <div className={cn('absolute top-4 left-20 z-10 w-52 rounded-lg border border-border-subtle bg-surface-panel p-3 shadow-lg')}>
+      {/* Farbauswahl */}
+      <div className={cn(showStrokeWidth || showFill || label !== undefined ? 'mb-3' : '')}>
+        <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Farbe</div>
+        <div className="flex flex-wrap gap-1.5">
+          {COLOR_SWATCHES.map(({ value, label: colorLabel }) => (
+            <button
+              key={value}
+              type="button"
+              title={colorLabel}
+              onClick={() => onStyleChange({ color: value, fillColor: value })}
+              className={cn(
+                'h-6 w-6 rounded-full border-2 transition-transform duration-100',
+                'hover:scale-110 focus-visible:shadow-focus-ring focus-visible:outline-none',
+                style.color === value ? 'scale-110 border-text-primary' : 'border-transparent',
+              )}
+              style={{ backgroundColor: value }}
+              aria-label={colorLabel}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Linienstärke (nicht für Punkte) */}
+      {showStrokeWidth && (
+        <div className={cn(showFill || label !== undefined ? 'mb-3' : '')}>
+          <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Linienstärke</div>
+          <div className="flex gap-1">
+            {STROKE_WIDTH_OPTIONS.map(({ value, label: widthLabel }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => onStyleChange({ strokeWidth: value })}
+                className={cn(toggleBase, style.strokeWidth === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+              >
+                {widthLabel}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Deckkraft-Slider (nicht für Punkte) */}
+      {showFill && (
+        <div className="mb-3">
+          <div className="mb-1.5 flex items-center justify-between">
+            <span className="text-xs font-semibold tracking-wide text-text-muted uppercase">Deckkraft</span>
+            <span className="text-xs tabular-nums text-text-muted">{Math.round(style.fillOpacity * 100)}%</span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={5}
+            value={Math.round(style.fillOpacity * 100)}
+            onChange={(e) => onStyleChange({ fillOpacity: Number(e.target.value) / 100 })}
+            className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-subtle accent-action-primary"
+            aria-label="Füll-Deckkraft"
+          />
+        </div>
+      )}
+
+      {/* Schraffur (nicht für Punkte) */}
+      {showFill && (
+        <div className={cn(label !== undefined ? 'mb-3' : '')}>
+          <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Schraffur</div>
+          {/* Muster-Buttons */}
+          <div className="flex gap-1">
+            {HATCH_TYPE_OPTIONS.map(({ value, label: patternLabel }) => (
+              <button
+                key={value}
+                type="button"
+                title={patternLabel}
+                onClick={() => updateHatch({ type: value })}
+                className={cn(
+                  'flex h-7 w-7 items-center justify-center rounded border transition-colors duration-100',
+                  'focus-visible:shadow-focus-ring focus-visible:outline-none',
+                  hatch.type === value ? 'border-action-primary bg-action-secondary' : 'border-border-subtle hover:bg-action-secondary',
+                )}
+                aria-label={`Schraffur: ${patternLabel}`}
+              >
+                <PatternIcon type={value} />
+              </button>
+            ))}
+          </div>
+
+          {/* Disclosure: "Anpassen..." */}
+          {hasHatch && (
+            <div className="mt-1.5">
+              <button
+                type="button"
+                onClick={() => setHatchExpanded((prev) => !prev)}
+                className="flex items-center gap-1 text-[10px] text-action-primary hover:text-action-primary/80"
+              >
+                <span className={cn('inline-block transition-transform', hatchExpanded && 'rotate-180')}>&#9660;</span>
+                Anpassen…
+              </button>
+
+              {hatchExpanded && (
+                <div className="mt-1.5 rounded-md border border-border-subtle bg-surface-panel/50 p-2">
+                  {/* Abstand */}
+                  <div className="mb-2">
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Abstand</span>
+                      <span className="text-[10px] tabular-nums text-text-muted">{hatch.spacing}px</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={6}
+                      max={32}
+                      step={2}
+                      value={hatch.spacing}
+                      onChange={(e) => updateHatch({ spacing: Number(e.target.value) })}
+                      className="h-1 w-full cursor-pointer appearance-none rounded-full bg-border-subtle accent-action-primary"
+                      aria-label="Schraffur-Abstand"
+                    />
+                  </div>
+
+                  {/* Strichstärke */}
+                  <div className="mb-2">
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Stärke</span>
+                      <span className="text-[10px] tabular-nums text-text-muted">{hatch.width}px</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={0.5}
+                      max={4}
+                      step={0.5}
+                      value={hatch.width}
+                      onChange={(e) => updateHatch({ width: Number(e.target.value) })}
+                      className="h-1 w-full cursor-pointer appearance-none rounded-full bg-border-subtle accent-action-primary"
+                      aria-label="Schraffur-Strichstärke"
+                    />
+                  </div>
+
+                  {/* Farbe */}
+                  <div>
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Farbe</span>
+                      <label className="flex items-center gap-1 text-[10px] text-text-muted">
+                        <input
+                          type="checkbox"
+                          checked={hatch.color === ''}
+                          onChange={(e) => updateHatch({ color: e.target.checked ? '' : style.color })}
+                          className="h-3 w-3 accent-action-primary"
+                        />
+                        Auto
+                      </label>
+                    </div>
+                    {hatch.color !== '' && (
+                      <div className="flex flex-wrap gap-1">
+                        {COLOR_SWATCHES.map(({ value, label: colorLabel }) => (
+                          <button
+                            key={value}
+                            type="button"
+                            title={colorLabel}
+                            onClick={() => updateHatch({ color: value })}
+                            className={cn(
+                              'h-4 w-4 rounded-full border-2 transition-transform duration-100',
+                              'hover:scale-110 focus-visible:shadow-focus-ring focus-visible:outline-none',
+                              hatch.color === value ? 'scale-110 border-text-primary' : 'border-transparent',
+                            )}
+                            style={{ backgroundColor: value }}
+                            aria-label={`Schraffurfarbe: ${colorLabel}`}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Text-Label (nur für Text-Features) */}
+      {label !== undefined && onLabelChange && (
+        <div>
+          <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Beschriftung</div>
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => onLabelChange(e.target.value)}
+            className={cn(
+              'w-full rounded border border-border-subtle bg-surface-panel px-2 py-1 text-sm text-text-primary',
+              'focus:border-action-primary focus:ring-1 focus:ring-action-primary focus:outline-none',
+            )}
+            placeholder="Text eingeben..."
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
+git commit -m "✨(frontend): DrawStylePanel Schraffur-Aufklapp-Sektion (#637)"
+```
+
+---
+
+### Task 5: LagekarteView Integration + Migration
+
+**Files:**
+- Modify: `packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx`
+
+- [ ] **Step 1: Imports aktualisieren**
+
+Ersetze die alten Imports:
+
+```typescript
+// Alt:
+import type { DrawingStyle, FillPattern } from '@/features/lagekarte/drawing/types';
+import { registerHatchPatterns } from '@/features/lagekarte/drawing/hatch-patterns';
+
+// Neu:
+import type { DrawingStyle, HatchConfig } from '@/features/lagekarte/drawing/types';
+import { DEFAULT_HATCH } from '@/features/lagekarte/drawing/types';
+import { ensureHatchImage, migrateLegacyFillPattern, reregisterHatchImages } from '@/features/lagekarte/drawing/hatch-patterns';
+```
+
+- [ ] **Step 2: onLoad und style.load Registrierung aktualisieren**
+
+Ersetze den `onLoad`-Handler:
+
+```typescript
+// Alt:
+onLoad={() => {
+  registerHatchPatterns(mapRef.current?.getMap());
+  setIsLoading(false);
+}}
+
+// Neu:
+onLoad={() => setIsLoading(false)}
+```
+
+Ersetze den `style.load` useEffect:
+
+```typescript
+// Alt:
+useEffect(() => {
+  const map = mapRef.current?.getMap();
+  if (!map || isLoading) return;
+  const reregister = () => registerHatchPatterns(map);
+  map.on('style.load', reregister);
+  return () => { map.off('style.load', reregister); };
+}, [isLoading]);
+
+// Neu:
+useEffect(() => {
+  const map = mapRef.current?.getMap();
+  if (!map || isLoading) return;
+  const reregister = () => reregisterHatchImages(map);
+  map.on('style.load', reregister);
+  return () => { map.off('style.load', reregister); };
+}, [isLoading]);
+```
+
+- [ ] **Step 3: Feature-Selektion mit Migration aktualisieren**
+
+Ersetze den Feature-Laden-Effect (I4 Block):
+
+```typescript
+  // I4: Stil des selektierten Features in das StylePanel laden
+  useEffect(() => {
+    if (selectedFeatureIds.length === 0) return;
+    const draw = drawRef.current;
+    if (!draw) return;
+    const feature = draw.get(selectedFeatureIds[0]);
+    if (!feature?.properties) return;
+    const props = feature.properties;
+
+    // Hatch-Config wiederherstellen (neues Format oder Legacy-Migration)
+    let hatch: HatchConfig = { ...DEFAULT_HATCH };
+    if (props.hatch) {
+      try {
+        hatch = typeof props.hatch === 'string' ? JSON.parse(props.hatch) : props.hatch;
+      } catch {
+        // Ungültiges JSON — Default beibehalten
+      }
+    } else if (props.fillPattern) {
+      // Legacy-Migration: alter String-Enum → HatchConfig
+      const migrated = migrateLegacyFillPattern(props.fillPattern);
+      if (migrated) hatch = migrated;
+    }
+
+    setActiveStyle((prev) => ({
+      ...prev,
+      ...(props.color && { color: props.color }),
+      ...(props.fillColor && { fillColor: props.fillColor }),
+      ...(props.strokeWidth != null && { strokeWidth: props.strokeWidth }),
+      ...(props.fillOpacity != null && { fillOpacity: props.fillOpacity }),
+      ...(props.strokeDasharray && { strokeDasharray: props.strokeDasharray }),
+      hatch,
+    }));
+  }, [selectedFeatureIds, drawRef]);
+```
+
+- [ ] **Step 4: handleStyleChange mit dynamischer Image-Registrierung aktualisieren**
+
+Ersetze `handleStyleChange`:
+
+```typescript
+  /** Stil ändern und auf selektierte Features anwenden */
+  const handleStyleChange = useCallback(
+    (partial: Partial<DrawingStyle>) => {
+      const next = { ...activeStyle, ...partial };
+      setActiveStyle(next);
+      const draw = drawRef.current;
+      if (!draw) return;
+      const map = mapRef.current?.getMap();
+
+      for (const id of selectedFeatureIds) {
+        // Einfache Properties setzen
+        for (const [key, value] of Object.entries(partial)) {
+          if (key === 'hatch') continue; // Hatch separat behandeln
+          draw.setFeatureProperty(id, key, value);
+        }
+
+        // Hatch-Config: als JSON speichern + Image-Namen berechnen
+        if (partial.hatch !== undefined) {
+          const hatch = next.hatch;
+          draw.setFeatureProperty(id, 'hatch', JSON.stringify(hatch));
+          const imageName = ensureHatchImage(map, hatch, next.color);
+          draw.setFeatureProperty(id, 'fillPattern', imageName);
+        }
+
+        // Wenn sich die Randfarbe ändert und Hatch "Auto"-Farbe nutzt → Image neu berechnen
+        if ((partial.color !== undefined) && next.hatch.type !== 'none' && next.hatch.color === '') {
+          const imageName = ensureHatchImage(map, next.hatch, next.color);
+          draw.setFeatureProperty(id, 'fillPattern', imageName);
+        }
+
+        // MapboxDraw Render erzwingen (setFeatureProperty triggert keinen Render)
+        const updated = draw.get(id);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (updated) draw.add(updated as any);
+      }
+      scheduleAutoSave();
+    },
+    [activeStyle, selectedFeatureIds, drawRef, mapRef, scheduleAutoSave],
+  );
+```
+
+- [ ] **Step 5: TypeScript-Fehler prüfen**
+
+Run: `pnpm --filter @bluelight-hub/frontend exec tsc --noEmit 2>&1 | head -20`
+
+Expected: Noch Fehler in `use-draw-control.ts` (referenziert noch `fillPattern`). Wird in Task 6 gefixt.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+git commit -m "✨(frontend): LagekarteView Hatch-Integration mit Migration (#637)"
+```
+
+---
+
+### Task 6: use-draw-control anpassen
+
+**Files:**
+- Modify: `packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts`
+
+- [ ] **Step 1: Import aktualisieren**
+
+Füge Import hinzu (am Anfang der Imports):
+
+```typescript
+import { ensureHatchImage } from '../drawing/hatch-patterns';
+```
+
+- [ ] **Step 2: handleCreate aktualisieren — Hatch-Properties auf neue Features setzen**
+
+Ersetze den Block in `handleCreate` wo Properties gesetzt werden (Zeilen 194–199):
+
+```typescript
+        // Alt:
+        draw.setFeatureProperty(featureId, 'color', currentStyle.color);
+        draw.setFeatureProperty(featureId, 'fillColor', currentStyle.fillColor);
+        draw.setFeatureProperty(featureId, 'strokeWidth', currentStyle.strokeWidth);
+        draw.setFeatureProperty(featureId, 'fillOpacity', currentStyle.fillOpacity);
+        draw.setFeatureProperty(featureId, 'fillPattern', currentStyle.fillPattern);
+        draw.setFeatureProperty(featureId, 'featureType', 'drawing');
+
+        // Neu:
+        draw.setFeatureProperty(featureId, 'color', currentStyle.color);
+        draw.setFeatureProperty(featureId, 'fillColor', currentStyle.fillColor);
+        draw.setFeatureProperty(featureId, 'strokeWidth', currentStyle.strokeWidth);
+        draw.setFeatureProperty(featureId, 'fillOpacity', currentStyle.fillOpacity);
+        draw.setFeatureProperty(featureId, 'hatch', JSON.stringify(currentStyle.hatch));
+        const map = mapRef.current?.getMap();
+        const imageName = ensureHatchImage(map, currentStyle.hatch, currentStyle.color);
+        draw.setFeatureProperty(featureId, 'fillPattern', imageName);
+        draw.setFeatureProperty(featureId, 'featureType', 'drawing');
+```
+
+Hinweis: `mapRef` ist bereits als Parameter in `useDrawControl` verfügbar (`UseDrawControlOptions.mapRef`), also über den Closure zugänglich.
+
+- [ ] **Step 3: TypeScript komplett prüfen**
+
+Run: `pnpm --filter @bluelight-hub/frontend exec tsc --noEmit`
+
+Expected: Keine Fehler. Alle alten `FillPattern`-Referenzen sind entfernt.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
+git commit -m "✨(frontend): use-draw-control mit HatchConfig (#637)"
+```
+
+---
+
+### Task 7: Endverifikation
+
+- [ ] **Step 1: Vollständiger TypeScript-Check**
+
+Run: `pnpm --filter @bluelight-hub/frontend exec tsc --noEmit`
+
+Expected: Keine Fehler.
+
+- [ ] **Step 2: Grep nach verwaisten FillPattern-Referenzen**
+
+Run: `grep -r "FillPattern\|fillPattern.*hatch-" packages/frontend/src/features/lagekarte/ --include="*.ts" --include="*.tsx" | grep -v node_modules | grep -v ".d.ts"`
+
+Expected: Keine Treffer auf den alten `FillPattern` Typ. `fillPattern` als Feature-Property-Name (in setFeatureProperty-Calls und draw-styles Filtern) ist korrekt — das ist der MapboxDraw Property-Name, nicht der alte Type.
+
+- [ ] **Step 3: Manueller Browser-Test**
+
+Checklist:
+1. Polygon zeichnen → Schraffur "Diagonal" auswählen → Muster sichtbar?
+2. "Anpassen..." öffnen → Abstand-Slider ziehen → Pattern ändert sich live?
+3. Stärke-Slider → Linien werden dicker/dünner?
+4. "Auto" Farbe deaktivieren → andere Farbe wählen → Schraffur ändert Farbe?
+5. Randfarbe ändern bei Auto-Farbe → Schraffur folgt?
+6. Deckkraft-Slider → Schraffur + Füllung werden beide transparent?
+7. Basislayer wechseln (OSM ↔ Satellite) → Schraffur bleibt?
+8. Feature deselektieren + wieder selektieren → alle Werte korrekt geladen?
+9. Undo/Redo mit Schraffur → funktioniert?
+
+- [ ] **Step 4: Abschluss-Commit (nur falls Fixes nötig)**
+
+```bash
+git add -A
+git commit -m "🐛(frontend): Hatch-Editor Verifikation Fixes (#637)"
+```

--- a/docs/superpowers/specs/2026-04-08-hatch-editor-design.md
+++ b/docs/superpowers/specs/2026-04-08-hatch-editor-design.md
@@ -1,0 +1,183 @@
+# Erweiterter Schraffur-Editor für Lagekarte
+
+**Datum:** 2026-04-08
+**Status:** Entwurf
+**Kontext:** Die Lagekarte-Zeichenwerkzeuge sollen detailliert konfigurierbare Schraffurmuster für Polygon-Flächen bekommen — Mustertyp, Abstand, Strichstärke und Farbe.
+
+## Ist-Zustand
+
+- 4 feste Pattern-Typen (diagonal, cross, horizontal, vertical) als Hardcoded Canvas-Images
+- Feste Linienfarbe (dunkelgrau), fester Abstand (12px), feste Strichstärke (1.5px)
+- 8 separate MapboxDraw-Layer (4 Muster × aktiv/inaktiv) weil fill-pattern fälschlicherweise als nicht data-driven angenommen wurde
+- `FillPattern` ist ein String-Enum: `'none' | 'hatch-diagonal' | 'hatch-cross' | ...`
+
+## Technische Erkenntnis
+
+MapLibre GL v5.22.0 unterstützt **data-driven `fill-pattern`** (`property-type: cross-faded-data-driven`, seit JS v0.49.0). Damit können die 8 Layer auf 2 reduziert werden (aktiv/inaktiv) und jedes Feature referenziert sein eigenes dynamisch generiertes Pattern-Image.
+
+## Datenmodell
+
+### HatchConfig (neu)
+
+```typescript
+interface HatchConfig {
+  /** Mustertyp */
+  type: 'none' | 'diagonal' | 'cross' | 'horizontal' | 'vertical';
+  /** Kachel-Größe / Linienabstand in Pixel (6–32, Default: 12) */
+  spacing: number;
+  /** Strichstärke der Schraffurlinien in Pixel (0.5–4, Default: 1.5) */
+  width: number;
+  /** Linienfarbe als Hex-String. Leer = Randfarbe des Features übernehmen */
+  color: string;
+}
+```
+
+### DrawingStyle (geändert)
+
+```typescript
+interface DrawingStyle {
+  color: string;
+  opacity: number;
+  strokeWidth: number;
+  strokeDasharray?: string;
+  fillColor: string;
+  fillOpacity: number;
+  hatch: HatchConfig;        // ersetzt fillPattern: FillPattern
+}
+
+const DEFAULT_DRAWING_STYLE: DrawingStyle = {
+  color: '#3b82f6',
+  opacity: 1,
+  strokeWidth: 2,
+  fillColor: '#3b82f6',
+  fillOpacity: 0.2,
+  hatch: { type: 'none', spacing: 12, width: 1.5, color: '' },
+};
+```
+
+### Feature-Property-Speicherung
+
+Auf dem GeoJSON-Feature werden zwei Properties gespeichert:
+
+- `hatch` — Serialisiertes `HatchConfig`-Objekt (JSON-String) für Persistenz und UI-Wiederherstellung
+- `fillPattern` — Berechneter Image-Name (z.B. `hatch-diagonal-12-1.5-ef4444`) für die MapLibre-Render-Expression
+
+`fillPattern` ist ein abgeleiteter Wert aus `hatch` + `color` (Fallback Randfarbe). Es wird bei jeder Hatch-Änderung neu berechnet.
+
+## Pattern-Image-Generierung
+
+### Deterministischer Image-Name
+
+```
+hatch-{type}-{spacing}-{width}-{colorHex}
+```
+
+Beispiele:
+- `hatch-diagonal-12-1.5-ef4444` — Diagonale, 12px Abstand, 1.5px Strich, Rot
+- `hatch-cross-8-2-1e293b` — Kreuz, 8px Abstand, 2px Strich, Dunkel
+
+### Dynamische Canvas-Erzeugung
+
+Die bestehende `hatch-patterns.ts` wird refactored:
+
+- Bisherige 4 feste Pattern-Creator werden zu einer einzigen parametrisierten Funktion `createHatchImage(config: HatchConfig, resolvedColor: string): ImageData`
+- `spacing` bestimmt die Canvas-Größe (Tile-Größe)
+- `width` bestimmt die Linienbreite
+- `resolvedColor` ist die finale Farbe (Hatch-Color oder Fallback Randfarbe)
+- Die Funktion erzeugt das nahtlos kachelbare Canvas-Pattern
+
+### Registrierung auf der Map
+
+- Neue Funktion `ensureHatchImage(map, config, resolvedColor): string` — gibt den Image-Namen zurück
+- Prüft mit `map.hasImage()` ob das Image bereits existiert
+- Generiert und registriert bei Bedarf
+- Wird in `handleStyleChange` aufgerufen wenn sich Hatch-Parameter ändern
+- Bei Style-Wechsel (Basislayer): Alle registrierten Hatch-Images erneut erzeugen
+
+#### Cleanup
+
+Alte, nicht mehr referenzierte Images werden nicht aktiv gelöscht. Die Anzahl ist durch die endlichen Parameterkombinationen begrenzt (Slider-Steps). Bei Style-Wechsel (der alle Images löscht) werden nur die aktuell benötigten neu registriert.
+
+## MapboxDraw Layer-Vereinfachung
+
+### Vorher (8 Layer)
+
+4 Muster × 2 States (aktiv/inaktiv), jeweils mit festem `fill-pattern` und Filter auf `user_fillPattern`.
+
+### Nachher (2 Layer)
+
+```javascript
+// Inaktiv
+{
+  id: 'gl-draw-polygon-hatch-inactive',
+  type: 'fill',
+  filter: ['all',
+    ['==', 'active', 'false'],
+    ['==', '$type', 'Polygon'],
+    ['!=', 'mode', 'static'],
+    ['has', 'user_fillPattern'],
+    ['!=', ['get', 'user_fillPattern'], ''],
+  ],
+  paint: {
+    'fill-pattern': ['get', 'user_fillPattern'],
+    'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.2],
+  },
+}
+
+// Aktiv (analog mit active = true)
+```
+
+Ein einzelner Layer pro State, der den Image-Namen direkt aus dem Feature liest.
+
+## UI-Design (Aufklapp-Sektion)
+
+### Layout im DrawStylePanel
+
+```
+[Farbe-Swatches]
+[Linienstärke: Dünn | Mittel | Dick]
+[Deckkraft: ====|====== 20%]
+[Schraffur]
+  [/] [X] [=] [||] [∅]     ← Muster-Buttons
+  ▼ Anpassen...              ← Disclosure (nur wenn Muster != none)
+  ┌─────────────────────┐
+  │ Abstand    ====|=  12px │
+  │ Stärke     ==|==  1.5px │
+  │ Farbe  [Auto ✓] [●●●●] │
+  └─────────────────────┘
+[Beschriftung]               ← nur für Text-Features
+```
+
+### Interaktionsverhalten
+
+- **Muster-Buttons**: Klick setzt `hatch.type`. Bei Wechsel von `none` zu einem Muster wird die Aufklapp-Sektion automatisch **nicht** geöffnet (erst bei Klick auf "Anpassen...").
+- **"Anpassen..."**: Toggle-Button, öffnet/schließt die Detail-Sektion. Nur sichtbar wenn `hatch.type !== 'none'`.
+- **Abstand-Slider**: Range 6–32, Step 2, zeigt Wert in px
+- **Stärke-Slider**: Range 0.5–4, Step 0.5, zeigt Wert in px
+- **Farbe**: "Auto"-Checkbox (= Randfarbe übernehmen) + gleiche Farb-Swatches wie oben. Auto ist Default. Deaktiviert zeigt separate Farbauswahl.
+- Alle Änderungen werden sofort angewendet (Live-Preview via `draw.add()` Render-Trick).
+
+### State-Management
+
+Der Aufklapp-Status ("Anpassen..." offen/zu) ist lokaler UI-State (`useState` im DrawStylePanel), kein persistierter Wert. Er resettet beim Feature-Wechsel.
+
+## Migration
+
+### Abwärtskompatibilität
+
+Features mit altem `fillPattern`-Format (z.B. `'hatch-diagonal'`) müssen weiterhin funktionieren:
+
+- Beim Laden eines alten Features: Wenn `fillPattern` ein alter Enum-Wert ist und kein `hatch`-Property existiert, wird ein `HatchConfig` mit Default-Werten erzeugt (`spacing: 12, width: 1.5, color: ''`).
+- Der alte `fillPattern`-Wert wird in den neuen `hatch.type` konvertiert (Strip `hatch-` Prefix).
+- Diese Konversion passiert in LagekarteView beim Feature-Selektion und im useDrawControl beim initialen Laden.
+
+## Betroffene Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `drawing/types.ts` | `HatchConfig` Interface, `DrawingStyle.hatch` statt `fillPattern` |
+| `drawing/hatch-patterns.ts` | Parametrisierte Image-Generierung, `ensureHatchImage()` |
+| `drawing/draw-styles.ts` | 8 Layer → 2 Layer, data-driven `fill-pattern` |
+| `DrawStylePanel.molecule.tsx` | Aufklapp-Sektion mit Slidern + Farbauswahl |
+| `LagekarteView.tsx` | Hatch-Config lesen/schreiben, Image-Registrierung, Migration |
+| `use-draw-control.ts` | `hatch` + `fillPattern` auf neue Features setzen |

--- a/packages/frontend/src/features/lagekarte/api/index.ts
+++ b/packages/frontend/src/features/lagekarte/api/index.ts
@@ -1,2 +1,3 @@
 export * from './queries';
 export * from './use-lagekarte';
+export * from './use-save-lagekarte-state';

--- a/packages/frontend/src/features/lagekarte/api/use-save-lagekarte-state.ts
+++ b/packages/frontend/src/features/lagekarte/api/use-save-lagekarte-state.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { FeatureCollection } from 'geojson';
+import { api } from '@/shared';
+import { LAGEKARTE_QUERY_KEYS } from './queries';
+
+/**
+ * Mutation Hook zum Speichern des Lagekarte-Zeichnungs-States
+ *
+ * Sendet eine GeoJSON FeatureCollection an das Backend und
+ * invalidiert anschließend den Lagekarte-Cache.
+ */
+export function useSaveLagekarteState(einsatzId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (state: FeatureCollection) => {
+      return api.lagekarte().lagekarteControllerSaveLagekarteStateVAlpha({
+        einsatzId,
+        saveLagekarteStateDto: { einsatzId, state: state as unknown as object },
+      });
+    },
+    onSuccess: () => {
+      // Cache für die nächste Query-Abfrage invalidieren
+      queryClient.invalidateQueries({
+        queryKey: LAGEKARTE_QUERY_KEYS.byEinsatz(einsatzId),
+      });
+    },
+  });
+}

--- a/packages/frontend/src/features/lagekarte/api/use-save-lagekarte-state.ts
+++ b/packages/frontend/src/features/lagekarte/api/use-save-lagekarte-state.ts
@@ -19,11 +19,13 @@ export function useSaveLagekarteState(einsatzId: string) {
         saveLagekarteStateDto: { einsatzId, state: state as unknown as object },
       });
     },
-    onSuccess: () => {
-      // Cache für die nächste Query-Abfrage invalidieren
-      queryClient.invalidateQueries({
-        queryKey: LAGEKARTE_QUERY_KEYS.byEinsatz(einsatzId),
-      });
+    onSuccess: (_data, savedState) => {
+      // Cache optimistisch aktualisieren (kein Refetch nötig)
+      queryClient.setQueryData(
+        LAGEKARTE_QUERY_KEYS.byEinsatz(einsatzId),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (old: any) => (old ? { ...old, state: savedState } : old),
+      );
     },
   });
 }

--- a/packages/frontend/src/features/lagekarte/drawing/custom-modes/freehand.mode.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/custom-modes/freehand.mode.ts
@@ -5,11 +5,17 @@
  * Implementiert das MapboxDraw Custom Mode Interface.
  */
 
+/** Interner State des Freihand-Modus */
+interface FreehandState {
+  line: { id: string; coordinates: number[][]; addCoordinate: (idx: number, lng: number, lat: number) => void };
+  isDrawing: boolean;
+}
+
 // MapboxDraw Custom Mode Interface
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const FreehandMode: any = {};
 
-FreehandMode.onSetup = function () {
+FreehandMode.onSetup = function (): FreehandState {
   const line = this.newFeature({
     type: 'Feature',
     geometry: { type: 'LineString', coordinates: [] },
@@ -21,19 +27,18 @@ FreehandMode.onSetup = function () {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-FreehandMode.onMouseDown = function (state: any, e: any) {
+FreehandMode.onMouseDown = function (state: FreehandState, e: any) {
   state.isDrawing = true;
   state.line.addCoordinate(0, e.lngLat.lng, e.lngLat.lat);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-FreehandMode.onMouseMove = function (state: any, e: any) {
+FreehandMode.onMouseMove = function (state: FreehandState, e: any) {
   if (!state.isDrawing) return;
   state.line.addCoordinate(state.line.coordinates.length, e.lngLat.lng, e.lngLat.lat);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-FreehandMode.onMouseUp = function (state: any) {
+FreehandMode.onMouseUp = function (state: FreehandState) {
   if (!state.isDrawing) return;
   state.isDrawing = false;
 
@@ -45,12 +50,11 @@ FreehandMode.onMouseUp = function (state: any) {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-FreehandMode.toDisplayFeatures = function (_state: any, geojson: any, display: any) {
+FreehandMode.toDisplayFeatures = function (_state: FreehandState, geojson: any, display: any) {
   display(geojson);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-FreehandMode.onStop = function (state: any) {
+FreehandMode.onStop = function (state: FreehandState) {
   if (state.line.coordinates.length < 2) {
     this.deleteFeature(state.line.id);
   }

--- a/packages/frontend/src/features/lagekarte/drawing/custom-modes/freehand.mode.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/custom-modes/freehand.mode.ts
@@ -23,6 +23,8 @@ FreehandMode.onSetup = function (): FreehandState {
   });
   this.addFeature(line);
   this.setActionableState({ trash: true, combineFeatures: false, uncombineFeatures: false });
+  // dragPan deaktivieren, damit onMouseMove auch bei gedrückter Maustaste feuert
+  this.map.dragPan.disable();
   return { line, isDrawing: false };
 };
 
@@ -32,8 +34,9 @@ FreehandMode.onMouseDown = function (state: FreehandState, e: any) {
   state.line.addCoordinate(0, e.lngLat.lng, e.lngLat.lat);
 };
 
+// onDrag feuert bei Mausbewegung MIT gedrückter Taste (onMouseMove nur OHNE)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-FreehandMode.onMouseMove = function (state: FreehandState, e: any) {
+FreehandMode.onDrag = function (state: FreehandState, e: any) {
   if (!state.isDrawing) return;
   state.line.addCoordinate(state.line.coordinates.length, e.lngLat.lng, e.lngLat.lat);
 };
@@ -45,7 +48,12 @@ FreehandMode.onMouseUp = function (state: FreehandState) {
   // Feature finalisieren wenn genügend Koordinaten
   if (state.line.coordinates.length < 2) {
     this.deleteFeature(state.line.id);
+  } else {
+    // draw.create explizit feuern (wie built-in Modes, z.B. draw_point)
+    // suppressAPIEvents=true verhindert automatisches Feuern bei addFeature
+    this.fire('draw.create', { features: [state.line.toGeoJSON()] });
   }
+  this.map.dragPan.enable();
   this.changeMode('simple_select', { featureIds: [state.line.id] });
 };
 
@@ -58,6 +66,7 @@ FreehandMode.onStop = function (state: FreehandState) {
   if (state.line.coordinates.length < 2) {
     this.deleteFeature(state.line.id);
   }
+  this.map.dragPan.enable();
 };
 
 export { FreehandMode };

--- a/packages/frontend/src/features/lagekarte/drawing/custom-modes/freehand.mode.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/custom-modes/freehand.mode.ts
@@ -1,0 +1,59 @@
+/**
+ * Freihand-Zeichenmodus für MapboxDraw
+ *
+ * Zeichnet einen LineString durch Mausbewegung bei gedrückter Maustaste.
+ * Implementiert das MapboxDraw Custom Mode Interface.
+ */
+
+// MapboxDraw Custom Mode Interface
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const FreehandMode: any = {};
+
+FreehandMode.onSetup = function () {
+  const line = this.newFeature({
+    type: 'Feature',
+    geometry: { type: 'LineString', coordinates: [] },
+    properties: { featureType: 'drawing' },
+  });
+  this.addFeature(line);
+  this.setActionableState({ trash: true, combineFeatures: false, uncombineFeatures: false });
+  return { line, isDrawing: false };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+FreehandMode.onMouseDown = function (state: any, e: any) {
+  state.isDrawing = true;
+  state.line.addCoordinate(0, e.lngLat.lng, e.lngLat.lat);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+FreehandMode.onMouseMove = function (state: any, e: any) {
+  if (!state.isDrawing) return;
+  state.line.addCoordinate(state.line.coordinates.length, e.lngLat.lng, e.lngLat.lat);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+FreehandMode.onMouseUp = function (state: any) {
+  if (!state.isDrawing) return;
+  state.isDrawing = false;
+
+  // Feature finalisieren wenn genügend Koordinaten
+  if (state.line.coordinates.length < 2) {
+    this.deleteFeature(state.line.id);
+  }
+  this.changeMode('simple_select', { featureIds: [state.line.id] });
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+FreehandMode.toDisplayFeatures = function (_state: any, geojson: any, display: any) {
+  display(geojson);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+FreehandMode.onStop = function (state: any) {
+  if (state.line.coordinates.length < 2) {
+    this.deleteFeature(state.line.id);
+  }
+};
+
+export { FreehandMode };

--- a/packages/frontend/src/features/lagekarte/drawing/draw-styles.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/draw-styles.ts
@@ -14,7 +14,7 @@ export const CUSTOM_DRAW_STYLES: object[] = [
     paint: {
       'fill-color': ['coalesce', ['get', 'user_fillColor'], '#3b82f6'],
       'fill-outline-color': ['coalesce', ['get', 'user_color'], '#3b82f6'],
-      'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.2],
+      'fill-opacity': ['case', ['==', ['get', 'user_fillEnabled'], false], 0, ['coalesce', ['get', 'user_fillOpacity'], 0.2]],
     },
   },
   // Polygon-Füllung (aktiv)
@@ -25,16 +25,17 @@ export const CUSTOM_DRAW_STYLES: object[] = [
     paint: {
       'fill-color': ['coalesce', ['get', 'user_fillColor'], '#fbbf24'],
       'fill-outline-color': ['coalesce', ['get', 'user_color'], '#fbbf24'],
-      'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.3],
+      'fill-opacity': ['case', ['==', ['get', 'user_fillEnabled'], false], 0, ['coalesce', ['get', 'user_fillOpacity'], 0.3]],
     },
   },
   // Polygon-Schraffur (inaktiv) — data-driven fill-pattern, ein Layer für alle Muster
+  // fill-pattern erwartet resolvedImage → ['image', ...] Wrapper nötig
   {
     id: 'gl-draw-polygon-hatch-inactive',
     type: 'fill',
-    filter: ['all', ['==', 'active', 'false'], ['==', '$type', 'Polygon'], ['!=', 'mode', 'static'], ['has', 'user_fillPattern'], ['!=', ['get', 'user_fillPattern'], '']],
+    filter: ['all', ['==', 'active', 'false'], ['==', '$type', 'Polygon'], ['!=', 'mode', 'static'], ['has', 'user_fillPattern'], ['!=', 'user_fillPattern', '']],
     paint: {
-      'fill-pattern': ['get', 'user_fillPattern'],
+      'fill-pattern': ['image', ['get', 'user_fillPattern']],
       'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.2],
     },
   },
@@ -42,9 +43,9 @@ export const CUSTOM_DRAW_STYLES: object[] = [
   {
     id: 'gl-draw-polygon-hatch-active',
     type: 'fill',
-    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon'], ['has', 'user_fillPattern'], ['!=', ['get', 'user_fillPattern'], '']],
+    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon'], ['has', 'user_fillPattern'], ['!=', 'user_fillPattern', '']],
     paint: {
-      'fill-pattern': ['get', 'user_fillPattern'],
+      'fill-pattern': ['image', ['get', 'user_fillPattern']],
       'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.2],
     },
   },

--- a/packages/frontend/src/features/lagekarte/drawing/draw-styles.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/draw-styles.ts
@@ -25,7 +25,27 @@ export const CUSTOM_DRAW_STYLES: object[] = [
     paint: {
       'fill-color': ['coalesce', ['get', 'user_fillColor'], '#fbbf24'],
       'fill-outline-color': ['coalesce', ['get', 'user_color'], '#fbbf24'],
-      'fill-opacity': 0.3,
+      'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.3],
+    },
+  },
+  // Polygon-Schraffur (inaktiv) — data-driven fill-pattern, ein Layer für alle Muster
+  {
+    id: 'gl-draw-polygon-hatch-inactive',
+    type: 'fill',
+    filter: ['all', ['==', 'active', 'false'], ['==', '$type', 'Polygon'], ['!=', 'mode', 'static'], ['has', 'user_fillPattern'], ['!=', ['get', 'user_fillPattern'], '']],
+    paint: {
+      'fill-pattern': ['get', 'user_fillPattern'],
+      'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.2],
+    },
+  },
+  // Polygon-Schraffur (aktiv)
+  {
+    id: 'gl-draw-polygon-hatch-active',
+    type: 'fill',
+    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon'], ['has', 'user_fillPattern'], ['!=', ['get', 'user_fillPattern'], '']],
+    paint: {
+      'fill-pattern': ['get', 'user_fillPattern'],
+      'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.2],
     },
   },
   // Polygon-Kontur (inaktiv)

--- a/packages/frontend/src/features/lagekarte/drawing/draw-styles.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/draw-styles.ts
@@ -37,6 +37,8 @@ export const CUSTOM_DRAW_STYLES: object[] = [
     paint: {
       'line-color': ['coalesce', ['get', 'user_color'], '#3b82f6'],
       'line-width': ['coalesce', ['get', 'user_strokeWidth'], 2],
+      // Hinweis: line-dasharray unterstützt keine data-driven Expressions in MapboxDraw,
+      // daher wird hier ein fester Wert verwendet
       'line-dasharray': [1],
     },
   },

--- a/packages/frontend/src/features/lagekarte/drawing/draw-styles.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/draw-styles.ts
@@ -1,0 +1,139 @@
+/**
+ * Benutzerdefinierte MapboxDraw-Styles
+ *
+ * Unterstützt farbige Zeichnungsobjekte über user_ Properties.
+ * MapboxDraw speichert benutzerdefinierte Properties intern mit dem Präfix `user_`.
+ */
+
+export const CUSTOM_DRAW_STYLES: object[] = [
+  // Polygon-Füllung (inaktiv)
+  {
+    id: 'gl-draw-polygon-fill-inactive',
+    type: 'fill',
+    filter: ['all', ['==', 'active', 'false'], ['==', '$type', 'Polygon'], ['!=', 'mode', 'static']],
+    paint: {
+      'fill-color': ['coalesce', ['get', 'user_fillColor'], '#3b82f6'],
+      'fill-outline-color': ['coalesce', ['get', 'user_color'], '#3b82f6'],
+      'fill-opacity': ['coalesce', ['get', 'user_fillOpacity'], 0.2],
+    },
+  },
+  // Polygon-Füllung (aktiv)
+  {
+    id: 'gl-draw-polygon-fill-active',
+    type: 'fill',
+    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon']],
+    paint: {
+      'fill-color': ['coalesce', ['get', 'user_fillColor'], '#fbbf24'],
+      'fill-outline-color': ['coalesce', ['get', 'user_color'], '#fbbf24'],
+      'fill-opacity': 0.3,
+    },
+  },
+  // Polygon-Kontur (inaktiv)
+  {
+    id: 'gl-draw-polygon-stroke-inactive',
+    type: 'line',
+    filter: ['all', ['==', 'active', 'false'], ['==', '$type', 'Polygon'], ['!=', 'mode', 'static']],
+    layout: { 'line-cap': 'round', 'line-join': 'round' },
+    paint: {
+      'line-color': ['coalesce', ['get', 'user_color'], '#3b82f6'],
+      'line-width': ['coalesce', ['get', 'user_strokeWidth'], 2],
+      'line-dasharray': [1],
+    },
+  },
+  // Polygon-Kontur (aktiv)
+  {
+    id: 'gl-draw-polygon-stroke-active',
+    type: 'line',
+    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon']],
+    layout: { 'line-cap': 'round', 'line-join': 'round' },
+    paint: {
+      'line-color': ['coalesce', ['get', 'user_color'], '#fbbf24'],
+      'line-width': ['coalesce', ['get', 'user_strokeWidth'], 2],
+    },
+  },
+  // Linie (inaktiv)
+  {
+    id: 'gl-draw-line-inactive',
+    type: 'line',
+    filter: ['all', ['==', 'active', 'false'], ['==', '$type', 'LineString'], ['!=', 'mode', 'static']],
+    layout: { 'line-cap': 'round', 'line-join': 'round' },
+    paint: {
+      'line-color': ['coalesce', ['get', 'user_color'], '#3b82f6'],
+      'line-width': ['coalesce', ['get', 'user_strokeWidth'], 2],
+    },
+  },
+  // Linie (aktiv)
+  {
+    id: 'gl-draw-line-active',
+    type: 'line',
+    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'LineString']],
+    layout: { 'line-cap': 'round', 'line-join': 'round' },
+    paint: {
+      'line-color': ['coalesce', ['get', 'user_color'], '#fbbf24'],
+      'line-width': ['coalesce', ['get', 'user_strokeWidth'], 2],
+    },
+  },
+  // Punkt (inaktiv)
+  {
+    id: 'gl-draw-point-inactive',
+    type: 'circle',
+    filter: ['all', ['==', 'active', 'false'], ['==', '$type', 'Point'], ['==', 'meta', 'feature'], ['!=', 'mode', 'static']],
+    paint: {
+      'circle-radius': 6,
+      'circle-color': ['coalesce', ['get', 'user_color'], '#3b82f6'],
+      'circle-stroke-width': 2,
+      'circle-stroke-color': '#ffffff',
+    },
+  },
+  // Punkt (aktiv)
+  {
+    id: 'gl-draw-point-active',
+    type: 'circle',
+    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Point'], ['==', 'meta', 'feature']],
+    paint: {
+      'circle-radius': 8,
+      'circle-color': ['coalesce', ['get', 'user_color'], '#fbbf24'],
+      'circle-stroke-width': 2,
+      'circle-stroke-color': '#ffffff',
+    },
+  },
+  // Vertex-Punkte (Bearbeitungsgriffe)
+  {
+    id: 'gl-draw-polygon-and-line-vertex-inactive',
+    type: 'circle',
+    filter: ['all', ['==', 'meta', 'vertex'], ['==', '$type', 'Point'], ['!=', 'mode', 'static']],
+    paint: {
+      'circle-radius': 4,
+      'circle-color': '#ffffff',
+      'circle-stroke-width': 2,
+      'circle-stroke-color': '#3b82f6',
+    },
+  },
+  // Midpoint-Punkte
+  {
+    id: 'gl-draw-polygon-midpoint',
+    type: 'circle',
+    filter: ['all', ['==', 'meta', 'midpoint'], ['==', '$type', 'Point']],
+    paint: {
+      'circle-radius': 3,
+      'circle-color': '#3b82f6',
+    },
+  },
+  // Text-Label-Layer (für draw_text Modus Features)
+  {
+    id: 'gl-draw-text-label',
+    type: 'symbol',
+    filter: ['all', ['==', '$type', 'Point'], ['has', 'user_label'], ['==', 'meta', 'feature']],
+    layout: {
+      'text-field': ['get', 'user_label'],
+      'text-size': 14,
+      'text-anchor': 'center',
+      'text-allow-overlap': true,
+    },
+    paint: {
+      'text-color': ['coalesce', ['get', 'user_color'], '#1e293b'],
+      'text-halo-color': '#ffffff',
+      'text-halo-width': 2,
+    },
+  },
+];

--- a/packages/frontend/src/features/lagekarte/drawing/hatch-patterns.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/hatch-patterns.ts
@@ -1,0 +1,135 @@
+/**
+ * Dynamische Schraffurmuster-Generierung für die Lagekarte
+ *
+ * Erzeugt parametrisierte Canvas-basierte Schraffurmuster und registriert
+ * sie on-demand auf der MapLibre-Instanz. Jede Parameterkombination
+ * (Typ, Abstand, Stärke, Farbe) erzeugt ein eigenes Image.
+ */
+
+import type { Map as MaplibreMap } from 'maplibre-gl';
+import type { HatchConfig, HatchType } from './types';
+
+/**
+ * Erzeugt einen deterministischen Image-Namen aus der Hatch-Konfiguration.
+ */
+export function buildHatchImageName(type: HatchType, spacing: number, width: number, resolvedColor: string): string {
+  const hex = resolvedColor.replace('#', '');
+  return `hatch-${type}-${spacing}-${width}-${hex}`;
+}
+
+/**
+ * Erzeugt ein nahtlos kachelbares Canvas-Pattern als ImageData.
+ */
+export function createHatchImage(type: HatchType, spacing: number, width: number, color: string): ImageData {
+  const canvas = document.createElement('canvas');
+  canvas.width = spacing;
+  canvas.height = spacing;
+  const ctx = canvas.getContext('2d')!;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = width;
+
+  switch (type) {
+    case 'diagonal':
+      drawDiagonal(ctx, spacing);
+      break;
+    case 'cross':
+      drawDiagonal(ctx, spacing);
+      drawReverseDiagonal(ctx, spacing);
+      break;
+    case 'horizontal':
+      drawHorizontal(ctx, spacing);
+      break;
+    case 'vertical':
+      drawVertical(ctx, spacing);
+      break;
+    default:
+      break;
+  }
+
+  return ctx.getImageData(0, 0, spacing, spacing);
+}
+
+function drawDiagonal(ctx: CanvasRenderingContext2D, size: number): void {
+  for (const offset of [-size, 0, size]) {
+    ctx.beginPath();
+    ctx.moveTo(offset, size);
+    ctx.lineTo(size + offset, 0);
+    ctx.stroke();
+  }
+}
+
+function drawReverseDiagonal(ctx: CanvasRenderingContext2D, size: number): void {
+  for (const offset of [-size, 0, size]) {
+    ctx.beginPath();
+    ctx.moveTo(offset, 0);
+    ctx.lineTo(size + offset, size);
+    ctx.stroke();
+  }
+}
+
+function drawHorizontal(ctx: CanvasRenderingContext2D, size: number): void {
+  const half = size / 2;
+  for (let y = half / 2; y < size; y += half) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(size, y);
+    ctx.stroke();
+  }
+}
+
+function drawVertical(ctx: CanvasRenderingContext2D, size: number): void {
+  const half = size / 2;
+  for (let x = half / 2; x < size; x += half) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, size);
+    ctx.stroke();
+  }
+}
+
+const registeredImages = new Set<string>();
+
+/**
+ * Stellt sicher, dass ein Hatch-Image auf der Map registriert ist.
+ */
+export function ensureHatchImage(map: MaplibreMap | undefined, config: HatchConfig, fallbackColor: string): string {
+  if (!map || config.type === 'none') return '';
+
+  const resolvedColor = config.color || fallbackColor;
+  const name = buildHatchImageName(config.type, config.spacing, config.width, resolvedColor);
+
+  if (!map.hasImage(name)) {
+    map.addImage(name, createHatchImage(config.type, config.spacing, config.width, resolvedColor));
+    registeredImages.add(name);
+  }
+
+  return name;
+}
+
+/**
+ * Re-registriert alle bekannten Hatch-Images nach einem Style-Wechsel.
+ */
+export function reregisterHatchImages(map: MaplibreMap | undefined): void {
+  if (!map) return;
+
+  for (const name of registeredImages) {
+    if (map.hasImage(name)) continue;
+    const parts = name.split('-');
+    if (parts.length < 5) continue;
+    const type = parts[1] as HatchType;
+    const spacing = Number(parts[2]);
+    const width = Number(parts[3]);
+    const hex = `#${parts.slice(4).join('-')}`;
+    map.addImage(name, createHatchImage(type, spacing, width, hex));
+  }
+}
+
+/**
+ * Migriert einen alten FillPattern-String zu einem HatchConfig.
+ */
+export function migrateLegacyFillPattern(fillPattern: string): HatchConfig | null {
+  const legacyTypes = ['hatch-diagonal', 'hatch-cross', 'hatch-horizontal', 'hatch-vertical'];
+  if (!legacyTypes.includes(fillPattern)) return null;
+  const type = fillPattern.replace('hatch-', '') as HatchType;
+  return { type, spacing: 12, width: 1.5, color: '' };
+}

--- a/packages/frontend/src/features/lagekarte/drawing/types.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/types.ts
@@ -18,7 +18,7 @@ export interface DrawingStyle {
   opacity: number;
   /** Linienstärke in Pixel */
   strokeWidth: number;
-  /** Strichmuster, z.B. '5,5' */
+  /** Strichmuster, z.B. '5,5' — Hinweis: Nicht data-driven per Feature unterstützt (MapboxDraw-Limitation) */
   strokeDasharray?: string;
   /** Füllfarbe (Hex) */
   fillColor: string;

--- a/packages/frontend/src/features/lagekarte/drawing/types.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Typen für die Lagekarte-Zeichenwerkzeuge
+ *
+ * Gemeinsame Typen für Draw-Modi, Styles und Feature-Properties.
+ */
+
+/** Verfügbare Zeichenmodi */
+export type DrawMode = 'idle' | 'select' | 'draw_point' | 'draw_line_string' | 'draw_polygon' | 'draw_freehand' | 'draw_text' | 'osm_mark';
+
+/** Status einer OSM-Markierung */
+export type OsmMarkierungStatus = 'betroffen' | 'gesperrt' | 'evakuiert';
+
+/** Stil-Eigenschaften für Zeichnungsobjekte */
+export interface DrawingStyle {
+  /** Linienfarbe (Hex) */
+  color: string;
+  /** Linien-Deckkraft (0–1) */
+  opacity: number;
+  /** Linienstärke in Pixel */
+  strokeWidth: number;
+  /** Strichmuster, z.B. '5,5' */
+  strokeDasharray?: string;
+  /** Füllfarbe (Hex) */
+  fillColor: string;
+  /** Füll-Deckkraft (0–1) */
+  fillOpacity: number;
+}
+
+/** Standard-Stil für neue Zeichnungen */
+export const DEFAULT_DRAWING_STYLE: DrawingStyle = {
+  color: '#3b82f6',
+  opacity: 1,
+  strokeWidth: 2,
+  fillColor: '#3b82f6',
+  fillOpacity: 0.2,
+};
+
+/** Properties eines gezeichneten GeoJSON-Features */
+export interface DrawFeatureProperties {
+  /** Stil-Überschreibung für dieses Feature */
+  drawingStyle?: DrawingStyle;
+  /** Beschriftung (für Text-Features) */
+  label?: string;
+  /** Typ des Features */
+  featureType: 'drawing' | 'osm_marking';
+  /** OSM-Feature-ID (nur für OSM-Markierungen) */
+  osmFeatureId?: string;
+  /** OSM-Layer-ID (nur für OSM-Markierungen) */
+  osmLayerId?: string;
+  /** Markierungsstatus (nur für OSM-Markierungen) */
+  osmStatus?: OsmMarkierungStatus;
+}
+
+/** Farbzuordnung für OSM-Markierungsstatus */
+export const OSM_MARKING_COLORS: Record<OsmMarkierungStatus, string> = {
+  betroffen: '#fbbf24',
+  gesperrt: '#ef4444',
+  evakuiert: '#a855f7',
+};

--- a/packages/frontend/src/features/lagekarte/drawing/types.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/types.ts
@@ -45,6 +45,8 @@ export interface DrawingStyle {
   strokeDasharray?: string;
   /** Füllfarbe (Hex) */
   fillColor: string;
+  /** Farbfüllung aktiv */
+  fillEnabled: boolean;
   /** Füll-Deckkraft (0–1) */
   fillOpacity: number;
   /** Schraffur-Konfiguration */
@@ -57,6 +59,7 @@ export const DEFAULT_DRAWING_STYLE: DrawingStyle = {
   opacity: 1,
   strokeWidth: 2,
   fillColor: '#3b82f6',
+  fillEnabled: true,
   fillOpacity: 0.2,
   hatch: { ...DEFAULT_HATCH },
 };

--- a/packages/frontend/src/features/lagekarte/drawing/types.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/types.ts
@@ -10,6 +10,29 @@ export type DrawMode = 'idle' | 'select' | 'draw_point' | 'draw_line_string' | '
 /** Status einer OSM-Markierung */
 export type OsmMarkierungStatus = 'betroffen' | 'gesperrt' | 'evakuiert';
 
+/** Verfügbare Schraffur-Mustertypen */
+export type HatchType = 'none' | 'diagonal' | 'cross' | 'horizontal' | 'vertical';
+
+/** Konfiguration für Schraffurmuster */
+export interface HatchConfig {
+  /** Mustertyp */
+  type: HatchType;
+  /** Kachel-Größe / Linienabstand in Pixel (6–32) */
+  spacing: number;
+  /** Strichstärke der Schraffurlinien in Pixel (0.5–4) */
+  width: number;
+  /** Linienfarbe als Hex-String. Leer = Randfarbe des Features übernehmen */
+  color: string;
+}
+
+/** Standard-Schraffur-Konfiguration */
+export const DEFAULT_HATCH: HatchConfig = {
+  type: 'none',
+  spacing: 12,
+  width: 1.5,
+  color: '',
+};
+
 /** Stil-Eigenschaften für Zeichnungsobjekte */
 export interface DrawingStyle {
   /** Linienfarbe (Hex) */
@@ -24,6 +47,8 @@ export interface DrawingStyle {
   fillColor: string;
   /** Füll-Deckkraft (0–1) */
   fillOpacity: number;
+  /** Schraffur-Konfiguration */
+  hatch: HatchConfig;
 }
 
 /** Standard-Stil für neue Zeichnungen */
@@ -33,6 +58,7 @@ export const DEFAULT_DRAWING_STYLE: DrawingStyle = {
   strokeWidth: 2,
   fillColor: '#3b82f6',
   fillOpacity: 0.2,
+  hatch: { ...DEFAULT_HATCH },
 };
 
 /** Properties eines gezeichneten GeoJSON-Features */

--- a/packages/frontend/src/features/lagekarte/hooks/index.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './use-map-layer';
 export * from './use-map-detail';
 export * from './use-lagekarte-permissions';
 export * from './use-draw-control';
+export * from './use-osm-markierung';

--- a/packages/frontend/src/features/lagekarte/hooks/index.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './use-map-layer';
 export * from './use-map-detail';
 export * from './use-lagekarte-permissions';
+export * from './use-draw-control';

--- a/packages/frontend/src/features/lagekarte/hooks/index.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './use-map-layer';
 export * from './use-map-detail';
+export * from './use-lagekarte-permissions';

--- a/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
@@ -16,7 +16,7 @@ import { useLagekarte } from '../api/use-lagekarte';
 import { DRAW_FEATURE_LIMIT } from '../utils/map-config';
 import { CUSTOM_DRAW_STYLES } from '../drawing/draw-styles';
 import { FreehandMode } from '../drawing/custom-modes/freehand.mode';
-import type { DrawMode } from '../drawing/types';
+import type { DrawMode, DrawingStyle } from '../drawing/types';
 
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 
@@ -49,6 +49,8 @@ interface UseDrawControlOptions {
   canDraw: boolean;
   /** Ob die Karte vollständig geladen ist */
   isMapLoaded: boolean;
+  /** Ref auf den aktuellen Zeichenstil (wird auf neue Features angewendet) */
+  activeStyleRef: React.RefObject<DrawingStyle>;
 }
 
 interface UseDrawControlReturn {
@@ -81,7 +83,7 @@ const EMPTY_FC: FeatureCollection = { type: 'FeatureCollection', features: [] };
  * @param options - Konfiguration für den Draw-Control
  * @returns API zum Steuern des Zeichenmodus
  */
-export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseDrawControlOptions): UseDrawControlReturn {
+export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, activeStyleRef }: UseDrawControlOptions): UseDrawControlReturn {
   const drawRef = useRef<MapboxDraw | null>(null);
   const undoStack = useRef<FeatureCollection[]>([]);
   const redoStack = useRef<FeatureCollection[]>([]);
@@ -143,6 +145,7 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
 
     const draw = new MapboxDraw({
       displayControlsDefault: false,
+      userProperties: true,
       modes: {
         ...MapboxDraw.modes,
         draw_freehand: FreehandMode,
@@ -184,12 +187,21 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
         return;
       }
 
-      // Text-Modus: Standard-Label setzen
-      if (drawModeRef.current === 'draw_text' && e.features?.length > 0) {
+      // Aktuellen Stil auf das neue Feature anwenden
+      if (e.features?.length > 0) {
         const featureId = String(e.features[0].id);
-        draw.setFeatureProperty(featureId, 'label', 'Text');
+        const currentStyle = activeStyleRef.current;
+        draw.setFeatureProperty(featureId, 'color', currentStyle.color);
+        draw.setFeatureProperty(featureId, 'fillColor', currentStyle.fillColor);
+        draw.setFeatureProperty(featureId, 'strokeWidth', currentStyle.strokeWidth);
+        draw.setFeatureProperty(featureId, 'fillOpacity', currentStyle.fillOpacity);
         draw.setFeatureProperty(featureId, 'featureType', 'drawing');
-        setSelectedFeatures([featureId]);
+
+        // Text-Modus: Standard-Label setzen
+        if (drawModeRef.current === 'draw_text') {
+          draw.setFeatureProperty(featureId, 'label', 'Text');
+          setSelectedFeatures([featureId]);
+        }
       }
 
       // Undo-Snapshot: State VOR der Änderung auf den Stack pushen
@@ -199,6 +211,21 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
       lastKnownStateRef.current = draw.getAll() as FeatureCollection;
       updateStackState();
       scheduleAutoSave();
+
+      // Zeichenmodus nach Feature-Erstellung erneut aktivieren (kontinuierliches Zeichnen).
+      // Text-Modus ausgenommen: Feature bleibt selektiert für Label-Bearbeitung.
+      const currentMode = drawModeRef.current;
+      const continuousModes: DrawMode[] = ['draw_point', 'draw_line_string', 'draw_polygon', 'draw_freehand'];
+      if (continuousModes.includes(currentMode)) {
+        const targetMapboxMode = DRAW_MODE_MAP[currentMode];
+        setTimeout(() => {
+          try {
+            draw.changeMode(targetMapboxMode);
+          } catch {
+            // Draw-Instanz könnte bereits entfernt sein
+          }
+        }, 0);
+      }
     };
 
     const handleUpdate = () => {

--- a/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
@@ -195,6 +195,7 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, active
         draw.setFeatureProperty(featureId, 'color', currentStyle.color);
         draw.setFeatureProperty(featureId, 'fillColor', currentStyle.fillColor);
         draw.setFeatureProperty(featureId, 'strokeWidth', currentStyle.strokeWidth);
+        draw.setFeatureProperty(featureId, 'fillEnabled', currentStyle.fillEnabled);
         draw.setFeatureProperty(featureId, 'fillOpacity', currentStyle.fillOpacity);
         draw.setFeatureProperty(featureId, 'hatch', JSON.stringify(currentStyle.hatch));
         const map = mapRef.current?.getMap();

--- a/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
@@ -1,0 +1,406 @@
+/**
+ * Core Draw-Control Hook für die Lagekarte
+ *
+ * Verwaltet den gesamten MapboxDraw-Lifecycle: Initialisierung, Events,
+ * Undo/Redo, Auto-Save und Keyboard-Shortcuts.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { MapRef } from 'react-map-gl/maplibre';
+import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import type { FeatureCollection } from 'geojson';
+import { useStore } from '@tanstack/react-store';
+import { drawStore, setDrawMode, setSelectedFeatures } from '../stores/draw.store';
+import { useSaveLagekarteState } from '../api/use-save-lagekarte-state';
+import { useLagekarte } from '../api/use-lagekarte';
+import { DRAW_FEATURE_LIMIT } from '../utils/map-config';
+import { CUSTOM_DRAW_STYLES } from '../drawing/draw-styles';
+import { FreehandMode } from '../drawing/custom-modes/freehand.mode';
+import type { DrawMode } from '../drawing/types';
+
+import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
+
+/** Maximale Undo-Stack-Tiefe */
+const MAX_UNDO_DEPTH = 50;
+
+/** Debounce-Verzögerung für Auto-Save in ms */
+const AUTO_SAVE_DELAY = 2000;
+
+/**
+ * Mapping von DrawMode auf MapboxDraw-interne Modusnamen
+ */
+const DRAW_MODE_MAP: Record<DrawMode, string> = {
+  idle: 'simple_select',
+  select: 'simple_select',
+  draw_point: 'draw_point',
+  draw_line_string: 'draw_line_string',
+  draw_polygon: 'draw_polygon',
+  draw_freehand: 'draw_freehand',
+  draw_text: 'draw_point',
+  osm_mark: 'simple_select',
+};
+
+interface UseDrawControlOptions {
+  /** Referenz auf die MapLibre-GL-Instanz */
+  mapRef: React.RefObject<MapRef | null>;
+  /** Einsatz-ID für Persistierung */
+  einsatzId: string;
+  /** Ob der Nutzer Zeichnen darf */
+  canDraw: boolean;
+  /** Ob die Karte vollständig geladen ist */
+  isMapLoaded: boolean;
+}
+
+interface UseDrawControlReturn {
+  /** Letzte Aktion rückgängig machen */
+  undo: () => void;
+  /** Rückgängig gemachte Aktion wiederherstellen */
+  redo: () => void;
+  /** Ob Undo verfügbar ist */
+  canUndo: boolean;
+  /** Ob Redo verfügbar ist */
+  canRedo: boolean;
+  /** Ausgewählte Features löschen */
+  deleteSelected: () => void;
+  /** Zeichenmodus setzen */
+  setMode: (mode: DrawMode) => void;
+  /** Alle aktuellen Features als FeatureCollection */
+  getFeatures: () => FeatureCollection;
+}
+
+/** Leere FeatureCollection als Fallback */
+const EMPTY_FC: FeatureCollection = { type: 'FeatureCollection', features: [] };
+
+/**
+ * Verwaltet MapboxDraw-Lifecycle, Events, Undo/Redo und Auto-Save
+ *
+ * @param options - Konfiguration für den Draw-Control
+ * @returns API zum Steuern des Zeichenmodus
+ */
+export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseDrawControlOptions): UseDrawControlReturn {
+  const drawRef = useRef<MapboxDraw | null>(null);
+  const undoStack = useRef<FeatureCollection[]>([]);
+  const redoStack = useRef<FeatureCollection[]>([]);
+  const isUndoInProgress = useRef(false);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  const drawMode = useStore(drawStore, (s) => s.drawMode);
+
+  const { data: lagekarte } = useLagekarte(einsatzId);
+  const { mutate: saveState } = useSaveLagekarteState(einsatzId);
+
+  // Referenz auf lagekarte.state für Initialisierung (vermeidet Stale-Closure)
+  const initialStateRef = useRef<FeatureCollection | null>(null);
+  useEffect(() => {
+    if (lagekarte?.state) {
+      initialStateRef.current = lagekarte.state;
+    }
+  }, [lagekarte?.state]);
+
+  /**
+   * Undo/Redo-Stack-Status aktualisieren
+   */
+  const updateStackState = useCallback(() => {
+    setCanUndo(undoStack.current.length > 0);
+    setCanRedo(redoStack.current.length > 0);
+  }, []);
+
+  /**
+   * Aktuellen Zustand als Snapshot auf den Undo-Stack pushen
+   */
+  const pushUndoSnapshot = useCallback(() => {
+    const draw = drawRef.current;
+    if (!draw) return;
+
+    const snapshot = draw.getAll() as FeatureCollection;
+    undoStack.current.push(snapshot);
+
+    // Stack-Tiefe begrenzen
+    if (undoStack.current.length > MAX_UNDO_DEPTH) {
+      undoStack.current.shift();
+    }
+
+    // Redo-Stack leeren bei neuer Aktion
+    redoStack.current = [];
+    updateStackState();
+  }, [updateStackState]);
+
+  /**
+   * Auto-Save mit Debounce auslösen
+   */
+  const scheduleAutoSave = useCallback(() => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      const draw = drawRef.current;
+      if (!draw) return;
+      saveState(draw.getAll() as FeatureCollection);
+    }, AUTO_SAVE_DELAY);
+  }, [saveState]);
+
+  // ============================================
+  // MapboxDraw Initialisierung & Cleanup
+  // ============================================
+  useEffect(() => {
+    if (!isMapLoaded || !canDraw || !mapRef.current) return;
+
+    const map = mapRef.current.getMap();
+    if (!map) return;
+
+    const draw = new MapboxDraw({
+      displayControlsDefault: false,
+      modes: {
+        ...MapboxDraw.modes,
+        draw_freehand: FreehandMode,
+      },
+      styles: CUSTOM_DRAW_STYLES,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    map.addControl(draw as any);
+    drawRef.current = draw;
+
+    // Initialen State aus Backend laden
+    const initialData = initialStateRef.current;
+    if (initialData?.features?.length) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      draw.add(initialData as any);
+    }
+
+    // Initialen Snapshot für Undo
+    undoStack.current = [];
+    redoStack.current = [];
+
+    // ----------------------------------------
+    // Event-Handler
+    // ----------------------------------------
+    const handleCreate = () => {
+      if (isUndoInProgress.current) return;
+
+      // Feature-Limit prüfen
+      const allFeatures = draw.getAll();
+      if (allFeatures.features.length > DRAW_FEATURE_LIMIT) {
+        const lastFeature = allFeatures.features.at(-1);
+        if (lastFeature?.id) {
+          draw.delete(String(lastFeature.id));
+        }
+        console.warn(`Feature-Limit (${DRAW_FEATURE_LIMIT}) erreicht. Neues Feature wurde entfernt.`);
+        return;
+      }
+
+      pushUndoSnapshot();
+      scheduleAutoSave();
+    };
+
+    const handleUpdate = () => {
+      if (isUndoInProgress.current) return;
+      pushUndoSnapshot();
+      scheduleAutoSave();
+    };
+
+    const handleDelete = () => {
+      if (isUndoInProgress.current) return;
+      pushUndoSnapshot();
+      scheduleAutoSave();
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleSelectionChange = (e: any) => {
+      const ids = (e.features ?? []).map((f: { id?: string }) => String(f.id ?? ''));
+      setSelectedFeatures(ids);
+    };
+
+    map.on('draw.create', handleCreate);
+    map.on('draw.update', handleUpdate);
+    map.on('draw.delete', handleDelete);
+    map.on('draw.selectionchange', handleSelectionChange);
+
+    return () => {
+      // Timer aufräumen
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+
+      // Event-Handler entfernen
+      map.off('draw.create', handleCreate);
+      map.off('draw.update', handleUpdate);
+      map.off('draw.delete', handleDelete);
+      map.off('draw.selectionchange', handleSelectionChange);
+
+      // Control entfernen
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        map.removeControl(draw as any);
+      } catch {
+        // Map könnte bereits zerstört sein
+      }
+
+      drawRef.current = null;
+      undoStack.current = [];
+      redoStack.current = [];
+      setCanUndo(false);
+      setCanRedo(false);
+    };
+    // pushUndoSnapshot und scheduleAutoSave sind stabile Callbacks,
+    // aber wir listen sie trotzdem für Korrektheit
+  }, [isMapLoaded, canDraw, mapRef, pushUndoSnapshot, scheduleAutoSave]);
+
+  // ============================================
+  // Modus-Synchronisierung: Store → MapboxDraw
+  // ============================================
+  useEffect(() => {
+    const draw = drawRef.current;
+    if (!draw) return;
+
+    const targetMode = DRAW_MODE_MAP[drawMode];
+    if (!targetMode) return;
+
+    try {
+      draw.changeMode(targetMode);
+    } catch {
+      // Modus-Wechsel kann fehlschlagen wenn Draw nicht bereit ist
+    }
+  }, [drawMode]);
+
+  // ============================================
+  // Keyboard-Shortcuts
+  // ============================================
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Nicht in Eingabefeldern reagieren
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
+
+      const isMeta = e.metaKey || e.ctrlKey;
+
+      // Escape → Idle-Modus
+      if (e.key === 'Escape') {
+        setDrawMode('idle');
+        return;
+      }
+
+      // Delete / Backspace → Ausgewählte Features löschen
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        deleteSelected();
+        return;
+      }
+
+      // Ctrl/Cmd+Shift+Z → Redo
+      if (isMeta && e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        redo();
+        return;
+      }
+
+      // Ctrl/Cmd+Z → Undo
+      if (isMeta && e.key === 'z') {
+        e.preventDefault();
+        undo();
+        return;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- undo/redo sind stabile Refs
+  }, []);
+
+  // ============================================
+  // Öffentliche API
+  // ============================================
+
+  /**
+   * Rückgängig: Letzten Snapshot wiederherstellen
+   */
+  const undo = useCallback(() => {
+    const draw = drawRef.current;
+    if (!draw || undoStack.current.length === 0) return;
+
+    isUndoInProgress.current = true;
+
+    // Aktuellen Zustand auf Redo-Stack
+    const current = draw.getAll() as FeatureCollection;
+    redoStack.current.push(current);
+
+    // Vorherigen Zustand wiederherstellen
+    const prev = undoStack.current.pop()!;
+    draw.deleteAll();
+    if (prev.features.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      draw.add(prev as any);
+    }
+
+    isUndoInProgress.current = false;
+    updateStackState();
+    scheduleAutoSave();
+  }, [updateStackState, scheduleAutoSave]);
+
+  /**
+   * Wiederherstellen: Redo-Snapshot anwenden
+   */
+  const redo = useCallback(() => {
+    const draw = drawRef.current;
+    if (!draw || redoStack.current.length === 0) return;
+
+    isUndoInProgress.current = true;
+
+    // Aktuellen Zustand auf Undo-Stack
+    const current = draw.getAll() as FeatureCollection;
+    undoStack.current.push(current);
+
+    // Nächsten Zustand wiederherstellen
+    const next = redoStack.current.pop()!;
+    draw.deleteAll();
+    if (next.features.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      draw.add(next as any);
+    }
+
+    isUndoInProgress.current = false;
+    updateStackState();
+    scheduleAutoSave();
+  }, [updateStackState, scheduleAutoSave]);
+
+  /**
+   * Ausgewählte Features löschen
+   */
+  const deleteSelected = useCallback(() => {
+    const draw = drawRef.current;
+    if (!draw) return;
+
+    const selected = draw.getSelectedIds();
+    if (selected.length === 0) return;
+
+    pushUndoSnapshot();
+    draw.trash();
+    scheduleAutoSave();
+  }, [pushUndoSnapshot, scheduleAutoSave]);
+
+  /**
+   * Zeichenmodus setzen
+   */
+  const setMode = useCallback((mode: DrawMode) => {
+    setDrawMode(mode);
+  }, []);
+
+  /**
+   * Alle aktuellen Features als FeatureCollection zurückgeben
+   */
+  const getFeatures = useCallback((): FeatureCollection => {
+    const draw = drawRef.current;
+    if (!draw) return EMPTY_FC;
+    return draw.getAll() as FeatureCollection;
+  }, []);
+
+  return {
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    deleteSelected,
+    setMode,
+    getFeatures,
+  };
+}

--- a/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
@@ -66,6 +66,8 @@ interface UseDrawControlReturn {
   setMode: (mode: DrawMode) => void;
   /** Alle aktuellen Features als FeatureCollection */
   getFeatures: () => FeatureCollection;
+  /** Referenz auf die MapboxDraw-Instanz (für externe Nutzung, z.B. OSM-Markierung) */
+  drawRef: React.RefObject<MapboxDraw | null>;
 }
 
 /** Leere FeatureCollection als Fallback */
@@ -402,5 +404,6 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
     deleteSelected,
     setMode,
     getFeatures,
+    drawRef,
   };
 }

--- a/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
@@ -5,7 +5,7 @@
  * Undo/Redo, Auto-Save und Keyboard-Shortcuts.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import type { FeatureCollection } from 'geojson';
@@ -68,6 +68,8 @@ interface UseDrawControlReturn {
   getFeatures: () => FeatureCollection;
   /** Referenz auf die MapboxDraw-Instanz (für externe Nutzung, z.B. OSM-Markierung) */
   drawRef: React.RefObject<MapboxDraw | null>;
+  /** Auto-Save mit Debounce auslösen */
+  scheduleAutoSave: () => void;
 }
 
 /** Leere FeatureCollection als Fallback */
@@ -85,6 +87,8 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
   const redoStack = useRef<FeatureCollection[]>([]);
   const isUndoInProgress = useRef(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Letzter bekannter State VOR der aktuellen Änderung (für korrektes Undo) */
+  const lastKnownStateRef = useRef<FeatureCollection>(EMPTY_FC);
 
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
@@ -102,6 +106,12 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
     }
   }, [lagekarte?.state]);
 
+  // Ref für aktuellen drawMode (vermeidet Stale-Closure in Event-Handlern)
+  const drawModeRef = useRef(drawMode);
+  useEffect(() => {
+    drawModeRef.current = drawMode;
+  }, [drawMode]);
+
   /**
    * Undo/Redo-Stack-Status aktualisieren
    */
@@ -109,26 +119,6 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
     setCanUndo(undoStack.current.length > 0);
     setCanRedo(redoStack.current.length > 0);
   }, []);
-
-  /**
-   * Aktuellen Zustand als Snapshot auf den Undo-Stack pushen
-   */
-  const pushUndoSnapshot = useCallback(() => {
-    const draw = drawRef.current;
-    if (!draw) return;
-
-    const snapshot = draw.getAll() as FeatureCollection;
-    undoStack.current.push(snapshot);
-
-    // Stack-Tiefe begrenzen
-    if (undoStack.current.length > MAX_UNDO_DEPTH) {
-      undoStack.current.shift();
-    }
-
-    // Redo-Stack leeren bei neuer Aktion
-    redoStack.current = [];
-    updateStackState();
-  }, [updateStackState]);
 
   /**
    * Auto-Save mit Debounce auslösen
@@ -174,37 +164,60 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
     // Initialen Snapshot für Undo
     undoStack.current = [];
     redoStack.current = [];
+    lastKnownStateRef.current = draw.getAll() as FeatureCollection;
 
     // ----------------------------------------
     // Event-Handler
     // ----------------------------------------
-    const handleCreate = () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleCreate = (e: any) => {
       if (isUndoInProgress.current) return;
 
       // Feature-Limit prüfen
       const allFeatures = draw.getAll();
       if (allFeatures.features.length > DRAW_FEATURE_LIMIT) {
-        const lastFeature = allFeatures.features.at(-1);
-        if (lastFeature?.id) {
-          draw.delete(String(lastFeature.id));
+        const newFeatureId = e.features?.[0]?.id;
+        if (newFeatureId) {
+          draw.delete(String(newFeatureId));
         }
         console.warn(`Feature-Limit (${DRAW_FEATURE_LIMIT}) erreicht. Neues Feature wurde entfernt.`);
         return;
       }
 
-      pushUndoSnapshot();
+      // Text-Modus: Standard-Label setzen
+      if (drawModeRef.current === 'draw_text' && e.features?.length > 0) {
+        const featureId = String(e.features[0].id);
+        draw.setFeatureProperty(featureId, 'label', 'Text');
+        draw.setFeatureProperty(featureId, 'featureType', 'drawing');
+        setSelectedFeatures([featureId]);
+      }
+
+      // Undo-Snapshot: State VOR der Änderung auf den Stack pushen
+      undoStack.current.push(lastKnownStateRef.current);
+      if (undoStack.current.length > MAX_UNDO_DEPTH) undoStack.current.shift();
+      redoStack.current = [];
+      lastKnownStateRef.current = draw.getAll() as FeatureCollection;
+      updateStackState();
       scheduleAutoSave();
     };
 
     const handleUpdate = () => {
       if (isUndoInProgress.current) return;
-      pushUndoSnapshot();
+      undoStack.current.push(lastKnownStateRef.current);
+      if (undoStack.current.length > MAX_UNDO_DEPTH) undoStack.current.shift();
+      redoStack.current = [];
+      lastKnownStateRef.current = draw.getAll() as FeatureCollection;
+      updateStackState();
       scheduleAutoSave();
     };
 
     const handleDelete = () => {
       if (isUndoInProgress.current) return;
-      pushUndoSnapshot();
+      undoStack.current.push(lastKnownStateRef.current);
+      if (undoStack.current.length > MAX_UNDO_DEPTH) undoStack.current.shift();
+      redoStack.current = [];
+      lastKnownStateRef.current = draw.getAll() as FeatureCollection;
+      updateStackState();
       scheduleAutoSave();
     };
 
@@ -220,8 +233,12 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
     map.on('draw.selectionchange', handleSelectionChange);
 
     return () => {
-      // Timer aufräumen
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      // Ausstehenden Auto-Save sofort ausführen
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        const currentState = draw.getAll() as FeatureCollection;
+        saveState(currentState);
+      }
 
       // Event-Handler entfernen
       map.off('draw.create', handleCreate);
@@ -243,9 +260,7 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
       setCanUndo(false);
       setCanRedo(false);
     };
-    // pushUndoSnapshot und scheduleAutoSave sind stabile Callbacks,
-    // aber wir listen sie trotzdem für Korrektheit
-  }, [isMapLoaded, canDraw, mapRef, pushUndoSnapshot, scheduleAutoSave]);
+  }, [isMapLoaded, canDraw, mapRef, updateStackState, scheduleAutoSave, saveState]);
 
   // ============================================
   // Modus-Synchronisierung: Store → MapboxDraw
@@ -263,51 +278,6 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
       // Modus-Wechsel kann fehlschlagen wenn Draw nicht bereit ist
     }
   }, [drawMode]);
-
-  // ============================================
-  // Keyboard-Shortcuts
-  // ============================================
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Nicht in Eingabefeldern reagieren
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-        return;
-      }
-
-      const isMeta = e.metaKey || e.ctrlKey;
-
-      // Escape → Idle-Modus
-      if (e.key === 'Escape') {
-        setDrawMode('idle');
-        return;
-      }
-
-      // Delete / Backspace → Ausgewählte Features löschen
-      if (e.key === 'Delete' || e.key === 'Backspace') {
-        deleteSelected();
-        return;
-      }
-
-      // Ctrl/Cmd+Shift+Z → Redo
-      if (isMeta && e.shiftKey && e.key === 'z') {
-        e.preventDefault();
-        redo();
-        return;
-      }
-
-      // Ctrl/Cmd+Z → Undo
-      if (isMeta && e.key === 'z') {
-        e.preventDefault();
-        undo();
-        return;
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- undo/redo sind stabile Refs
-  }, []);
 
   // ============================================
   // Öffentliche API
@@ -334,6 +304,7 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
       draw.add(prev as any);
     }
 
+    lastKnownStateRef.current = draw.getAll() as FeatureCollection;
     isUndoInProgress.current = false;
     updateStackState();
     scheduleAutoSave();
@@ -360,6 +331,7 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
       draw.add(next as any);
     }
 
+    lastKnownStateRef.current = draw.getAll() as FeatureCollection;
     isUndoInProgress.current = false;
     updateStackState();
     scheduleAutoSave();
@@ -375,10 +347,78 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
     const selected = draw.getSelectedIds();
     if (selected.length === 0) return;
 
-    pushUndoSnapshot();
+    // Undo-Snapshot: State VOR dem Löschen
+    undoStack.current.push(lastKnownStateRef.current);
+    if (undoStack.current.length > MAX_UNDO_DEPTH) undoStack.current.shift();
+    redoStack.current = [];
+
     draw.trash();
+
+    lastKnownStateRef.current = draw.getAll() as FeatureCollection;
+    updateStackState();
     scheduleAutoSave();
-  }, [pushUndoSnapshot, scheduleAutoSave]);
+  }, [updateStackState, scheduleAutoSave]);
+
+  // ============================================
+  // Refs für Keyboard-Shortcuts (C1: Stale-Closure vermeiden)
+  // ============================================
+  const undoRef = useRef(undo);
+  const redoRef = useRef(redo);
+  const deleteSelectedRef = useRef(deleteSelected);
+
+  useEffect(() => {
+    undoRef.current = undo;
+  }, [undo]);
+  useEffect(() => {
+    redoRef.current = redo;
+  }, [redo]);
+  useEffect(() => {
+    deleteSelectedRef.current = deleteSelected;
+  }, [deleteSelected]);
+
+  // ============================================
+  // Keyboard-Shortcuts
+  // ============================================
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Nicht in Eingabefeldern reagieren
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
+
+      const isMeta = e.metaKey || e.ctrlKey;
+
+      // Escape → Idle-Modus
+      if (e.key === 'Escape') {
+        setDrawMode('idle');
+        return;
+      }
+
+      // Delete / Backspace → Ausgewählte Features löschen
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        deleteSelectedRef.current();
+        return;
+      }
+
+      // Ctrl/Cmd+Shift+Z → Redo
+      if (isMeta && e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        redoRef.current();
+        return;
+      }
+
+      // Ctrl/Cmd+Z → Undo
+      if (isMeta && e.key === 'z') {
+        e.preventDefault();
+        undoRef.current();
+        return;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   /**
    * Zeichenmodus setzen
@@ -396,14 +436,18 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded }: UseD
     return draw.getAll() as FeatureCollection;
   }, []);
 
-  return {
-    undo,
-    redo,
-    canUndo,
-    canRedo,
-    deleteSelected,
-    setMode,
-    getFeatures,
-    drawRef,
-  };
+  return useMemo(
+    () => ({
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      deleteSelected,
+      setMode,
+      getFeatures,
+      drawRef,
+      scheduleAutoSave,
+    }),
+    [undo, redo, canUndo, canRedo, deleteSelected, setMode, getFeatures, scheduleAutoSave],
+  );
 }

--- a/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
@@ -17,6 +17,7 @@ import { DRAW_FEATURE_LIMIT } from '../utils/map-config';
 import { CUSTOM_DRAW_STYLES } from '../drawing/draw-styles';
 import { FreehandMode } from '../drawing/custom-modes/freehand.mode';
 import type { DrawMode, DrawingStyle } from '../drawing/types';
+import { ensureHatchImage } from '../drawing/hatch-patterns';
 
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 
@@ -195,6 +196,10 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, active
         draw.setFeatureProperty(featureId, 'fillColor', currentStyle.fillColor);
         draw.setFeatureProperty(featureId, 'strokeWidth', currentStyle.strokeWidth);
         draw.setFeatureProperty(featureId, 'fillOpacity', currentStyle.fillOpacity);
+        draw.setFeatureProperty(featureId, 'hatch', JSON.stringify(currentStyle.hatch));
+        const map = mapRef.current?.getMap();
+        const imageName = ensureHatchImage(map, currentStyle.hatch, currentStyle.color);
+        draw.setFeatureProperty(featureId, 'fillPattern', imageName);
         draw.setFeatureProperty(featureId, 'featureType', 'drawing');
 
         // Text-Modus: Standard-Label setzen

--- a/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
@@ -10,7 +10,7 @@ import type { MapRef } from 'react-map-gl/maplibre';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import type { FeatureCollection } from 'geojson';
 import { useStore } from '@tanstack/react-store';
-import { drawStore, setDrawMode, setSelectedFeatures } from '../stores/draw.store';
+import { drawStore, setDirectSelect, setDrawMode, setSelectedFeatures } from '../stores/draw.store';
 import { useSaveLagekarteState } from '../api/use-save-lagekarte-state';
 import { useLagekarte } from '../api/use-lagekarte';
 import { DRAW_FEATURE_LIMIT } from '../utils/map-config';
@@ -260,10 +260,16 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, active
       setSelectedFeatures(ids);
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleModeChange = (e: any) => {
+      setDirectSelect(e.mode === 'direct_select');
+    };
+
     map.on('draw.create', handleCreate);
     map.on('draw.update', handleUpdate);
     map.on('draw.delete', handleDelete);
     map.on('draw.selectionchange', handleSelectionChange);
+    map.on('draw.modechange', handleModeChange);
 
     return () => {
       // Ausstehenden Auto-Save sofort ausführen
@@ -278,6 +284,7 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, active
       map.off('draw.update', handleUpdate);
       map.off('draw.delete', handleDelete);
       map.off('draw.selectionchange', handleSelectionChange);
+      map.off('draw.modechange', handleModeChange);
 
       // Control entfernen
       try {

--- a/packages/frontend/src/features/lagekarte/hooks/use-lagekarte-permissions.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-lagekarte-permissions.ts
@@ -1,0 +1,16 @@
+import { useEinsatzRolleContext } from '@/features/einsatz/contexts';
+
+/**
+ * Berechtigungs-Hook für Lagekarte-Zeichenwerkzeuge
+ *
+ * Nutzt die Einsatz-Rolle aus dem Layout-Kontext um zu prüfen,
+ * ob der aktuelle Benutzer zeichnen darf.
+ * Sekundäre Rollen (z.B. Beobachter) haben keine Zeichenberechtigung.
+ */
+export function useLagekartePermissions() {
+  const { meineRolle, isLoading } = useEinsatzRolleContext();
+
+  const canDraw = !isLoading && !!meineRolle && !meineRolle.permissions.isSecondaryRole;
+
+  return { canDraw, isLoading };
+}

--- a/packages/frontend/src/features/lagekarte/hooks/use-osm-markierung.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-osm-markierung.ts
@@ -126,26 +126,24 @@ export function useOsmMarkierung({ mapRef, drawRef, isVectorBaseLayer }: UseOsmM
       const draw = drawRef.current;
       if (!draw || !pendingOsmMark) return;
 
+      // Alle Properties VOR dem Hinzufügen setzen, damit draw.create
+      // den vollständigen State erfasst und Auto-Save korrekt auslöst
       const feature: GeoJSON.Feature = {
         type: 'Feature',
         geometry: pendingOsmMark.geometry,
-        properties: {},
+        properties: {
+          featureType: 'osm_marking',
+          osmFeatureId: pendingOsmMark.osmFeatureId,
+          osmLayerId: pendingOsmMark.osmLayerId,
+          osmStatus: status,
+          color: OSM_MARKING_COLORS[status],
+          fillColor: OSM_MARKING_COLORS[status],
+          fillOpacity: 0.4,
+        },
       };
 
-      // Feature zu MapboxDraw hinzufügen
-      const addedIds = draw.add(feature);
-      const featureId = Array.isArray(addedIds) ? addedIds[0] : addedIds;
-
-      if (featureId) {
-        // User-Properties setzen für Rendering und Persistierung
-        draw.setFeatureProperty(String(featureId), 'featureType', 'osm_marking');
-        draw.setFeatureProperty(String(featureId), 'osmFeatureId', pendingOsmMark.osmFeatureId);
-        draw.setFeatureProperty(String(featureId), 'osmLayerId', pendingOsmMark.osmLayerId);
-        draw.setFeatureProperty(String(featureId), 'osmStatus', status);
-        draw.setFeatureProperty(String(featureId), 'color', OSM_MARKING_COLORS[status]);
-        draw.setFeatureProperty(String(featureId), 'fillColor', OSM_MARKING_COLORS[status]);
-        draw.setFeatureProperty(String(featureId), 'fillOpacity', 0.4);
-      }
+      // Feature zu MapboxDraw hinzufügen (löst draw.create Event aus)
+      draw.add(feature);
 
       setPendingOsmMark(null);
     },

--- a/packages/frontend/src/features/lagekarte/hooks/use-osm-markierung.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-osm-markierung.ts
@@ -60,6 +60,118 @@ function resolveFeatureName(layerId: string): string {
 }
 
 /**
+ * Layer-Priorität für Feature-Auswahl.
+ * Spezifische Features (Gebäude) werden gegenüber großflächigen Features
+ * (Landuse/Landcover) bevorzugt, damit beim Klick auf ein Gebäude nicht
+ * das darunterliegende Stadtviertel-Polygon selektiert wird.
+ *
+ * Niedrigerer Wert = höhere Priorität.
+ */
+function getLayerPriority(layerId: string): number {
+  const id = layerId.toLowerCase();
+  if (id.includes('building')) return 1;
+  if (id.includes('road') || id.includes('highway') || id.includes('transport')) return 2;
+  if (id.includes('water')) return 3;
+  if (id.includes('landuse') || id.includes('landcover') || id.includes('park')) return 99;
+  return 50;
+}
+
+/**
+ * Prüft ob ein Punkt innerhalb eines Polygon-Rings liegt (Ray-Casting-Algorithmus).
+ */
+function isPointInRing(point: [number, number], ring: GeoJSON.Position[]): boolean {
+  const [x, y] = point;
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0],
+      yi = ring[i][1];
+    const xj = ring[j][0],
+      yj = ring[j][1];
+    if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+/**
+ * Quadrierte Distanz zwischen Punkt und einem Liniensegment (A→B).
+ * Vermeidet Math.sqrt für Performance.
+ */
+function sqDistToSegment(p: [number, number], a: GeoJSON.Position, b: GeoJSON.Position): number {
+  let dx = b[0] - a[0];
+  let dy = b[1] - a[1];
+  if (dx !== 0 || dy !== 0) {
+    const t = Math.max(0, Math.min(1, ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / (dx * dx + dy * dy)));
+    dx = a[0] + t * dx - p[0];
+    dy = a[1] + t * dy - p[1];
+  } else {
+    dx = a[0] - p[0];
+    dy = a[1] - p[1];
+  }
+  return dx * dx + dy * dy;
+}
+
+/**
+ * Minimale quadrierte Distanz von einem Punkt zu einer Linie (Array von Koordinaten).
+ */
+function sqDistToLine(point: [number, number], line: GeoJSON.Position[]): number {
+  let minDist = Infinity;
+  for (let i = 0; i < line.length - 1; i++) {
+    minDist = Math.min(minDist, sqDistToSegment(point, line[i], line[i + 1]));
+  }
+  return minDist;
+}
+
+/**
+ * Extrahiert die einzelne Geometrie am Klickpunkt aus Multi*-Geometrien.
+ *
+ * In Vektor-Tiles werden Features häufig pro Tile zu Multi*-Geometrien
+ * zusammengefasst. Ohne diese Zerlegung würde ein Klick auf ein einzelnes
+ * Gebäude/Straßensegment alle Features im Tile einfärben.
+ */
+function extractClickedGeometry(geometry: GeoJSON.Geometry, clickPoint: [number, number]): GeoJSON.Geometry {
+  if (geometry.type === 'MultiPolygon') {
+    for (const polygonCoords of geometry.coordinates) {
+      if (isPointInRing(clickPoint, polygonCoords[0])) {
+        return { type: 'Polygon', coordinates: polygonCoords };
+      }
+    }
+    return geometry;
+  }
+
+  if (geometry.type === 'MultiLineString') {
+    let closestIdx = 0;
+    let closestDist = Infinity;
+    for (let i = 0; i < geometry.coordinates.length; i++) {
+      const dist = sqDistToLine(clickPoint, geometry.coordinates[i]);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestIdx = i;
+      }
+    }
+    return { type: 'LineString', coordinates: geometry.coordinates[closestIdx] };
+  }
+
+  if (geometry.type === 'MultiPoint') {
+    let closestIdx = 0;
+    let closestDist = Infinity;
+    for (let i = 0; i < geometry.coordinates.length; i++) {
+      const dx = geometry.coordinates[i][0] - clickPoint[0];
+      const dy = geometry.coordinates[i][1] - clickPoint[1];
+      const dist = dx * dx + dy * dy;
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestIdx = i;
+      }
+    }
+    return { type: 'Point', coordinates: geometry.coordinates[closestIdx] };
+  }
+
+  return geometry;
+}
+
+/**
  * Hook für OSM-Objekt-Markierungen
  *
  * Verarbeitet Klicks auf Vektor-Tile-Features und ermöglicht das Zuweisen
@@ -90,22 +202,32 @@ export function useOsmMarkierung({ mapRef, drawRef, isVectorBaseLayer }: UseOsmM
 
       if (!features || features.length === 0) return false;
 
-      // Erstes passendes Feature finden (MapboxDraw-Layer überspringen)
-      const match = features.find((f) => {
+      // Kandidaten filtern (MapboxDraw-Layer überspringen) und nach
+      // Layer-Priorität sortieren, damit spezifische Features (Gebäude)
+      // vor großflächigen Features (Landuse) bevorzugt werden
+      const candidates = features.filter((f) => {
         if (!f.geometry) return false;
         const layerId = f.layer?.id ?? '';
         if (layerId.startsWith('gl-draw-')) return false;
         return true;
       });
 
-      if (!match) return false;
+      if (candidates.length === 0) return false;
+
+      candidates.sort((a, b) => getLayerPriority(a.layer?.id ?? '') - getLayerPriority(b.layer?.id ?? ''));
+
+      const match = candidates[0];
 
       // Feature-ID extrahieren
       const osmFeatureId = String(match.id ?? match.properties?.id ?? match.properties?.['@id'] ?? `unknown-${Date.now()}`);
       const osmLayerId = match.layer?.id ?? 'unknown';
 
+      // Bei MultiPolygons (häufig in Vektor-Tiles: Gebäude pro Tile
+      // zusammengefasst) nur das angeklickte Einzelpolygon extrahieren
+      const resolvedGeometry = extractClickedGeometry(match.geometry, [event.lngLat.lng, event.lngLat.lat]);
+
       setPendingOsmMark({
-        geometry: match.geometry,
+        geometry: resolvedGeometry,
         osmFeatureId,
         osmLayerId,
         featureName: resolveFeatureName(osmLayerId),

--- a/packages/frontend/src/features/lagekarte/hooks/use-osm-markierung.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-osm-markierung.ts
@@ -1,0 +1,168 @@
+/**
+ * Hook für OSM-Objekt-Markierungen auf der Lagekarte
+ *
+ * Ermöglicht das Klicken auf Vektor-Tile-Features (Gebäude, Straßen etc.)
+ * und das Zuweisen eines Status (betroffen/gesperrt/evakuiert).
+ */
+
+import { useCallback, useState } from 'react';
+import type { MapRef, MapLayerMouseEvent } from 'react-map-gl/maplibre';
+import type MapboxDraw from '@mapbox/mapbox-gl-draw';
+import type { OsmMarkierungStatus } from '../drawing/types';
+import { OSM_MARKING_COLORS } from '../drawing/types';
+
+/**
+ * Ausstehende OSM-Markierung — zeigt Popup für Statusauswahl
+ */
+export interface PendingOsmMark {
+  /** Geometrie des OSM-Features */
+  geometry: GeoJSON.Geometry;
+  /** ID des OSM-Features (aus Vektor-Tile) */
+  osmFeatureId: string;
+  /** Layer-ID des OSM-Features */
+  osmLayerId: string;
+  /** Name/Typ des Features (z.B. "Gebäude", "Straße") */
+  featureName: string;
+  /** Koordinaten für Popup-Positionierung */
+  coordinate: { lng: number; lat: number };
+}
+
+interface UseOsmMarkierungOptions {
+  /** Referenz auf die MapLibre-GL-Instanz */
+  mapRef: React.RefObject<MapRef | null>;
+  /** Referenz auf die MapboxDraw-Instanz */
+  drawRef: React.RefObject<MapboxDraw | null>;
+  /** Ob der Basislayer Vektor-Features hat (true für OSM, false für Topo/Satellit) */
+  isVectorBaseLayer: boolean;
+}
+
+interface UseOsmMarkierungReturn {
+  /** Verarbeitet einen Karten-Klick im OSM-Markierungsmodus */
+  handleOsmClick: (event: MapLayerMouseEvent) => boolean;
+  /** Ausstehende OSM-Markierung (für Popup-Anzeige) */
+  pendingOsmMark: PendingOsmMark | null;
+  /** Bestätigt die OSM-Markierung mit einem Status */
+  confirmOsmMark: (status: OsmMarkierungStatus) => void;
+  /** Bricht die ausstehende Markierung ab */
+  cancelOsmMark: () => void;
+}
+
+/**
+ * Ermittelt einen lesbaren Feature-Namen anhand der Layer-ID
+ */
+function resolveFeatureName(layerId: string): string {
+  const id = layerId.toLowerCase();
+  if (id.includes('building')) return 'Gebäude';
+  if (id.includes('road') || id.includes('highway')) return 'Straße';
+  if (id.includes('water')) return 'Gewässer';
+  if (id.includes('landuse') || id.includes('landcover')) return 'Fläche';
+  return 'Objekt';
+}
+
+/**
+ * Hook für OSM-Objekt-Markierungen
+ *
+ * Verarbeitet Klicks auf Vektor-Tile-Features und ermöglicht das Zuweisen
+ * eines Markierungsstatus. Die markierten Features werden als GeoJSON-Features
+ * in die MapboxDraw-Kollektion aufgenommen.
+ *
+ * @param options - Konfiguration mit Map-Ref, Draw-Ref und Basislayer-Info
+ * @returns API zum Verarbeiten von OSM-Markierungen
+ */
+export function useOsmMarkierung({ mapRef, drawRef, isVectorBaseLayer }: UseOsmMarkierungOptions): UseOsmMarkierungReturn {
+  const [pendingOsmMark, setPendingOsmMark] = useState<PendingOsmMark | null>(null);
+
+  /**
+   * Verarbeitet einen Karten-Klick im OSM-Markierungsmodus.
+   * Gibt true zurück wenn ein OSM-Feature gefunden wurde (Klick wird konsumiert),
+   * false wenn kein Feature gefunden wurde.
+   */
+  const handleOsmClick = useCallback(
+    (event: MapLayerMouseEvent): boolean => {
+      if (!isVectorBaseLayer) return false;
+
+      const map = mapRef.current?.getMap();
+      if (!map) return false;
+
+      // Alle gerenderten Features am Klickpunkt abfragen
+      const point: [number, number] = [event.point.x, event.point.y];
+      const features = map.queryRenderedFeatures(point);
+
+      if (!features || features.length === 0) return false;
+
+      // Erstes passendes Feature finden (MapboxDraw-Layer überspringen)
+      const match = features.find((f) => {
+        if (!f.geometry) return false;
+        const layerId = f.layer?.id ?? '';
+        if (layerId.startsWith('gl-draw-')) return false;
+        return true;
+      });
+
+      if (!match) return false;
+
+      // Feature-ID extrahieren
+      const osmFeatureId = String(match.id ?? match.properties?.id ?? match.properties?.['@id'] ?? `unknown-${Date.now()}`);
+      const osmLayerId = match.layer?.id ?? 'unknown';
+
+      setPendingOsmMark({
+        geometry: match.geometry,
+        osmFeatureId,
+        osmLayerId,
+        featureName: resolveFeatureName(osmLayerId),
+        coordinate: { lng: event.lngLat.lng, lat: event.lngLat.lat },
+      });
+
+      return true;
+    },
+    [isVectorBaseLayer, mapRef],
+  );
+
+  /**
+   * Bestätigt die ausstehende OSM-Markierung mit dem gewählten Status.
+   * Fügt das Feature als GeoJSON in die MapboxDraw-Kollektion ein.
+   */
+  const confirmOsmMark = useCallback(
+    (status: OsmMarkierungStatus) => {
+      const draw = drawRef.current;
+      if (!draw || !pendingOsmMark) return;
+
+      const feature: GeoJSON.Feature = {
+        type: 'Feature',
+        geometry: pendingOsmMark.geometry,
+        properties: {},
+      };
+
+      // Feature zu MapboxDraw hinzufügen
+      const addedIds = draw.add(feature);
+      const featureId = Array.isArray(addedIds) ? addedIds[0] : addedIds;
+
+      if (featureId) {
+        // User-Properties setzen für Rendering und Persistierung
+        draw.setFeatureProperty(String(featureId), 'featureType', 'osm_marking');
+        draw.setFeatureProperty(String(featureId), 'osmFeatureId', pendingOsmMark.osmFeatureId);
+        draw.setFeatureProperty(String(featureId), 'osmLayerId', pendingOsmMark.osmLayerId);
+        draw.setFeatureProperty(String(featureId), 'osmStatus', status);
+        draw.setFeatureProperty(String(featureId), 'color', OSM_MARKING_COLORS[status]);
+        draw.setFeatureProperty(String(featureId), 'fillColor', OSM_MARKING_COLORS[status]);
+        draw.setFeatureProperty(String(featureId), 'fillOpacity', 0.4);
+      }
+
+      setPendingOsmMark(null);
+    },
+    [drawRef, pendingOsmMark],
+  );
+
+  /**
+   * Bricht die ausstehende Markierung ab
+   */
+  const cancelOsmMark = useCallback(() => {
+    setPendingOsmMark(null);
+  }, []);
+
+  return {
+    handleOsmClick,
+    pendingOsmMark,
+    confirmOsmMark,
+    cancelOsmMark,
+  };
+}

--- a/packages/frontend/src/features/lagekarte/stores/draw.store.ts
+++ b/packages/frontend/src/features/lagekarte/stores/draw.store.ts
@@ -1,0 +1,75 @@
+/**
+ * Draw Store
+ *
+ * Verwaltet den UI-Zustand der Zeichenwerkzeuge (Modus, Selektion, Toolbar-Sichtbarkeit)
+ * mit @tanstack/react-store.
+ */
+
+import { createStore } from '@tanstack/react-store';
+import type { DrawMode } from '../drawing/types';
+
+/**
+ * State für die Zeichenwerkzeuge der Lagekarte
+ */
+export interface DrawStoreState {
+  /** Aktiver Zeichenmodus */
+  drawMode: DrawMode;
+  /** IDs der aktuell selektierten Features */
+  selectedFeatureIds: string[];
+  /** Ist die Draw-Toolbar sichtbar */
+  isDrawToolbarVisible: boolean;
+}
+
+const initialState: DrawStoreState = {
+  drawMode: 'idle',
+  selectedFeatureIds: [],
+  isDrawToolbarVisible: true,
+};
+
+/**
+ * Draw Store Instanz
+ */
+export const drawStore = createStore<DrawStoreState>(initialState);
+
+// ============================================
+// Store Actions
+// ============================================
+
+/**
+ * Setzt den aktiven Zeichenmodus
+ */
+export const setDrawMode = (mode: DrawMode) => {
+  drawStore.setState((state) => ({
+    ...state,
+    drawMode: mode,
+    // Selektion aufheben wenn ein Zeichenmodus aktiviert wird
+    selectedFeatureIds: mode !== 'select' && mode !== 'idle' ? [] : state.selectedFeatureIds,
+  }));
+};
+
+/**
+ * Setzt die selektierten Feature-IDs
+ */
+export const setSelectedFeatures = (ids: string[]) => {
+  drawStore.setState((state) => ({
+    ...state,
+    selectedFeatureIds: ids,
+  }));
+};
+
+/**
+ * Schaltet die Sichtbarkeit der Draw-Toolbar um
+ */
+export const toggleDrawToolbar = () => {
+  drawStore.setState((state) => ({
+    ...state,
+    isDrawToolbarVisible: !state.isDrawToolbarVisible,
+  }));
+};
+
+/**
+ * Setzt den Draw-Store auf den Initialzustand zurück
+ */
+export const resetDrawStore = () => {
+  drawStore.setState(() => initialState);
+};

--- a/packages/frontend/src/features/lagekarte/stores/draw.store.ts
+++ b/packages/frontend/src/features/lagekarte/stores/draw.store.ts
@@ -18,12 +18,15 @@ export interface DrawStoreState {
   selectedFeatureIds: string[];
   /** Ist die Draw-Toolbar sichtbar */
   isDrawToolbarVisible: boolean;
+  /** Ist MapboxDraw im Vertex-Bearbeitungsmodus (direct_select) */
+  isDirectSelect: boolean;
 }
 
 const initialState: DrawStoreState = {
   drawMode: 'idle',
   selectedFeatureIds: [],
   isDrawToolbarVisible: true,
+  isDirectSelect: false,
 };
 
 /**
@@ -54,6 +57,16 @@ export const setSelectedFeatures = (ids: string[]) => {
   drawStore.setState((state) => ({
     ...state,
     selectedFeatureIds: ids,
+  }));
+};
+
+/**
+ * Setzt den direct_select-Status (Vertex-Bearbeitung)
+ */
+export const setDirectSelect = (active: boolean) => {
+  drawStore.setState((state) => ({
+    ...state,
+    isDirectSelect: active,
   }));
 };
 

--- a/packages/frontend/src/features/lagekarte/stores/draw.store.ts
+++ b/packages/frontend/src/features/lagekarte/stores/draw.store.ts
@@ -25,7 +25,7 @@ export interface DrawStoreState {
 const initialState: DrawStoreState = {
   drawMode: 'idle',
   selectedFeatureIds: [],
-  isDrawToolbarVisible: true,
+  isDrawToolbarVisible: false,
   isDirectSelect: false,
 };
 
@@ -47,6 +47,8 @@ export const setDrawMode = (mode: DrawMode) => {
     drawMode: mode,
     // Selektion aufheben wenn ein Zeichenmodus aktiviert wird
     selectedFeatureIds: mode !== 'select' && mode !== 'idle' ? [] : state.selectedFeatureIds,
+    // Toolbar einklappen wenn Zeichenmodus beendet wird
+    isDrawToolbarVisible: mode === 'idle' ? false : state.isDrawToolbarVisible,
   }));
 };
 
@@ -77,6 +79,8 @@ export const toggleDrawToolbar = () => {
   drawStore.setState((state) => ({
     ...state,
     isDrawToolbarVisible: !state.isDrawToolbarVisible,
+    // Beim Einklappen auf Select-Modus wechseln
+    drawMode: !state.isDrawToolbarVisible ? state.drawMode : 'select',
   }));
 };
 

--- a/packages/frontend/src/features/lagekarte/stores/index.ts
+++ b/packages/frontend/src/features/lagekarte/stores/index.ts
@@ -1,1 +1,2 @@
 export * from './map-layer.store';
+export * from './draw.store';

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawShortcutBar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawShortcutBar.molecule.tsx
@@ -1,12 +1,14 @@
 /**
- * DrawShortcutBar — Kontextabhängige Shortcut-Anzeige für Zeichenwerkzeuge
+ * DrawShortcutBar — Kontextabhängige Shortcut-Anzeige und Aktions-Buttons für Zeichenwerkzeuge
  *
- * Zeigt am unteren Kartenrand nur die aktuell relevanten Tastenkürzel
- * und Bedienhinweise an. Passt sich dynamisch an den aktiven Zeichenmodus,
- * Selektionszustand und Vertex-Bearbeitungsmodus an.
+ * Zeigt am unteren Kartenrand relevante Tastenkürzel, Bedienhinweise sowie
+ * Aktions-Buttons (Undo/Redo/Löschen) an. Passt sich dynamisch an den aktiven
+ * Zeichenmodus, Selektionszustand und Vertex-Bearbeitungsmodus an.
  */
 
+import { cn } from '@/shared/ui/cn';
 import { useMemo } from 'react';
+import { PiArrowClockwise, PiArrowCounterClockwise, PiTrash } from 'react-icons/pi';
 import type { DrawMode } from '../../drawing/types';
 
 interface Hint {
@@ -29,6 +31,9 @@ const MODE_HINTS: Partial<Record<DrawMode, string>> = {
   osm_mark: 'Klick auf Objekt zum Markieren',
 };
 
+/** Gemeinsame Styles für Aktions-Buttons */
+const actionButtonBase = 'flex items-center justify-center rounded p-1 transition-colors duration-100 focus-visible:shadow-focus-ring focus-visible:outline-none';
+
 export interface DrawShortcutBarProps {
   /** Aktiver Zeichenmodus */
   activeMode: DrawMode;
@@ -40,9 +45,15 @@ export interface DrawShortcutBarProps {
   canRedo: boolean;
   /** Ist im Vertex-Bearbeitungsmodus (direct_select) */
   isDirectSelect: boolean;
+  /** Undo ausführen */
+  onUndo: () => void;
+  /** Redo ausführen */
+  onRedo: () => void;
+  /** Selektierte Features löschen */
+  onDeleteSelected: () => void;
 }
 
-export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, isDirectSelect }: DrawShortcutBarProps) {
+export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, isDirectSelect, onUndo, onRedo, onDeleteSelected }: DrawShortcutBarProps) {
   const hints = useMemo<Hint[]>(() => {
     const isActive = activeMode !== 'idle';
     // Hinweise zeigen wenn ein Werkzeug aktiv ist ODER ein Feature selektiert ist
@@ -71,7 +82,7 @@ export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, is
       result.push({ keys: ['Esc'], label: 'Werkzeug ablegen' });
     }
 
-    // Undo/Redo immer anzeigen wenn verfügbar
+    // Undo/Redo-Hinweise nur als Shortcuts (Buttons sind separat)
     if (canUndo) {
       result.push({ keys: [MOD, 'Z'], label: 'Rückgängig' });
     }
@@ -82,13 +93,15 @@ export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, is
     return result;
   }, [activeMode, hasSelection, canUndo, canRedo, isDirectSelect]);
 
-  if (hints.length === 0) return null;
+  const hasActions = canUndo || canRedo || hasSelection;
+
+  if (hints.length === 0 && !hasActions) return null;
 
   return (
     <div className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2">
       <div className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-panel/90 px-3 py-1.5 text-xs text-text-muted shadow-sm backdrop-blur-sm">
         {hints.map((hint, i) => (
-          <span key={hint.label} className="flex items-center gap-1.5">
+          <span key={i} className="flex items-center gap-1.5">
             {i > 0 && <span className="mr-1.5 h-3 w-px bg-border-subtle" aria-hidden="true" />}
             {hint.keys.length > 0 && (
               <span className="flex items-center gap-0.5">
@@ -105,6 +118,34 @@ export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, is
             <span>{hint.label}</span>
           </span>
         ))}
+
+        {/* Aktions-Buttons */}
+        {hasActions && hints.length > 0 && <span className="h-3 w-px bg-border-subtle" aria-hidden="true" />}
+        {hasActions && (
+          <span className="flex items-center gap-1">
+            {canUndo && (
+              <button type="button" onClick={onUndo} aria-label="Rückgängig" title="Rückgängig" className={cn(actionButtonBase, 'text-text-muted hover:bg-action-secondary hover:text-text-primary')}>
+                <PiArrowCounterClockwise className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            )}
+            {canRedo && (
+              <button type="button" onClick={onRedo} aria-label="Wiederholen" title="Wiederholen" className={cn(actionButtonBase, 'text-text-muted hover:bg-action-secondary hover:text-text-primary')}>
+                <PiArrowClockwise className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            )}
+            {hasSelection && (
+              <button
+                type="button"
+                onClick={onDeleteSelected}
+                aria-label="Auswahl löschen"
+                title="Auswahl löschen"
+                className={cn(actionButtonBase, 'text-text-muted hover:bg-red-50 hover:text-red-600')}
+              >
+                <PiTrash className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            )}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawShortcutBar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawShortcutBar.molecule.tsx
@@ -1,0 +1,111 @@
+/**
+ * DrawShortcutBar — Kontextabhängige Shortcut-Anzeige für Zeichenwerkzeuge
+ *
+ * Zeigt am unteren Kartenrand nur die aktuell relevanten Tastenkürzel
+ * und Bedienhinweise an. Passt sich dynamisch an den aktiven Zeichenmodus,
+ * Selektionszustand und Vertex-Bearbeitungsmodus an.
+ */
+
+import { useMemo } from 'react';
+import type { DrawMode } from '../../drawing/types';
+
+interface Hint {
+  /** Tastenkürzel — leer für reine Texthinweise */
+  keys: string[];
+  label: string;
+}
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent);
+const MOD = isMac ? '⌘' : 'Strg';
+const DEL = isMac ? '⌫' : 'Entf';
+
+/** Modus-spezifische Bedienhinweise */
+const MODE_HINTS: Partial<Record<DrawMode, string>> = {
+  draw_point: 'Klick zum Setzen',
+  draw_line_string: 'Klick für Punkte · Doppelklick zum Abschließen',
+  draw_polygon: 'Klick für Punkte · Klick auf Start zum Schließen',
+  draw_freehand: 'Ziehen zum Zeichnen',
+  draw_text: 'Klick zum Platzieren',
+  osm_mark: 'Klick auf Objekt zum Markieren',
+};
+
+export interface DrawShortcutBarProps {
+  /** Aktiver Zeichenmodus */
+  activeMode: DrawMode;
+  /** Hat selektierte Features */
+  hasSelection: boolean;
+  /** Kann rückgängig gemacht werden */
+  canUndo: boolean;
+  /** Kann wiederholt werden */
+  canRedo: boolean;
+  /** Ist im Vertex-Bearbeitungsmodus (direct_select) */
+  isDirectSelect: boolean;
+}
+
+export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, isDirectSelect }: DrawShortcutBarProps) {
+  const hints = useMemo<Hint[]>(() => {
+    const isActive = activeMode !== 'idle';
+    // Hinweise zeigen wenn ein Werkzeug aktiv ist ODER ein Feature selektiert ist
+    if (!isActive && !hasSelection) return [];
+
+    const result: Hint[] = [];
+
+    if (isDirectSelect) {
+      // Vertex-Bearbeitungsmodus
+      result.push({ keys: [], label: 'Punkte ziehen zum Verschieben' });
+      result.push({ keys: [DEL], label: 'Punkt entfernen' });
+      result.push({ keys: ['Esc'], label: 'Bearbeitung beenden' });
+    } else if (hasSelection && !isActive) {
+      // Feature selektiert, kein Werkzeug aktiv
+      result.push({ keys: [], label: 'Doppelklick zum Bearbeiten' });
+      result.push({ keys: [DEL], label: 'Objekt löschen' });
+    } else {
+      // Zeichenmodus aktiv
+      const modeHint = MODE_HINTS[activeMode];
+      if (modeHint) {
+        result.push({ keys: [], label: modeHint });
+      }
+      if (hasSelection) {
+        result.push({ keys: [DEL], label: 'Löschen' });
+      }
+      result.push({ keys: ['Esc'], label: 'Werkzeug ablegen' });
+    }
+
+    // Undo/Redo immer anzeigen wenn verfügbar
+    if (canUndo) {
+      result.push({ keys: [MOD, 'Z'], label: 'Rückgängig' });
+    }
+    if (canRedo) {
+      result.push({ keys: [MOD, '⇧', 'Z'], label: 'Wiederholen' });
+    }
+
+    return result;
+  }, [activeMode, hasSelection, canUndo, canRedo, isDirectSelect]);
+
+  if (hints.length === 0) return null;
+
+  return (
+    <div className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2">
+      <div className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-panel/90 px-3 py-1.5 text-xs text-text-muted shadow-sm backdrop-blur-sm">
+        {hints.map((hint, i) => (
+          <span key={hint.label} className="flex items-center gap-1.5">
+            {i > 0 && <span className="mr-1.5 h-3 w-px bg-border-subtle" aria-hidden="true" />}
+            {hint.keys.length > 0 && (
+              <span className="flex items-center gap-0.5">
+                {hint.keys.map((key) => (
+                  <kbd
+                    key={key}
+                    className="bg-surface-secondary inline-flex min-w-[1.25rem] items-center justify-center rounded border border-border-subtle px-1 py-0.5 font-mono text-[10px] leading-none font-medium text-text-secondary"
+                  >
+                    {key}
+                  </kbd>
+                ))}
+              </span>
+            )}
+            <span>{hint.label}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
@@ -1,0 +1,157 @@
+/**
+ * DrawStylePanel - Stil-Editor für selektierte Zeichnungsobjekte
+ *
+ * Schwebendes Panel rechts neben der Toolbar. Ermöglicht das Ändern von
+ * Farbe, Linienstärke, Füllung und Strichmuster für das aktuell
+ * ausgewählte Feature.
+ */
+
+import { cn } from '@/shared/ui/cn';
+import type { DrawingStyle } from '../../drawing/types';
+
+/** Props für die DrawStylePanel-Komponente */
+export interface DrawStylePanelProps {
+  /** Aktueller Stil des selektierten Features */
+  style: DrawingStyle;
+  /** Stil ändern */
+  onStyleChange: (style: Partial<DrawingStyle>) => void;
+  /** Ob das Panel sichtbar ist */
+  isVisible: boolean;
+  /** Optionales Label (für Text-Features) */
+  label?: string;
+  /** Label ändern */
+  onLabelChange?: (label: string) => void;
+}
+
+/** Vordefinierte Farben für die Farbauswahl */
+const COLOR_SWATCHES = [
+  { value: '#ef4444', label: 'Rot' },
+  { value: '#f97316', label: 'Orange' },
+  { value: '#eab308', label: 'Gelb' },
+  { value: '#22c55e', label: 'Grün' },
+  { value: '#3b82f6', label: 'Blau' },
+  { value: '#8b5cf6', label: 'Lila' },
+  { value: '#ec4899', label: 'Pink' },
+  { value: '#1e293b', label: 'Dunkel' },
+] as const;
+
+/** Optionen für Linienstärke */
+const STROKE_WIDTH_OPTIONS = [
+  { value: 1, label: 'Dünn' },
+  { value: 2, label: 'Mittel' },
+  { value: 4, label: 'Dick' },
+] as const;
+
+/** Optionen für Füll-Deckkraft */
+const FILL_OPACITY_OPTIONS = [
+  { value: 0, label: 'Keine' },
+  { value: 0.2, label: 'Leicht' },
+  { value: 0.5, label: 'Solide' },
+] as const;
+
+/** Optionen für Strichmuster */
+const DASH_OPTIONS = [
+  { value: undefined as string | undefined, label: 'Durchgezogen' },
+  { value: '5,5', label: 'Gestrichelt' },
+] as const;
+
+/** Gemeinsame Toggle-Button-Styles */
+const toggleBase = 'rounded px-2.5 py-1 text-xs font-medium transition-colors duration-100 focus-visible:shadow-focus-ring focus-visible:outline-none';
+
+export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabelChange }: DrawStylePanelProps) {
+  if (!isVisible) return null;
+
+  return (
+    <div className={cn('absolute top-4 left-20 z-10 w-52 rounded-lg border border-border-subtle bg-surface-panel p-3 shadow-lg')}>
+      {/* Farbauswahl */}
+      <div className="mb-3">
+        <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Farbe</div>
+        <div className="flex flex-wrap gap-1.5">
+          {COLOR_SWATCHES.map(({ value, label: colorLabel }) => (
+            <button
+              key={value}
+              type="button"
+              title={colorLabel}
+              onClick={() => onStyleChange({ color: value, fillColor: value })}
+              className={cn(
+                'h-6 w-6 rounded-full border-2 transition-transform duration-100',
+                'hover:scale-110 focus-visible:shadow-focus-ring focus-visible:outline-none',
+                style.color === value ? 'scale-110 border-text-primary' : 'border-transparent',
+              )}
+              style={{ backgroundColor: value }}
+              aria-label={colorLabel}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Linienstärke */}
+      <div className="mb-3">
+        <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Linienstärke</div>
+        <div className="flex gap-1">
+          {STROKE_WIDTH_OPTIONS.map(({ value, label: widthLabel }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onStyleChange({ strokeWidth: value })}
+              className={cn(toggleBase, style.strokeWidth === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+            >
+              {widthLabel}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Füllung */}
+      <div className="mb-3">
+        <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Füllung</div>
+        <div className="flex gap-1">
+          {FILL_OPACITY_OPTIONS.map(({ value, label: fillLabel }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onStyleChange({ fillOpacity: value })}
+              className={cn(toggleBase, style.fillOpacity === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+            >
+              {fillLabel}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Strichmuster */}
+      <div className={cn(label !== undefined ? 'mb-3' : '')}>
+        <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Muster</div>
+        <div className="flex gap-1">
+          {DASH_OPTIONS.map(({ value, label: dashLabel }) => (
+            <button
+              key={dashLabel}
+              type="button"
+              onClick={() => onStyleChange({ strokeDasharray: value })}
+              className={cn(toggleBase, style.strokeDasharray === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+            >
+              {dashLabel}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Text-Label (nur für Text-Features) */}
+      {label !== undefined && onLabelChange && (
+        <div>
+          <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Beschriftung</div>
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => onLabelChange(e.target.value)}
+            className={cn(
+              'w-full rounded border border-border-subtle bg-surface-panel px-2 py-1 text-sm text-text-primary',
+              'focus:border-action-primary focus:ring-1 focus:ring-action-primary focus:outline-none',
+            )}
+            placeholder="Text eingeben..."
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
@@ -167,23 +167,28 @@ export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabel
         </div>
       )}
 
-      {/* Deckkraft-Slider (nicht für Punkte) */}
+      {/* Füllung Toggle + Deckkraft (nicht für Punkte) */}
       {showFill && (
         <div className="mb-3">
           <div className="mb-1.5 flex items-center justify-between">
-            <span className="text-xs font-semibold tracking-wide text-text-muted uppercase">Deckkraft</span>
-            <span className="text-xs text-text-muted tabular-nums">{Math.round(style.fillOpacity * 100)}%</span>
+            <label className="flex items-center gap-1.5">
+              <input type="checkbox" checked={style.fillEnabled !== false} onChange={(e) => onStyleChange({ fillEnabled: e.target.checked })} className="h-3 w-3 accent-action-primary" />
+              <span className="text-xs font-semibold tracking-wide text-text-muted uppercase">Füllung</span>
+            </label>
+            {style.fillEnabled !== false && <span className="text-xs text-text-muted tabular-nums">{Math.round(style.fillOpacity * 100)}%</span>}
           </div>
-          <input
-            type="range"
-            min={0}
-            max={100}
-            step={5}
-            value={Math.round(style.fillOpacity * 100)}
-            onChange={(e) => onStyleChange({ fillOpacity: Number(e.target.value) / 100 })}
-            className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-subtle accent-action-primary"
-            aria-label="Füll-Deckkraft"
-          />
+          {style.fillEnabled !== false && (
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={Math.round(style.fillOpacity * 100)}
+              onChange={(e) => onStyleChange({ fillOpacity: Number(e.target.value) / 100 })}
+              className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-subtle accent-action-primary"
+              aria-label="Füll-Deckkraft"
+            />
+          )}
         </div>
       )}
 

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
@@ -2,11 +2,13 @@
  * DrawStylePanel - Stil-Editor für selektierte Zeichnungsobjekte
  *
  * Schwebendes Panel rechts neben der Toolbar. Ermöglicht das Ändern von
- * Farbe, Linienstärke und Füllung für das aktuell ausgewählte Feature.
+ * Farbe, Linienstärke, Füllung und Schraffur für das aktuell ausgewählte Feature.
  */
 
+import { useState } from 'react';
 import { cn } from '@/shared/ui/cn';
-import type { DrawingStyle } from '../../drawing/types';
+import type { DrawingStyle, HatchConfig, HatchType } from '../../drawing/types';
+import { DEFAULT_HATCH } from '../../drawing/types';
 
 /** Props für die DrawStylePanel-Komponente */
 export interface DrawStylePanelProps {
@@ -43,22 +45,84 @@ const STROKE_WIDTH_OPTIONS = [
   { value: 4, label: 'Dick' },
 ] as const;
 
-/** Optionen für Füll-Deckkraft */
-const FILL_OPACITY_OPTIONS = [
-  { value: 0, label: 'Keine' },
-  { value: 0.2, label: 'Leicht' },
-  { value: 0.5, label: 'Solide' },
-] as const;
+/** Optionen für Schraffurmuster */
+const HATCH_TYPE_OPTIONS: { value: HatchType; label: string }[] = [
+  { value: 'none', label: 'Keine' },
+  { value: 'diagonal', label: 'Diagonal' },
+  { value: 'cross', label: 'Kreuz' },
+  { value: 'horizontal', label: 'Horizontal' },
+  { value: 'vertical', label: 'Vertikal' },
+];
 
 /** Gemeinsame Toggle-Button-Styles */
 const toggleBase = 'rounded px-2.5 py-1 text-xs font-medium transition-colors duration-100 focus-visible:shadow-focus-ring focus-visible:outline-none';
 
+/** SVG-Icon für Schraffurmuster-Vorschau */
+function PatternIcon({ type }: { type: HatchType }) {
+  const s = 14;
+  const stroke = 'currentColor';
+  const sw = 1.5;
+
+  if (type === 'none') {
+    return (
+      <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+        <line x1={1} y1={1} x2={s - 1} y2={s - 1} stroke={stroke} strokeWidth={sw} strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  if (type === 'diagonal') {
+    return (
+      <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+        <line x1={0} y1={s} x2={s} y2={0} stroke={stroke} strokeWidth={sw} />
+        <line x1={-4} y1={s - 4} x2={s - 4} y2={-4} stroke={stroke} strokeWidth={sw} />
+        <line x1={4} y1={s + 4} x2={s + 4} y2={4} stroke={stroke} strokeWidth={sw} />
+      </svg>
+    );
+  }
+
+  if (type === 'cross') {
+    return (
+      <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+        <line x1={0} y1={s} x2={s} y2={0} stroke={stroke} strokeWidth={sw} />
+        <line x1={0} y1={0} x2={s} y2={s} stroke={stroke} strokeWidth={sw} />
+      </svg>
+    );
+  }
+
+  if (type === 'horizontal') {
+    return (
+      <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+        <line x1={0} y1={4} x2={s} y2={4} stroke={stroke} strokeWidth={sw} />
+        <line x1={0} y1={10} x2={s} y2={10} stroke={stroke} strokeWidth={sw} />
+      </svg>
+    );
+  }
+
+  // vertical
+  return (
+    <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden>
+      <line x1={4} y1={0} x2={4} y2={s} stroke={stroke} strokeWidth={sw} />
+      <line x1={10} y1={0} x2={10} y2={s} stroke={stroke} strokeWidth={sw} />
+    </svg>
+  );
+}
+
 export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabelChange, geometryType }: DrawStylePanelProps) {
+  const [hatchExpanded, setHatchExpanded] = useState(false);
+
   if (!isVisible) return null;
 
   const isPoint = geometryType === 'Point';
   const showStrokeWidth = !isPoint;
   const showFill = !isPoint;
+  const hatch = style.hatch ?? DEFAULT_HATCH;
+  const hasHatch = hatch.type !== 'none';
+
+  /** Hatch-Config partiell ändern */
+  const updateHatch = (partial: Partial<HatchConfig>) => {
+    onStyleChange({ hatch: { ...hatch, ...partial } });
+  };
 
   return (
     <div className={cn('absolute top-4 left-20 z-10 w-52 rounded-lg border border-border-subtle bg-surface-panel p-3 shadow-lg')}>
@@ -103,22 +167,129 @@ export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabel
         </div>
       )}
 
-      {/* Füllung (nicht für Punkte) */}
+      {/* Deckkraft-Slider (nicht für Punkte) */}
+      {showFill && (
+        <div className="mb-3">
+          <div className="mb-1.5 flex items-center justify-between">
+            <span className="text-xs font-semibold tracking-wide text-text-muted uppercase">Deckkraft</span>
+            <span className="text-xs text-text-muted tabular-nums">{Math.round(style.fillOpacity * 100)}%</span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={5}
+            value={Math.round(style.fillOpacity * 100)}
+            onChange={(e) => onStyleChange({ fillOpacity: Number(e.target.value) / 100 })}
+            className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-subtle accent-action-primary"
+            aria-label="Füll-Deckkraft"
+          />
+        </div>
+      )}
+
+      {/* Schraffur (nicht für Punkte) */}
       {showFill && (
         <div className={cn(label !== undefined ? 'mb-3' : '')}>
-          <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Füllung</div>
+          <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Schraffur</div>
+          {/* Muster-Buttons */}
           <div className="flex gap-1">
-            {FILL_OPACITY_OPTIONS.map(({ value, label: fillLabel }) => (
+            {HATCH_TYPE_OPTIONS.map(({ value, label: patternLabel }) => (
               <button
                 key={value}
                 type="button"
-                onClick={() => onStyleChange({ fillOpacity: value })}
-                className={cn(toggleBase, style.fillOpacity === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+                title={patternLabel}
+                onClick={() => updateHatch({ type: value })}
+                className={cn(
+                  'flex h-7 w-7 items-center justify-center rounded border transition-colors duration-100',
+                  'focus-visible:shadow-focus-ring focus-visible:outline-none',
+                  hatch.type === value ? 'border-action-primary bg-action-secondary' : 'border-border-subtle hover:bg-action-secondary',
+                )}
+                aria-label={`Schraffur: ${patternLabel}`}
               >
-                {fillLabel}
+                <PatternIcon type={value} />
               </button>
             ))}
           </div>
+
+          {/* Disclosure: "Anpassen..." */}
+          {hasHatch && (
+            <div className="mt-1.5">
+              <button type="button" onClick={() => setHatchExpanded((prev) => !prev)} className="flex items-center gap-1 text-[10px] text-action-primary hover:text-action-primary/80">
+                <span className={cn('inline-block transition-transform', hatchExpanded && 'rotate-180')}>&#9660;</span>
+                Anpassen…
+              </button>
+
+              {hatchExpanded && (
+                <div className="mt-1.5 rounded-md border border-border-subtle bg-surface-panel/50 p-2">
+                  {/* Abstand */}
+                  <div className="mb-2">
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-[10px] font-semibold tracking-wide text-text-muted uppercase">Abstand</span>
+                      <span className="text-[10px] text-text-muted tabular-nums">{hatch.spacing}px</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={6}
+                      max={32}
+                      step={2}
+                      value={hatch.spacing}
+                      onChange={(e) => updateHatch({ spacing: Number(e.target.value) })}
+                      className="h-1 w-full cursor-pointer appearance-none rounded-full bg-border-subtle accent-action-primary"
+                      aria-label="Schraffur-Abstand"
+                    />
+                  </div>
+
+                  {/* Strichstärke */}
+                  <div className="mb-2">
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-[10px] font-semibold tracking-wide text-text-muted uppercase">Stärke</span>
+                      <span className="text-[10px] text-text-muted tabular-nums">{hatch.width}px</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={0.5}
+                      max={4}
+                      step={0.5}
+                      value={hatch.width}
+                      onChange={(e) => updateHatch({ width: Number(e.target.value) })}
+                      className="h-1 w-full cursor-pointer appearance-none rounded-full bg-border-subtle accent-action-primary"
+                      aria-label="Schraffur-Strichstärke"
+                    />
+                  </div>
+
+                  {/* Farbe */}
+                  <div>
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-[10px] font-semibold tracking-wide text-text-muted uppercase">Farbe</span>
+                      <label className="flex items-center gap-1 text-[10px] text-text-muted">
+                        <input type="checkbox" checked={hatch.color === ''} onChange={(e) => updateHatch({ color: e.target.checked ? '' : style.color })} className="h-3 w-3 accent-action-primary" />
+                        Auto
+                      </label>
+                    </div>
+                    {hatch.color !== '' && (
+                      <div className="flex flex-wrap gap-1">
+                        {COLOR_SWATCHES.map(({ value, label: colorLabel }) => (
+                          <button
+                            key={value}
+                            type="button"
+                            title={colorLabel}
+                            onClick={() => updateHatch({ color: value })}
+                            className={cn(
+                              'h-4 w-4 rounded-full border-2 transition-transform duration-100',
+                              'hover:scale-110 focus-visible:shadow-focus-ring focus-visible:outline-none',
+                              hatch.color === value ? 'scale-110 border-text-primary' : 'border-transparent',
+                            )}
+                            style={{ backgroundColor: value }}
+                            aria-label={`Schraffurfarbe: ${colorLabel}`}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
@@ -2,8 +2,7 @@
  * DrawStylePanel - Stil-Editor für selektierte Zeichnungsobjekte
  *
  * Schwebendes Panel rechts neben der Toolbar. Ermöglicht das Ändern von
- * Farbe, Linienstärke, Füllung und Strichmuster für das aktuell
- * ausgewählte Feature.
+ * Farbe, Linienstärke und Füllung für das aktuell ausgewählte Feature.
  */
 
 import { cn } from '@/shared/ui/cn';
@@ -47,12 +46,6 @@ const FILL_OPACITY_OPTIONS = [
   { value: 0, label: 'Keine' },
   { value: 0.2, label: 'Leicht' },
   { value: 0.5, label: 'Solide' },
-] as const;
-
-/** Optionen für Strichmuster */
-const DASH_OPTIONS = [
-  { value: undefined as string | undefined, label: 'Durchgezogen' },
-  { value: '5,5', label: 'Gestrichelt' },
 ] as const;
 
 /** Gemeinsame Toggle-Button-Styles */
@@ -103,7 +96,7 @@ export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabel
       </div>
 
       {/* Füllung */}
-      <div className="mb-3">
+      <div className={cn(label !== undefined ? 'mb-3' : '')}>
         <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Füllung</div>
         <div className="flex gap-1">
           {FILL_OPACITY_OPTIONS.map(({ value, label: fillLabel }) => (
@@ -114,23 +107,6 @@ export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabel
               className={cn(toggleBase, style.fillOpacity === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
             >
               {fillLabel}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Strichmuster */}
-      <div className={cn(label !== undefined ? 'mb-3' : '')}>
-        <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Muster</div>
-        <div className="flex gap-1">
-          {DASH_OPTIONS.map(({ value, label: dashLabel }) => (
-            <button
-              key={dashLabel}
-              type="button"
-              onClick={() => onStyleChange({ strokeDasharray: value })}
-              className={cn(toggleBase, style.strokeDasharray === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
-            >
-              {dashLabel}
             </button>
           ))}
         </div>

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
@@ -20,6 +20,8 @@ export interface DrawStylePanelProps {
   label?: string;
   /** Label ändern */
   onLabelChange?: (label: string) => void;
+  /** Geometrie-Typ des selektierten Features (steuert sichtbare Optionen) */
+  geometryType?: string;
 }
 
 /** Vordefinierte Farben für die Farbauswahl */
@@ -51,13 +53,17 @@ const FILL_OPACITY_OPTIONS = [
 /** Gemeinsame Toggle-Button-Styles */
 const toggleBase = 'rounded px-2.5 py-1 text-xs font-medium transition-colors duration-100 focus-visible:shadow-focus-ring focus-visible:outline-none';
 
-export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabelChange }: DrawStylePanelProps) {
+export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabelChange, geometryType }: DrawStylePanelProps) {
   if (!isVisible) return null;
+
+  const isPoint = geometryType === 'Point';
+  const showStrokeWidth = !isPoint;
+  const showFill = !isPoint;
 
   return (
     <div className={cn('absolute top-4 left-20 z-10 w-52 rounded-lg border border-border-subtle bg-surface-panel p-3 shadow-lg')}>
       {/* Farbauswahl */}
-      <div className="mb-3">
+      <div className={cn(showStrokeWidth || showFill || label !== undefined ? 'mb-3' : '')}>
         <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Farbe</div>
         <div className="flex flex-wrap gap-1.5">
           {COLOR_SWATCHES.map(({ value, label: colorLabel }) => (
@@ -78,39 +84,43 @@ export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabel
         </div>
       </div>
 
-      {/* Linienstärke */}
-      <div className="mb-3">
-        <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Linienstärke</div>
-        <div className="flex gap-1">
-          {STROKE_WIDTH_OPTIONS.map(({ value, label: widthLabel }) => (
-            <button
-              key={value}
-              type="button"
-              onClick={() => onStyleChange({ strokeWidth: value })}
-              className={cn(toggleBase, style.strokeWidth === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
-            >
-              {widthLabel}
-            </button>
-          ))}
+      {/* Linienstärke (nicht für Punkte) */}
+      {showStrokeWidth && (
+        <div className={cn(showFill || label !== undefined ? 'mb-3' : '')}>
+          <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Linienstärke</div>
+          <div className="flex gap-1">
+            {STROKE_WIDTH_OPTIONS.map(({ value, label: widthLabel }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => onStyleChange({ strokeWidth: value })}
+                className={cn(toggleBase, style.strokeWidth === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+              >
+                {widthLabel}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
-      {/* Füllung */}
-      <div className={cn(label !== undefined ? 'mb-3' : '')}>
-        <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Füllung</div>
-        <div className="flex gap-1">
-          {FILL_OPACITY_OPTIONS.map(({ value, label: fillLabel }) => (
-            <button
-              key={value}
-              type="button"
-              onClick={() => onStyleChange({ fillOpacity: value })}
-              className={cn(toggleBase, style.fillOpacity === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
-            >
-              {fillLabel}
-            </button>
-          ))}
+      {/* Füllung (nicht für Punkte) */}
+      {showFill && (
+        <div className={cn(label !== undefined ? 'mb-3' : '')}>
+          <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Füllung</div>
+          <div className="flex gap-1">
+            {FILL_OPACITY_OPTIONS.map(({ value, label: fillLabel }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => onStyleChange({ fillOpacity: value })}
+                className={cn(toggleBase, style.fillOpacity === value ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+              >
+                {fillLabel}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Text-Label (nur für Text-Features) */}
       {label !== undefined && onLabelChange && (

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
@@ -28,8 +28,6 @@ export interface DrawToolbarProps {
   onDeleteSelected: () => void;
   /** Hat selektierte Features */
   hasSelection: boolean;
-  /** Toolbar deaktiviert (kein Zeichenrecht) */
-  disabled: boolean;
 }
 
 /** Konfiguration für die Zeichenmodus-Buttons */
@@ -44,14 +42,13 @@ const DRAW_MODE_BUTTONS: { mode: DrawMode; icon: React.ComponentType<{ className
 /** Gemeinsame Button-Styles */
 const buttonBase = 'flex items-center justify-center p-2 transition-colors duration-100 focus-visible:shadow-focus-ring focus-visible:outline-none';
 
-export function DrawToolbar({ activeMode, onModeChange, onUndo, onRedo, canUndo, canRedo, onDeleteSelected, hasSelection, disabled }: DrawToolbarProps) {
-  if (disabled) return null;
-
+export function DrawToolbar({ activeMode, onModeChange, onUndo, onRedo, canUndo, canRedo, onDeleteSelected, hasSelection }: DrawToolbarProps) {
   return (
     <div className={cn('absolute top-4 left-4 z-10 flex flex-col overflow-hidden rounded-lg border border-border-subtle bg-surface-panel shadow-lg')} role="toolbar" aria-label="Zeichenwerkzeuge">
       {/* Auswahl-Modus */}
       <button
         type="button"
+        aria-label="Auswählen"
         title="Auswählen"
         onClick={() => onModeChange('select')}
         className={cn(buttonBase, activeMode === 'select' ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
@@ -67,6 +64,7 @@ export function DrawToolbar({ activeMode, onModeChange, onUndo, onRedo, canUndo,
         <button
           key={mode}
           type="button"
+          aria-label={label}
           title={label}
           onClick={() => onModeChange(mode)}
           className={cn(buttonBase, activeMode === mode ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
@@ -81,6 +79,7 @@ export function DrawToolbar({ activeMode, onModeChange, onUndo, onRedo, canUndo,
       {/* OSM-Markierung */}
       <button
         type="button"
+        aria-label="OSM-Gebäude markieren"
         title="OSM-Gebäude markieren"
         onClick={() => onModeChange('osm_mark')}
         className={cn(buttonBase, activeMode === 'osm_mark' ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
@@ -94,6 +93,7 @@ export function DrawToolbar({ activeMode, onModeChange, onUndo, onRedo, canUndo,
       {/* Undo */}
       <button
         type="button"
+        aria-label="Rückgängig"
         title="Rückgängig"
         onClick={onUndo}
         disabled={!canUndo}
@@ -105,6 +105,7 @@ export function DrawToolbar({ activeMode, onModeChange, onUndo, onRedo, canUndo,
       {/* Redo */}
       <button
         type="button"
+        aria-label="Wiederholen"
         title="Wiederholen"
         onClick={onRedo}
         disabled={!canRedo}
@@ -116,6 +117,7 @@ export function DrawToolbar({ activeMode, onModeChange, onUndo, onRedo, canUndo,
       {/* Löschen */}
       <button
         type="button"
+        aria-label="Auswahl löschen"
         title="Auswahl löschen"
         onClick={onDeleteSelected}
         disabled={!hasSelection}

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
@@ -1,0 +1,132 @@
+/**
+ * DrawToolbar - Schwebende Werkzeugleiste für Zeichenmodi auf der Lagekarte
+ *
+ * Positioniert oben links auf der Karte. Ermöglicht das Wechseln zwischen
+ * Zeichenmodi (Punkt, Linie, Polygon, Freihand, Text, OSM-Markierung)
+ * sowie Undo/Redo und Löschen selektierter Features.
+ */
+
+import { cn } from '@/shared/ui/cn';
+import { PiArrowClockwise, PiArrowCounterClockwise, PiBuildings, PiCursor, PiLineSegment, PiMapPin, PiPolygon, PiScribbleLoop, PiTextT, PiTrash } from 'react-icons/pi';
+import type { DrawMode } from '../../drawing/types';
+
+/** Props für die DrawToolbar-Komponente */
+export interface DrawToolbarProps {
+  /** Aktiver Zeichenmodus */
+  activeMode: DrawMode;
+  /** Modus wechseln */
+  onModeChange: (mode: DrawMode) => void;
+  /** Undo ausführen */
+  onUndo: () => void;
+  /** Redo ausführen */
+  onRedo: () => void;
+  /** Kann rückgängig gemacht werden */
+  canUndo: boolean;
+  /** Kann wiederholt werden */
+  canRedo: boolean;
+  /** Selektierte Features löschen */
+  onDeleteSelected: () => void;
+  /** Hat selektierte Features */
+  hasSelection: boolean;
+  /** Toolbar deaktiviert (kein Zeichenrecht) */
+  disabled: boolean;
+}
+
+/** Konfiguration für die Zeichenmodus-Buttons */
+const DRAW_MODE_BUTTONS: { mode: DrawMode; icon: React.ComponentType<{ className?: string }>; label: string }[] = [
+  { mode: 'draw_point', icon: PiMapPin, label: 'Punkt zeichnen' },
+  { mode: 'draw_line_string', icon: PiLineSegment, label: 'Linie zeichnen' },
+  { mode: 'draw_polygon', icon: PiPolygon, label: 'Polygon zeichnen' },
+  { mode: 'draw_freehand', icon: PiScribbleLoop, label: 'Freihand zeichnen' },
+  { mode: 'draw_text', icon: PiTextT, label: 'Text platzieren' },
+];
+
+/** Gemeinsame Button-Styles */
+const buttonBase = 'flex items-center justify-center p-2 transition-colors duration-100 focus-visible:shadow-focus-ring focus-visible:outline-none';
+
+export function DrawToolbar({ activeMode, onModeChange, onUndo, onRedo, canUndo, canRedo, onDeleteSelected, hasSelection, disabled }: DrawToolbarProps) {
+  if (disabled) return null;
+
+  return (
+    <div className={cn('absolute top-4 left-4 z-10 flex flex-col overflow-hidden rounded-lg border border-border-subtle bg-surface-panel shadow-lg')} role="toolbar" aria-label="Zeichenwerkzeuge">
+      {/* Auswahl-Modus */}
+      <button
+        type="button"
+        title="Auswählen"
+        onClick={() => onModeChange('select')}
+        className={cn(buttonBase, activeMode === 'select' ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+      >
+        <PiCursor className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      {/* Separator */}
+      <div className="mx-2 border-t border-border-subtle" />
+
+      {/* Zeichenmodi */}
+      {DRAW_MODE_BUTTONS.map(({ mode, icon: Icon, label }) => (
+        <button
+          key={mode}
+          type="button"
+          title={label}
+          onClick={() => onModeChange(mode)}
+          className={cn(buttonBase, activeMode === mode ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+        >
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </button>
+      ))}
+
+      {/* Separator */}
+      <div className="mx-2 border-t border-border-subtle" />
+
+      {/* OSM-Markierung */}
+      <button
+        type="button"
+        title="OSM-Gebäude markieren"
+        onClick={() => onModeChange('osm_mark')}
+        className={cn(buttonBase, activeMode === 'osm_mark' ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+      >
+        <PiBuildings className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      {/* Separator */}
+      <div className="mx-2 border-t border-border-subtle" />
+
+      {/* Undo */}
+      <button
+        type="button"
+        title="Rückgängig"
+        onClick={onUndo}
+        disabled={!canUndo}
+        className={cn(buttonBase, 'text-text-primary hover:bg-action-secondary disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50')}
+      >
+        <PiArrowCounterClockwise className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      {/* Redo */}
+      <button
+        type="button"
+        title="Wiederholen"
+        onClick={onRedo}
+        disabled={!canRedo}
+        className={cn(buttonBase, 'text-text-primary hover:bg-action-secondary disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50')}
+      >
+        <PiArrowClockwise className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      {/* Löschen */}
+      <button
+        type="button"
+        title="Auswahl löschen"
+        onClick={onDeleteSelected}
+        disabled={!hasSelection}
+        className={cn(
+          buttonBase,
+          'disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50',
+          hasSelection ? 'text-text-primary hover:bg-red-50 hover:text-red-600' : 'text-text-primary',
+        )}
+      >
+        <PiTrash className="h-5 w-5" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
@@ -1,14 +1,17 @@
 /**
- * DrawToolbar - Schwebende Werkzeugleiste für Zeichenmodi auf der Lagekarte
+ * DrawToolbar - Einklappbare Werkzeugleiste für Zeichenmodi auf der Lagekarte
  *
- * Positioniert oben links auf der Karte. Ermöglicht das Wechseln zwischen
- * Zeichenmodi (Punkt, Linie, Polygon, Freihand, Text, OSM-Markierung)
- * sowie Undo/Redo und Löschen selektierter Features.
+ * Positioniert oben links auf der Karte. Im eingeklappten Zustand wird nur ein
+ * Toggle-Button (Stift-Icon) angezeigt. Per Klick expandiert die Toolbar und
+ * zeigt Zeichenmodi (Punkt, Linie, Polygon, Freihand, Text, OSM-Markierung).
+ * Undo/Redo/Löschen befinden sich in der DrawShortcutBar am unteren Kartenrand.
  */
 
 import { cn } from '@/shared/ui/cn';
-import { PiArrowClockwise, PiArrowCounterClockwise, PiBuildings, PiCursor, PiLineSegment, PiMapPin, PiPolygon, PiScribbleLoop, PiTextT, PiTrash } from 'react-icons/pi';
+import { useStore } from '@tanstack/react-store';
+import { PiBuildings, PiCursor, PiLineSegment, PiMapPin, PiPencilSimple, PiPolygon, PiScribbleLoop, PiTextT } from 'react-icons/pi';
 import type { DrawMode } from '../../drawing/types';
+import { drawStore, toggleDrawToolbar } from '../../stores/draw.store';
 
 /** Props für die DrawToolbar-Komponente */
 export interface DrawToolbarProps {
@@ -16,119 +19,61 @@ export interface DrawToolbarProps {
   activeMode: DrawMode;
   /** Modus wechseln */
   onModeChange: (mode: DrawMode) => void;
-  /** Undo ausführen */
-  onUndo: () => void;
-  /** Redo ausführen */
-  onRedo: () => void;
-  /** Kann rückgängig gemacht werden */
-  canUndo: boolean;
-  /** Kann wiederholt werden */
-  canRedo: boolean;
-  /** Selektierte Features löschen */
-  onDeleteSelected: () => void;
-  /** Hat selektierte Features */
-  hasSelection: boolean;
 }
 
 /** Konfiguration für die Zeichenmodus-Buttons */
 const DRAW_MODE_BUTTONS: { mode: DrawMode; icon: React.ComponentType<{ className?: string }>; label: string }[] = [
+  { mode: 'select', icon: PiCursor, label: 'Auswählen' },
   { mode: 'draw_point', icon: PiMapPin, label: 'Punkt zeichnen' },
   { mode: 'draw_line_string', icon: PiLineSegment, label: 'Linie zeichnen' },
   { mode: 'draw_polygon', icon: PiPolygon, label: 'Polygon zeichnen' },
   { mode: 'draw_freehand', icon: PiScribbleLoop, label: 'Freihand zeichnen' },
   { mode: 'draw_text', icon: PiTextT, label: 'Text platzieren' },
+  { mode: 'osm_mark', icon: PiBuildings, label: 'OSM-Gebäude markieren' },
 ];
 
 /** Gemeinsame Button-Styles */
 const buttonBase = 'flex items-center justify-center p-2 transition-colors duration-100 focus-visible:shadow-focus-ring focus-visible:outline-none';
 
-export function DrawToolbar({ activeMode, onModeChange, onUndo, onRedo, canUndo, canRedo, onDeleteSelected, hasSelection }: DrawToolbarProps) {
+export function DrawToolbar({ activeMode, onModeChange }: DrawToolbarProps) {
+  const isExpanded = useStore(drawStore, (s) => s.isDrawToolbarVisible);
+  const isDrawing = activeMode !== 'idle' && activeMode !== 'select';
+
   return (
-    <div className={cn('absolute top-4 left-4 z-10 flex flex-col overflow-hidden rounded-lg border border-border-subtle bg-surface-panel shadow-lg')} role="toolbar" aria-label="Zeichenwerkzeuge">
-      {/* Auswahl-Modus */}
+    <div className="absolute top-4 left-4 z-10 flex flex-col overflow-hidden rounded-lg border border-border-subtle bg-surface-panel shadow-lg" role="toolbar" aria-label="Zeichenwerkzeuge">
+      {/* Toggle-Button */}
       <button
         type="button"
-        aria-label="Auswählen"
-        title="Auswählen"
-        onClick={() => onModeChange('select')}
-        className={cn(buttonBase, activeMode === 'select' ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+        aria-label={isExpanded ? 'Werkzeugleiste einklappen' : 'Werkzeugleiste ausklappen'}
+        aria-expanded={isExpanded}
+        aria-controls="draw-toolbar-modes"
+        title={isExpanded ? 'Werkzeugleiste einklappen' : 'Werkzeugleiste ausklappen'}
+        onClick={toggleDrawToolbar}
+        className={cn(buttonBase, isExpanded || isDrawing ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
       >
-        <PiCursor className="h-5 w-5" aria-hidden="true" />
+        <PiPencilSimple className="h-5 w-5" aria-hidden="true" />
       </button>
 
-      {/* Separator */}
-      <div className="mx-2 border-t border-border-subtle" />
+      {/* Expandierbarer Werkzeug-Bereich */}
+      <div id="draw-toolbar-modes" className={cn('grid transition-[grid-template-rows] duration-200 ease-out', isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]')}>
+        <div className="overflow-hidden" {...(!isExpanded && { inert: '' })}>
+          <div className="mx-2 border-t border-border-subtle" />
 
-      {/* Zeichenmodi */}
-      {DRAW_MODE_BUTTONS.map(({ mode, icon: Icon, label }) => (
-        <button
-          key={mode}
-          type="button"
-          aria-label={label}
-          title={label}
-          onClick={() => onModeChange(mode)}
-          className={cn(buttonBase, activeMode === mode ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
-        >
-          <Icon className="h-5 w-5" aria-hidden="true" />
-        </button>
-      ))}
-
-      {/* Separator */}
-      <div className="mx-2 border-t border-border-subtle" />
-
-      {/* OSM-Markierung */}
-      <button
-        type="button"
-        aria-label="OSM-Gebäude markieren"
-        title="OSM-Gebäude markieren"
-        onClick={() => onModeChange('osm_mark')}
-        className={cn(buttonBase, activeMode === 'osm_mark' ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
-      >
-        <PiBuildings className="h-5 w-5" aria-hidden="true" />
-      </button>
-
-      {/* Separator */}
-      <div className="mx-2 border-t border-border-subtle" />
-
-      {/* Undo */}
-      <button
-        type="button"
-        aria-label="Rückgängig"
-        title="Rückgängig"
-        onClick={onUndo}
-        disabled={!canUndo}
-        className={cn(buttonBase, 'text-text-primary hover:bg-action-secondary disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50')}
-      >
-        <PiArrowCounterClockwise className="h-5 w-5" aria-hidden="true" />
-      </button>
-
-      {/* Redo */}
-      <button
-        type="button"
-        aria-label="Wiederholen"
-        title="Wiederholen"
-        onClick={onRedo}
-        disabled={!canRedo}
-        className={cn(buttonBase, 'text-text-primary hover:bg-action-secondary disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50')}
-      >
-        <PiArrowClockwise className="h-5 w-5" aria-hidden="true" />
-      </button>
-
-      {/* Löschen */}
-      <button
-        type="button"
-        aria-label="Auswahl löschen"
-        title="Auswahl löschen"
-        onClick={onDeleteSelected}
-        disabled={!hasSelection}
-        className={cn(
-          buttonBase,
-          'disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50',
-          hasSelection ? 'text-text-primary hover:bg-red-50 hover:text-red-600' : 'text-text-primary',
-        )}
-      >
-        <PiTrash className="h-5 w-5" aria-hidden="true" />
-      </button>
+          {DRAW_MODE_BUTTONS.map(({ mode, icon: Icon, label }) => (
+            <button
+              key={mode}
+              type="button"
+              aria-label={label}
+              title={label}
+              tabIndex={isExpanded ? 0 : -1}
+              onClick={() => onModeChange(mode)}
+              className={cn(buttonBase, activeMode === mode ? 'bg-action-secondary text-action-primary' : 'text-text-primary hover:bg-action-secondary')}
+            >
+              <Icon className="h-5 w-5" aria-hidden="true" />
+            </button>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/frontend/src/features/lagekarte/ui/molecules/OsmMarkierungPopup.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/OsmMarkierungPopup.molecule.tsx
@@ -1,0 +1,59 @@
+/**
+ * OsmMarkierungPopup - Status-Auswahl für OSM-Gebäudemarkierungen
+ *
+ * Wird als Inhalt eines Map-Popups gerendert, wenn ein OSM-Feature
+ * zur Markierung angeklickt wurde. Ermöglicht die Auswahl zwischen
+ * "Betroffen", "Gesperrt" und "Evakuiert".
+ */
+
+import { cn } from '@/shared/ui/cn';
+import type { OsmMarkierungStatus } from '../../drawing/types';
+import type { PendingOsmMark } from '../../hooks/use-osm-markierung';
+
+/** Props für die OsmMarkierungPopup-Komponente */
+export interface OsmMarkierungPopupProps {
+  /** Pending OSM-Markierung */
+  pendingMark: PendingOsmMark;
+  /** Status zuweisen */
+  onConfirm: (status: OsmMarkierungStatus) => void;
+  /** Markierung abbrechen */
+  onCancel: () => void;
+}
+
+/** Status-Optionen mit Darstellung */
+const STATUS_OPTIONS: { status: OsmMarkierungStatus; label: string; bgClass: string }[] = [
+  { status: 'betroffen', label: 'Betroffen', bgClass: 'bg-amber-400 hover:bg-amber-500' },
+  { status: 'gesperrt', label: 'Gesperrt', bgClass: 'bg-red-500 hover:bg-red-600' },
+  { status: 'evakuiert', label: 'Evakuiert', bgClass: 'bg-purple-500 hover:bg-purple-600' },
+];
+
+export function OsmMarkierungPopup({ pendingMark, onConfirm, onCancel }: OsmMarkierungPopupProps) {
+  return (
+    <div className="min-w-48 p-1">
+      <p className="mb-2 text-sm text-text-primary">
+        <span className="font-bold">{pendingMark.featureName}</span> markieren als:
+      </p>
+
+      <div className="flex gap-1.5">
+        {STATUS_OPTIONS.map(({ status, label, bgClass }) => (
+          <button
+            key={status}
+            type="button"
+            onClick={() => onConfirm(status)}
+            className={cn('rounded px-2.5 py-1.5 text-xs font-medium text-white transition-colors duration-100', 'focus-visible:shadow-focus-ring focus-visible:outline-none', bgClass)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={onCancel}
+        className={cn('mt-2 text-xs text-text-muted transition-colors duration-100', 'hover:text-text-primary focus-visible:shadow-focus-ring focus-visible:outline-none')}
+      >
+        Abbrechen
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/src/features/lagekarte/ui/molecules/index.ts
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/index.ts
@@ -1,3 +1,6 @@
 export * from './MapLayerSwitcher.molecule';
 export * from './MapDetailPopup.molecule';
 export * from './MapDetailPanel.molecule';
+export * from './DrawToolbar.molecule';
+export * from './DrawStylePanel.molecule';
+export * from './OsmMarkierungPopup.molecule';

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -280,17 +280,17 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
       {/* Draw-Toolbar */}
       {canDraw && (
         <>
-          <DrawToolbar
+          <DrawToolbar activeMode={drawMode} onModeChange={setMode} />
+          <DrawShortcutBar
             activeMode={drawMode}
-            onModeChange={setMode}
-            onUndo={undo}
-            onRedo={redo}
+            hasSelection={selectedFeatureIds.length > 0}
             canUndo={canUndo}
             canRedo={canRedo}
+            isDirectSelect={isDirectSelect}
+            onUndo={undo}
+            onRedo={redo}
             onDeleteSelected={deleteSelected}
-            hasSelection={selectedFeatureIds.length > 0}
           />
-          <DrawShortcutBar activeMode={drawMode} hasSelection={selectedFeatureIds.length > 0} canUndo={canUndo} canRedo={canRedo} isDirectSelect={isDirectSelect} />
         </>
       )}
 

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -12,7 +12,7 @@ import { Spinner } from '@/shared/ui/atoms/spinner.atom';
 import { cn } from '@/shared/ui/cn';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type * as React from 'react';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Layer, Map, NavigationControl, Popup, Source } from 'react-map-gl/maplibre';
 import type { MapLayerMouseEvent, MapRef } from 'react-map-gl/maplibre';
 import { useStore } from '@tanstack/react-store';
@@ -59,7 +59,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   const isMapLoaded = !isLoading;
 
   // Draw-Control (Kern-Hook)
-  const { undo, redo, canUndo, canRedo, deleteSelected, setMode, drawRef } = useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded });
+  const { undo, redo, canUndo, canRedo, deleteSelected, setMode, drawRef, scheduleAutoSave } = useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded });
 
   // OSM-Markierung (nur bei Vektor-Basislayer)
   const isVectorBaseLayer = selectedBaseLayer === 'osm';
@@ -67,6 +67,31 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
 
   // Style-Panel State
   const [activeStyle, setActiveStyle] = useState<DrawingStyle>(DEFAULT_DRAWING_STYLE);
+
+  // I4: Stil des selektierten Features in das StylePanel laden
+  useEffect(() => {
+    if (selectedFeatureIds.length === 0) return;
+    const draw = drawRef.current;
+    if (!draw) return;
+    const feature = draw.get(selectedFeatureIds[0]);
+    if (!feature?.properties) return;
+    const props = feature.properties;
+    setActiveStyle((prev) => ({
+      ...prev,
+      ...(props.color && { color: props.color }),
+      ...(props.fillColor && { fillColor: props.fillColor }),
+      ...(props.strokeWidth != null && { strokeWidth: props.strokeWidth }),
+      ...(props.fillOpacity != null && { fillOpacity: props.fillOpacity }),
+      ...(props.strokeDasharray && { strokeDasharray: props.strokeDasharray }),
+    }));
+  }, [selectedFeatureIds, drawRef]);
+
+  // Label des selektierten Features lesen
+  const selectedFeatureLabel = useMemo(() => {
+    if (selectedFeatureIds.length === 0 || !drawRef.current) return undefined;
+    const feature = drawRef.current.get(selectedFeatureIds[0]);
+    return feature?.properties?.label as string | undefined;
+  }, [selectedFeatureIds, drawRef]);
 
   /** Stil ändern und auf selektierte Features anwenden */
   const handleStyleChange = useCallback(
@@ -79,8 +104,22 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
           draw.setFeatureProperty(id, key, value);
         }
       }
+      scheduleAutoSave();
     },
-    [selectedFeatureIds, drawRef],
+    [selectedFeatureIds, drawRef, scheduleAutoSave],
+  );
+
+  /** Label ändern und auf selektierte Features anwenden */
+  const handleLabelChange = useCallback(
+    (label: string) => {
+      const draw = drawRef.current;
+      if (!draw) return;
+      for (const id of selectedFeatureIds) {
+        draw.setFeatureProperty(id, 'label', label);
+      }
+      scheduleAutoSave();
+    },
+    [selectedFeatureIds, drawRef, scheduleAutoSave],
   );
 
   /**
@@ -181,12 +220,11 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
           canRedo={canRedo}
           onDeleteSelected={deleteSelected}
           hasSelection={selectedFeatureIds.length > 0}
-          disabled={!canDraw}
         />
       )}
 
       {/* Style-Panel für selektierte Features */}
-      <DrawStylePanel style={activeStyle} onStyleChange={handleStyleChange} isVisible={selectedFeatureIds.length > 0 && canDraw} />
+      <DrawStylePanel style={activeStyle} onStyleChange={handleStyleChange} isVisible={selectedFeatureIds.length > 0 && canDraw} label={selectedFeatureLabel} onLabelChange={handleLabelChange} />
 
       <MapLayerSwitcher availableLayers={availableLayers} selectedBaseLayer={selectedBaseLayer} dwdOverlayEnabled={dwdOverlayEnabled} ninaOverlays={ninaOverlays} />
 

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -2,16 +2,26 @@ import { MAP_DEFAULTS, getDwdWmsTileUrl } from '@/features/lagekarte/utils/map-c
 import { useMapLayer } from '@/features/lagekarte/hooks/use-map-layer';
 import { useMapDetail } from '@/features/lagekarte/hooks/use-map-detail';
 import { useNinaMapData } from '@/features/lagekarte/api/use-nina-map-data';
+import { useDrawControl } from '@/features/lagekarte/hooks/use-draw-control';
+import { useLagekartePermissions } from '@/features/lagekarte/hooks/use-lagekarte-permissions';
+import { useOsmMarkierung } from '@/features/lagekarte/hooks/use-osm-markierung';
+import { drawStore } from '@/features/lagekarte/stores/draw.store';
+import { DEFAULT_DRAWING_STYLE } from '@/features/lagekarte/drawing/types';
+import type { DrawingStyle } from '@/features/lagekarte/drawing/types';
 import { Spinner } from '@/shared/ui/atoms/spinner.atom';
 import { cn } from '@/shared/ui/cn';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type * as React from 'react';
-import { useRef, useState } from 'react';
-import { Layer, Map, NavigationControl, Source } from 'react-map-gl/maplibre';
-import type { MapRef } from 'react-map-gl/maplibre';
+import { useCallback, useRef, useState } from 'react';
+import { Layer, Map, NavigationControl, Popup, Source } from 'react-map-gl/maplibre';
+import type { MapLayerMouseEvent, MapRef } from 'react-map-gl/maplibre';
+import { useStore } from '@tanstack/react-store';
 import { MapLayerSwitcher } from '../../molecules/MapLayerSwitcher.molecule';
 import { MapDetailPopup } from '../../molecules/MapDetailPopup.molecule';
 import { MapDetailPanel } from '../../molecules/MapDetailPanel.molecule';
+import { DrawToolbar } from '../../molecules/DrawToolbar.molecule';
+import { DrawStylePanel } from '../../molecules/DrawStylePanel.molecule';
+import { OsmMarkierungPopup } from '../../molecules/OsmMarkierungPopup.molecule';
 import { FullscreenCloseButton } from '../FullscreenCloseButton/FullscreenCloseButton';
 import { NinaGeoJsonLayer } from '../../molecules/NinaGeoJsonLayer.molecule';
 import '@/features/lagekarte/detail-providers';
@@ -37,6 +47,72 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   const [isLoading, setIsLoading] = useState(true);
   const mapRef = useRef<MapRef | null>(null);
   const { results, coordinate, panelIndex, isPanelOpen, isLoading: isDetailLoading, handleMapClick, openPanel, navigatePanel, closePanel, clearSelection } = useMapDetail(mapRef);
+
+  // Berechtigungen
+  const { canDraw } = useLagekartePermissions();
+
+  // Draw-Store State
+  const drawMode = useStore(drawStore, (s) => s.drawMode);
+  const selectedFeatureIds = useStore(drawStore, (s) => s.selectedFeatureIds);
+
+  // Map-Ladezustand
+  const isMapLoaded = !isLoading;
+
+  // Draw-Control (Kern-Hook)
+  const { undo, redo, canUndo, canRedo, deleteSelected, setMode, drawRef } = useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded });
+
+  // OSM-Markierung (nur bei Vektor-Basislayer)
+  const isVectorBaseLayer = selectedBaseLayer === 'osm';
+  const { handleOsmClick, pendingOsmMark, confirmOsmMark, cancelOsmMark } = useOsmMarkierung({ mapRef, drawRef, isVectorBaseLayer });
+
+  // Style-Panel State
+  const [activeStyle, setActiveStyle] = useState<DrawingStyle>(DEFAULT_DRAWING_STYLE);
+
+  /** Stil ändern und auf selektierte Features anwenden */
+  const handleStyleChange = useCallback(
+    (partial: Partial<DrawingStyle>) => {
+      setActiveStyle((prev) => ({ ...prev, ...partial }));
+      const draw = drawRef.current;
+      if (!draw) return;
+      for (const id of selectedFeatureIds) {
+        for (const [key, value] of Object.entries(partial)) {
+          draw.setFeatureProperty(id, key, value);
+        }
+      }
+    },
+    [selectedFeatureIds, drawRef],
+  );
+
+  /**
+   * Kombinierter Klick-Handler: Entscheidet je nach Zeichenmodus,
+   * ob Draw, OSM-Markierung oder Detail-Provider den Klick verarbeitet.
+   */
+  const handleCombinedClick = useCallback(
+    (event: MapLayerMouseEvent) => {
+      // 1. Im Zeichenmodus: Draw hat Vorrang (MapboxDraw verarbeitet den Klick)
+      if (drawMode !== 'idle' && drawMode !== 'select' && drawMode !== 'osm_mark') {
+        return;
+      }
+
+      // 2. OSM-Markierungsmodus: OSM-Feature-Klick verarbeiten
+      if (drawMode === 'osm_mark') {
+        handleOsmClick(event);
+        return;
+      }
+
+      // 3. Idle/Select: Bestehender Detail-Provider-Flow
+      handleMapClick(event);
+    },
+    [drawMode, handleOsmClick, handleMapClick],
+  );
+
+  /** Cursor je nach Modus bestimmen */
+  const getCursor = () => {
+    if (isDetailLoading) return 'wait';
+    if (drawMode === 'osm_mark') return 'crosshair';
+    if (drawMode !== 'idle' && drawMode !== 'select') return 'crosshair';
+    return undefined;
+  };
 
   return (
     <div className={cn('relative w-full overflow-hidden rounded-lg', mode === 'standard' && 'h-[600px] md:h-[calc(100vh-180px)]', (mode === 'fullscreen' || mode === 'presentation') && 'h-screen')}>
@@ -67,8 +143,8 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
         }}
         style={{ width: '100%', height: '100%' }}
         mapStyle={resolvedStyle}
-        onClick={handleMapClick}
-        cursor={isDetailLoading ? 'wait' : undefined}
+        onClick={handleCombinedClick}
+        cursor={getCursor()}
         onLoad={() => setIsLoading(false)}
         aria-label="Lagekarte"
       >
@@ -85,7 +161,32 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
 
         {/* Detail-Popup am Klick-Punkt */}
         {results.length > 0 && coordinate && !isPanelOpen && <MapDetailPopup results={results} coordinate={coordinate} onShowDetails={openPanel} onClose={clearSelection} />}
+
+        {/* OSM-Markierungs-Popup */}
+        {pendingOsmMark && (
+          <Popup longitude={pendingOsmMark.coordinate.lng} latitude={pendingOsmMark.coordinate.lat} onClose={cancelOsmMark} closeOnClick={false} anchor="bottom">
+            <OsmMarkierungPopup pendingMark={pendingOsmMark} onConfirm={confirmOsmMark} onCancel={cancelOsmMark} />
+          </Popup>
+        )}
       </Map>
+
+      {/* Draw-Toolbar */}
+      {canDraw && (
+        <DrawToolbar
+          activeMode={drawMode}
+          onModeChange={setMode}
+          onUndo={undo}
+          onRedo={redo}
+          canUndo={canUndo}
+          canRedo={canRedo}
+          onDeleteSelected={deleteSelected}
+          hasSelection={selectedFeatureIds.length > 0}
+          disabled={!canDraw}
+        />
+      )}
+
+      {/* Style-Panel für selektierte Features */}
+      <DrawStylePanel style={activeStyle} onStyleChange={handleStyleChange} isVisible={selectedFeatureIds.length > 0 && canDraw} />
 
       <MapLayerSwitcher availableLayers={availableLayers} selectedBaseLayer={selectedBaseLayer} dwdOverlayEnabled={dwdOverlayEnabled} ninaOverlays={ninaOverlays} />
 

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -22,6 +22,7 @@ import { MapLayerSwitcher } from '../../molecules/MapLayerSwitcher.molecule';
 import { MapDetailPopup } from '../../molecules/MapDetailPopup.molecule';
 import { MapDetailPanel } from '../../molecules/MapDetailPanel.molecule';
 import { DrawToolbar } from '../../molecules/DrawToolbar.molecule';
+import { DrawShortcutBar } from '../../molecules/DrawShortcutBar.molecule';
 import { DrawStylePanel } from '../../molecules/DrawStylePanel.molecule';
 import { OsmMarkierungPopup } from '../../molecules/OsmMarkierungPopup.molecule';
 import { FullscreenCloseButton } from '../FullscreenCloseButton/FullscreenCloseButton';
@@ -56,6 +57,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   // Draw-Store State
   const drawMode = useStore(drawStore, (s) => s.drawMode);
   const selectedFeatureIds = useStore(drawStore, (s) => s.selectedFeatureIds);
+  const isDirectSelect = useStore(drawStore, (s) => s.isDirectSelect);
 
   // Map-Ladezustand
   const isMapLoaded = !isLoading;
@@ -120,11 +122,16 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
     };
   }, [isLoading]);
 
-  // Label und Geometrie-Typ des selektierten Features lesen
-  const selectedFeatureLabel = useMemo(() => {
-    if (selectedFeatureIds.length === 0 || !drawRef.current) return undefined;
+  // Label des selektierten Features (lokaler State für sofortige Input-Reaktion)
+  const [selectedFeatureLabel, setSelectedFeatureLabel] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (selectedFeatureIds.length === 0 || !drawRef.current) {
+      setSelectedFeatureLabel(undefined);
+      return;
+    }
     const feature = drawRef.current.get(selectedFeatureIds[0]);
-    return feature?.properties?.label as string | undefined;
+    setSelectedFeatureLabel(feature?.properties?.label as string | undefined);
   }, [selectedFeatureIds, drawRef]);
 
   const selectedFeatureGeometryType = useMemo(() => {
@@ -172,6 +179,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   /** Label ändern und auf selektierte Features anwenden */
   const handleLabelChange = useCallback(
     (label: string) => {
+      setSelectedFeatureLabel(label);
       const draw = drawRef.current;
       if (!draw) return;
       for (const id of selectedFeatureIds) {
@@ -271,16 +279,19 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
 
       {/* Draw-Toolbar */}
       {canDraw && (
-        <DrawToolbar
-          activeMode={drawMode}
-          onModeChange={setMode}
-          onUndo={undo}
-          onRedo={redo}
-          canUndo={canUndo}
-          canRedo={canRedo}
-          onDeleteSelected={deleteSelected}
-          hasSelection={selectedFeatureIds.length > 0}
-        />
+        <>
+          <DrawToolbar
+            activeMode={drawMode}
+            onModeChange={setMode}
+            onUndo={undo}
+            onRedo={redo}
+            canUndo={canUndo}
+            canRedo={canRedo}
+            onDeleteSelected={deleteSelected}
+            hasSelection={selectedFeatureIds.length > 0}
+          />
+          <DrawShortcutBar activeMode={drawMode} hasSelection={selectedFeatureIds.length > 0} canUndo={canUndo} canRedo={canRedo} isDirectSelect={isDirectSelect} />
+        </>
       )}
 
       {/* Style-Panel für selektierte Features */}

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -58,15 +58,19 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   // Map-Ladezustand
   const isMapLoaded = !isLoading;
 
+  // Style-Panel State (vor useDrawControl, damit activeStyleRef verfügbar ist)
+  const [activeStyle, setActiveStyle] = useState<DrawingStyle>(DEFAULT_DRAWING_STYLE);
+  const activeStyleRef = useRef<DrawingStyle>(DEFAULT_DRAWING_STYLE);
+  useEffect(() => {
+    activeStyleRef.current = activeStyle;
+  }, [activeStyle]);
+
   // Draw-Control (Kern-Hook)
-  const { undo, redo, canUndo, canRedo, deleteSelected, setMode, drawRef, scheduleAutoSave } = useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded });
+  const { undo, redo, canUndo, canRedo, deleteSelected, setMode, drawRef, scheduleAutoSave } = useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, activeStyleRef });
 
   // OSM-Markierung (nur bei Vektor-Basislayer)
   const isVectorBaseLayer = selectedBaseLayer === 'osm';
   const { handleOsmClick, pendingOsmMark, confirmOsmMark, cancelOsmMark } = useOsmMarkierung({ mapRef, drawRef, isVectorBaseLayer });
-
-  // Style-Panel State
-  const [activeStyle, setActiveStyle] = useState<DrawingStyle>(DEFAULT_DRAWING_STYLE);
 
   // I4: Stil des selektierten Features in das StylePanel laden
   useEffect(() => {
@@ -86,11 +90,17 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
     }));
   }, [selectedFeatureIds, drawRef]);
 
-  // Label des selektierten Features lesen
+  // Label und Geometrie-Typ des selektierten Features lesen
   const selectedFeatureLabel = useMemo(() => {
     if (selectedFeatureIds.length === 0 || !drawRef.current) return undefined;
     const feature = drawRef.current.get(selectedFeatureIds[0]);
     return feature?.properties?.label as string | undefined;
+  }, [selectedFeatureIds, drawRef]);
+
+  const selectedFeatureGeometryType = useMemo(() => {
+    if (selectedFeatureIds.length === 0 || !drawRef.current) return undefined;
+    const feature = drawRef.current.get(selectedFeatureIds[0]);
+    return feature?.geometry?.type as string | undefined;
   }, [selectedFeatureIds, drawRef]);
 
   /** Stil ändern und auf selektierte Features anwenden */
@@ -224,7 +234,14 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
       )}
 
       {/* Style-Panel für selektierte Features */}
-      <DrawStylePanel style={activeStyle} onStyleChange={handleStyleChange} isVisible={selectedFeatureIds.length > 0 && canDraw} label={selectedFeatureLabel} onLabelChange={handleLabelChange} />
+      <DrawStylePanel
+        style={activeStyle}
+        onStyleChange={handleStyleChange}
+        isVisible={selectedFeatureIds.length > 0 && canDraw}
+        label={selectedFeatureLabel}
+        onLabelChange={handleLabelChange}
+        geometryType={selectedFeatureGeometryType}
+      />
 
       <MapLayerSwitcher availableLayers={availableLayers} selectedBaseLayer={selectedBaseLayer} dwdOverlayEnabled={dwdOverlayEnabled} ninaOverlays={ninaOverlays} />
 

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -101,6 +101,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
       ...(props.color && { color: props.color }),
       ...(props.fillColor && { fillColor: props.fillColor }),
       ...(props.strokeWidth != null && { strokeWidth: props.strokeWidth }),
+      ...(props.fillEnabled != null && { fillEnabled: props.fillEnabled }),
       ...(props.fillOpacity != null && { fillOpacity: props.fillOpacity }),
       ...(props.strokeDasharray && { strokeDasharray: props.strokeDasharray }),
       hatch,

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -7,7 +7,9 @@ import { useLagekartePermissions } from '@/features/lagekarte/hooks/use-lagekart
 import { useOsmMarkierung } from '@/features/lagekarte/hooks/use-osm-markierung';
 import { drawStore } from '@/features/lagekarte/stores/draw.store';
 import { DEFAULT_DRAWING_STYLE } from '@/features/lagekarte/drawing/types';
-import type { DrawingStyle } from '@/features/lagekarte/drawing/types';
+import type { DrawingStyle, HatchConfig } from '@/features/lagekarte/drawing/types';
+import { DEFAULT_HATCH } from '@/features/lagekarte/drawing/types';
+import { ensureHatchImage, migrateLegacyFillPattern, reregisterHatchImages } from '@/features/lagekarte/drawing/hatch-patterns';
 import { Spinner } from '@/shared/ui/atoms/spinner.atom';
 import { cn } from '@/shared/ui/cn';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -80,6 +82,20 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
     const feature = draw.get(selectedFeatureIds[0]);
     if (!feature?.properties) return;
     const props = feature.properties;
+
+    // Hatch-Config wiederherstellen (neues Format oder Legacy-Migration)
+    let hatch: HatchConfig = { ...DEFAULT_HATCH };
+    if (props.hatch) {
+      try {
+        hatch = typeof props.hatch === 'string' ? JSON.parse(props.hatch) : props.hatch;
+      } catch {
+        // Ungültiges JSON — Default beibehalten
+      }
+    } else if (props.fillPattern) {
+      const migrated = migrateLegacyFillPattern(props.fillPattern);
+      if (migrated) hatch = migrated;
+    }
+
     setActiveStyle((prev) => ({
       ...prev,
       ...(props.color && { color: props.color }),
@@ -87,8 +103,21 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
       ...(props.strokeWidth != null && { strokeWidth: props.strokeWidth }),
       ...(props.fillOpacity != null && { fillOpacity: props.fillOpacity }),
       ...(props.strokeDasharray && { strokeDasharray: props.strokeDasharray }),
+      hatch,
     }));
   }, [selectedFeatureIds, drawRef]);
+
+  // Schraffurmuster bei Style-Wechsel erneut registrieren (style.load entfernt alle Images)
+  useEffect(() => {
+    const map = mapRef.current?.getMap();
+    if (!map || isLoading) return;
+
+    const reregister = () => reregisterHatchImages(map);
+    map.on('style.load', reregister);
+    return () => {
+      map.off('style.load', reregister);
+    };
+  }, [isLoading]);
 
   // Label und Geometrie-Typ des selektierten Features lesen
   const selectedFeatureLabel = useMemo(() => {
@@ -106,17 +135,37 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   /** Stil ändern und auf selektierte Features anwenden */
   const handleStyleChange = useCallback(
     (partial: Partial<DrawingStyle>) => {
-      setActiveStyle((prev) => ({ ...prev, ...partial }));
+      const next = { ...activeStyle, ...partial };
+      setActiveStyle(next);
       const draw = drawRef.current;
       if (!draw) return;
+      const map = mapRef.current?.getMap();
+
       for (const id of selectedFeatureIds) {
         for (const [key, value] of Object.entries(partial)) {
+          if (key === 'hatch') continue;
           draw.setFeatureProperty(id, key, value);
         }
+
+        if (partial.hatch !== undefined) {
+          const hatch = next.hatch;
+          draw.setFeatureProperty(id, 'hatch', JSON.stringify(hatch));
+          const imageName = ensureHatchImage(map, hatch, next.color);
+          draw.setFeatureProperty(id, 'fillPattern', imageName);
+        }
+
+        if (partial.color !== undefined && next.hatch.type !== 'none' && next.hatch.color === '') {
+          const imageName = ensureHatchImage(map, next.hatch, next.color);
+          draw.setFeatureProperty(id, 'fillPattern', imageName);
+        }
+
+        const updated = draw.get(id);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (updated) draw.add(updated as any);
       }
       scheduleAutoSave();
     },
-    [selectedFeatureIds, drawRef, scheduleAutoSave],
+    [activeStyle, selectedFeatureIds, drawRef, mapRef, scheduleAutoSave],
   );
 
   /** Label ändern und auf selektierte Features anwenden */

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/lagekarte-view.css
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/lagekarte-view.css
@@ -5,3 +5,8 @@
 .maplibregl-ctrl-bottom-left {
   z-index: 0 !important;
 }
+
+/* MapboxDraw Default-Controls ausblenden — eigene Toolbar wird verwendet */
+.mapboxgl-ctrl-group:has(.mapbox-gl-draw_ctrl-draw-btn) {
+  display: none;
+}


### PR DESCRIPTION
## Summary

- Vollständige Zeichenwerkzeuge für die Lagekarte: Polygon, Linie, Punkt, Freihand, OSM-Objektmarkierung
- Erweiterter Schraffur-Editor mit parametrischer Pattern-Generierung (Mustertyp, Abstand, Strichstärke, Farbe)
- NINA/DWD-Warnlayer mit Detail-Provider-System und GeoJSON-Overlays

## Changes

### Frontend — Zeichenwerkzeuge
- Draw-Control Hook mit Undo/Redo, Auto-Save, Keyboard-Shortcuts
- DrawToolbar (einklappbar), DrawShortcutBar, DrawStylePanel UI-Komponenten
- Freihand-Zeichenmodus (Custom MapboxDraw Mode)
- OSM-Markierungs-Hook mit Overpass-API-Abfrage
- Feature-Selektion, Label-Bearbeitung, Style-Anwendung auf selektierte Features
- Draw-Store (@tanstack/react-store) für Modus- und Selektions-State

### Frontend — Schraffur-Editor
- `HatchConfig`-Objekt ersetzt altes `FillPattern` String-Enum
- Parametrische Canvas-basierte Pattern-Generierung (6 Mustertypen)
- 8 hardcoded Hatch-Layer → 2 data-driven MapLibre Layer
- Migration bestehender Feature-Properties auf neues Format
- DrawStylePanel Aufklapp-Sektion für Schraffur-Anpassung
- Fill-Toggle für Flächen-Features

### Frontend — NINA/DWD-Warnlayer
- Layer-Detail-Provider System (Registry-Pattern)
- NINA GeoJSON Map-Layer mit Unterlayer-Toggles
- DWD-Warnungen und NINA Warn-Details on-demand
- DOMPurify für sichere NINA-Text-Darstellung

### Backend
- Warnungen-Controller mit DWD- und NINA-Services
- NINA GeoJSON Map-Data Service

## Test plan

- [ ] Polygon, Linie, Punkt zeichnen — Style wird korrekt angewendet
- [ ] Freihand-Modus zeichnet flüssig, Re-Entry funktioniert
- [ ] OSM-Markierung: Klick auf Gebäude → Popup → Bestätigen → Feature wird erstellt
- [ ] Schraffur-Editor: Mustertyp, Abstand, Strichstärke, Farbe konfigurierbar
- [ ] Fill-Toggle: Füllung ein/aus für Polygon-Features
- [ ] Undo/Redo funktioniert korrekt (Ctrl+Z / Ctrl+Shift+Z)
- [ ] Feature-Selektion → Label bearbeiten → Style ändern
- [ ] DrawToolbar einklappbar, ShortcutBar kontextabhängig
- [ ] Bestehende Lagekarte-Daten werden korrekt migriert (altes Format → HatchConfig)
- [ ] NINA/DWD-Layer ein/ausblenden, Details anzeigen

🤖 Generated with [Claude Code](https://claude.com/claude-code)