### PR TITLE
✨(frontend): Lagekarte Default Shapes + Snapping (#643)

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -48,6 +48,7 @@
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-store": "^2.4.2",
+    "@turf/turf": "^7.3.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/packages/frontend/src/features/lagekarte/drawing/custom-modes/circle.mode.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/custom-modes/circle.mode.ts
@@ -1,0 +1,96 @@
+/**
+ * Kreis-Zeichenmodus für MapboxDraw
+ *
+ * Zeichnet einen Kreis durch Klick (Mittelpunkt) + Drag (Radius).
+ * Ergebnis ist ein Polygon (64-Punkt-Approximation via turf.circle).
+ */
+
+import { berechneAbstand, erstelleKreis } from '../../utils/geo-calculations';
+
+/** Interner State des Kreis-Modus */
+interface CircleState {
+  polygon: {
+    id: string;
+    properties: Record<string, unknown>;
+    coordinates: number[][][];
+    incomingCoords: (coords: number[][][]) => void;
+    toGeoJSON: () => GeoJSON.Feature;
+  };
+  center: [number, number] | null;
+  currentRadius: number;
+  isDrawing: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const CircleMode: any = {};
+
+CircleMode.onSetup = function (): CircleState {
+  const polygon = this.newFeature({
+    type: 'Feature',
+    geometry: { type: 'Polygon', coordinates: [[]] },
+    properties: { featureType: 'drawing', shapeType: 'circle' },
+  });
+  this.addFeature(polygon);
+  this.setActionableState({ trash: true, combineFeatures: false, uncombineFeatures: false });
+  this.map.dragPan.disable();
+  return { polygon, center: null, currentRadius: 0, isDrawing: false };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+CircleMode.onMouseDown = function (state: CircleState, e: any) {
+  state.center = [e.lngLat.lng, e.lngLat.lat];
+  state.isDrawing = true;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+CircleMode.onDrag = function (state: CircleState, e: any) {
+  if (!state.isDrawing || !state.center) return;
+
+  const current: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+  const radius = berechneAbstand(state.center, current);
+  if (radius < 1) return;
+
+  state.currentRadius = radius;
+  const coords = erstelleKreis(state.center, radius);
+  state.polygon.incomingCoords(coords);
+};
+
+CircleMode.onMouseUp = function (state: CircleState) {
+  if (!state.isDrawing || !state.center) return;
+  state.isDrawing = false;
+  this.map.dragPan.enable();
+
+  if ((state.polygon.coordinates[0]?.length ?? 0) < 3) {
+    this.deleteFeature(state.polygon.id);
+    this.changeMode('simple_select');
+    return;
+  }
+
+  // Shape-Properties direkt am Feature setzen (vor draw.create)
+  state.polygon.properties.shapeCenter = JSON.stringify(state.center);
+  state.polygon.properties.shapeRadius = state.currentRadius;
+
+  this.fire('draw.create', { features: [state.polygon.toGeoJSON()] });
+  this.changeMode('simple_select', { featureIds: [state.polygon.id] });
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+CircleMode.toDisplayFeatures = function (_state: CircleState, geojson: any, display: any) {
+  // Polygon ohne gültige Koordinaten nicht rendern (wie built-in draw_polygon).
+  // Ohne diesen Guard erzeugt ein leeres Polygon ungültiges GeoJSON ([[undefined]]),
+  // das MapboxGL dazu bringt, die gesamte Source nicht zu rendern.
+  if (geojson.geometry.type === 'Polygon') {
+    const ring = geojson.geometry.coordinates?.[0];
+    if (!ring || ring.length < 4) return;
+  }
+  display(geojson);
+};
+
+CircleMode.onStop = function (state: CircleState) {
+  if ((state.polygon.coordinates[0]?.length ?? 0) < 3) {
+    this.deleteFeature(state.polygon.id);
+  }
+  this.map.dragPan.enable();
+};
+
+export { CircleMode };

--- a/packages/frontend/src/features/lagekarte/drawing/custom-modes/direct-select.mode.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/custom-modes/direct-select.mode.ts
@@ -1,0 +1,161 @@
+/**
+ * Custom Direct-Select-Modus für parametrische Formen
+ *
+ * Für Kreise: Zeigt nur einen einzigen Resize-Griff statt aller 64 Polygon-Vertices.
+ * Beim Ziehen wird der Kreis aus Mittelpunkt + neuem Radius neu berechnet.
+ * Für alle anderen Features: Standard-direct_select-Verhalten.
+ */
+
+import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import { berechneAbstand, erstelleKreis, erstelleSektor } from '../../utils/geo-calculations';
+
+const defaultDirectSelect = MapboxDraw.modes.direct_select;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const CustomDirectSelect: any = { ...defaultDirectSelect };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+CustomDirectSelect.onSetup = function (opts: any) {
+  const state = defaultDirectSelect.onSetup.call(this, opts);
+
+  const props = state.feature.properties;
+  if (props.shapeType === 'circle' && props.shapeCenter) {
+    state.isParametric = true;
+    state.shapeType = 'circle';
+    state.shapeCenter = JSON.parse(props.shapeCenter) as [number, number];
+    state.shapeRadius = props.shapeRadius ?? 0;
+  } else if (props.shapeType === 'sector' && props.shapeCenter) {
+    state.isParametric = true;
+    state.shapeType = 'sector';
+    state.shapeCenter = JSON.parse(props.shapeCenter) as [number, number];
+    state.shapeRadius = props.shapeRadius ?? 0;
+    state.shapeBearing = props.shapeBearing ?? 0;
+    state.shapeOpeningAngle = props.shapeOpeningAngle ?? 60;
+  }
+
+  // GAMS-Zonen: Min/Max-Radius aus Nachbar-Zonen berechnen
+  state.minRadius = 1;
+  state.maxRadius = Infinity;
+
+  if (state.isParametric && props.featureType === 'gams_zone') {
+    const centerStr = props.shapeCenter;
+    // Draw-Instanz über Map-Controls finden (für getAll)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const drawCtrl = this.map._controls?.find((c: any) => typeof c.getAll === 'function');
+    const allFeatures = drawCtrl?.getAll()?.features ?? [];
+    const siblingRadii: number[] = [];
+
+    for (const f of allFeatures) {
+      if (f.id !== state.featureId && f.properties?.featureType === 'gams_zone' && f.properties?.shapeCenter === centerStr && f.properties?.shapeRadius) {
+        siblingRadii.push(f.properties.shapeRadius);
+      }
+    }
+
+    siblingRadii.sort((a: number, b: number) => a - b);
+    const currentR = state.shapeRadius;
+
+    for (const r of siblingRadii) {
+      if (r < currentR) state.minRadius = r + 1;
+    }
+    for (const r of siblingRadii) {
+      if (r > currentR) {
+        state.maxRadius = r - 1;
+        break;
+      }
+    }
+  }
+
+  return state;
+};
+
+/**
+ * Zeigt für parametrische Formen nur einen Resize-Griff,
+ * für andere Features das Standard-Verhalten mit allen Vertices.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+CustomDirectSelect.toDisplayFeatures = function (state: any, geojson: any, push: any) {
+  if (!state.isParametric || state.featureId !== geojson.properties.id) {
+    return defaultDirectSelect.toDisplayFeatures.call(this, state, geojson, push);
+  }
+
+  // Polygon mit active-Flag anzeigen
+  geojson.properties.active = 'true';
+  push(geojson);
+
+  // Nur einen einzigen Resize-Griff anzeigen (statt 64+ Vertices)
+  const coords = geojson.geometry.coordinates[0];
+  if (coords?.length > 0) {
+    // Griff am ersten Punkt des Rings (= "nördlichster" Punkt bei turf.circle)
+    const handleCoord = coords[0];
+    const isSelected = state.selectedCoordPaths.indexOf('0.0') !== -1;
+    push({
+      type: 'Feature',
+      properties: {
+        meta: 'vertex',
+        parent: state.featureId,
+        coord_path: '0.0',
+        active: isSelected ? 'true' : 'false',
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: handleCoord,
+      },
+    });
+  }
+
+  this.fireActionable(state);
+};
+
+/**
+ * Für parametrische Formen: Gesamte Geometrie neu berechnen statt einzelnen Vertex zu verschieben.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+CustomDirectSelect.dragVertex = function (state: any, e: any, delta: any) {
+  if (!state.isParametric) {
+    return defaultDirectSelect.dragVertex.call(this, state, e, delta);
+  }
+
+  const center = state.shapeCenter as [number, number];
+  const dragPoint: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+  let newRadius = berechneAbstand(center, dragPoint);
+
+  // Radius zwischen Min/Max beschränken (GAMS-Zonen)
+  newRadius = Math.max(state.minRadius ?? 1, Math.min(state.maxRadius ?? Infinity, newRadius));
+  if (newRadius < 1) return;
+
+  state.shapeRadius = newRadius;
+
+  if (state.shapeType === 'circle') {
+    const coords = erstelleKreis(center, newRadius);
+    // incomingCoords erwartet GeoJSON-Koordinaten (mit Closing-Point)
+    state.feature.incomingCoords(coords);
+  } else if (state.shapeType === 'sector') {
+    const coords = erstelleSektor(center, newRadius, state.shapeBearing, state.shapeOpeningAngle);
+    state.feature.incomingCoords(coords);
+  }
+};
+
+/**
+ * Keine Midpoints für parametrische Formen zulassen (würden die Form korrumpieren).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+CustomDirectSelect.onMidpoint = function (state: any, e: any) {
+  if (state.isParametric) return;
+  return defaultDirectSelect.onMidpoint.call(this, state, e);
+};
+
+/**
+ * Nach dem Drag: Shape-Properties (Radius) am Feature aktualisieren.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+CustomDirectSelect.onTouchEnd = CustomDirectSelect.onMouseUp = function (state: any) {
+  if (state.isParametric && state.dragMoving) {
+    state.feature.properties.shapeRadius = state.shapeRadius;
+  }
+  if (state.dragMoving) {
+    this.fireUpdate();
+  }
+  this.stopDragging(state);
+};
+
+export { CustomDirectSelect };

--- a/packages/frontend/src/features/lagekarte/drawing/custom-modes/freehand.mode.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/custom-modes/freehand.mode.ts
@@ -59,6 +59,11 @@ FreehandMode.onMouseUp = function (state: FreehandState) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 FreehandMode.toDisplayFeatures = function (_state: FreehandState, geojson: any, display: any) {
+  if (geojson.geometry.type === 'LineString' && (geojson.geometry.coordinates?.length ?? 0) < 2) return;
+  if (geojson.geometry.type === 'Polygon') {
+    const ring = geojson.geometry.coordinates?.[0];
+    if (!ring || ring.length < 4) return;
+  }
   display(geojson);
 };
 

--- a/packages/frontend/src/features/lagekarte/drawing/custom-modes/gams.mode.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/custom-modes/gams.mode.ts
@@ -1,0 +1,144 @@
+/**
+ * GAMS-Zonen-Platzierungsmodus für MapboxDraw
+ *
+ * Zwei Eingabemodi:
+ * 1. Klick + Drag → Zone interaktiv aufziehen (nacheinander Rot → Orange → Gelb → Grün)
+ * 2. Einfacher Klick → Popup mit Radien-Eingabe (für exakte Werte)
+ */
+
+import { berechneAbstand, erstelleKreis } from '../../utils/geo-calculations';
+
+/** GAMS-Zonen-Farben [Rot, Orange, Gelb, Grün] */
+const GAMS_FARBEN = ['#ef4444', '#f97316', '#eab308', '#22c55e'] as const;
+
+/** Interner State des GAMS-Modus */
+interface GamsState {
+  center: [number, number] | null;
+  /** Aktueller Zonen-Index (0–3) */
+  zoneIndex: number;
+  /** Polygon für die aktuell gezeichnete Zone */
+  currentPolygon: {
+    id: string;
+    properties: Record<string, unknown>;
+    coordinates: number[][][];
+    incomingCoords: (coords: number[][][]) => void;
+    toGeoJSON: () => GeoJSON.Feature;
+  } | null;
+  /** IDs der bereits platzierten Zonen-Features */
+  placedIds: string[];
+  isDrawing: boolean;
+  /** True wenn Nutzer nur geklickt hat (kein Drag) → Popup-Modus */
+  wasClick: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const GamsMode: any = {};
+
+GamsMode.onSetup = function (): GamsState {
+  this.setActionableState({ trash: true, combineFeatures: false, uncombineFeatures: false });
+  return {
+    center: null,
+    zoneIndex: 0,
+    currentPolygon: null,
+    placedIds: [],
+    isDrawing: false,
+    wasClick: true,
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+GamsMode.onMouseDown = function (state: GamsState, e: any) {
+  if (state.zoneIndex >= 4) return;
+
+  const clickPos: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+
+  if (!state.center) {
+    state.center = clickPos;
+  }
+
+  // Neues Polygon für aktuelle Zone erstellen
+  const farbe = GAMS_FARBEN[state.zoneIndex];
+  const polygon = this.newFeature({
+    type: 'Feature',
+    geometry: { type: 'Polygon', coordinates: [[]] },
+    properties: {
+      featureType: 'gams_zone',
+      shapeType: 'circle',
+      color: farbe,
+      fillColor: farbe,
+      fillEnabled: true,
+      fillOpacity: 0.15,
+      strokeWidth: 2,
+      shapeCenter: JSON.stringify(state.center),
+    },
+  });
+  this.addFeature(polygon);
+  state.currentPolygon = polygon;
+  state.isDrawing = true;
+  state.wasClick = true;
+  this.map.dragPan.disable();
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+GamsMode.onDrag = function (state: GamsState, e: any) {
+  if (!state.isDrawing || !state.center || !state.currentPolygon) return;
+
+  state.wasClick = false;
+  const current: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+  const radius = berechneAbstand(state.center, current);
+  if (radius < 1) return;
+
+  const coords = erstelleKreis(state.center, radius);
+  state.currentPolygon.incomingCoords(coords);
+  state.currentPolygon.properties.shapeRadius = radius;
+};
+
+GamsMode.onMouseUp = function (state: GamsState) {
+  if (!state.isDrawing || !state.currentPolygon) return;
+  state.isDrawing = false;
+  this.map.dragPan.enable();
+
+  if (state.wasClick) {
+    // Nur Klick ohne Drag → Popup-Modus
+    this.deleteFeature(state.currentPolygon.id);
+    state.currentPolygon = null;
+
+    this.map.fire('gams.platzieren', { center: state.center });
+    return;
+  }
+
+  // Aufzieh-Modus: Zone finalisieren
+  if ((state.currentPolygon.coordinates[0]?.length ?? 0) < 3) {
+    this.deleteFeature(state.currentPolygon.id);
+    state.currentPolygon = null;
+    return;
+  }
+
+  this.fire('draw.create', { features: [state.currentPolygon.toGeoJSON()] });
+  state.placedIds.push(state.currentPolygon.id);
+  state.currentPolygon = null;
+  state.zoneIndex++;
+
+  if (state.zoneIndex >= 4) {
+    // Alle 4 Zonen platziert → Modus beenden
+    this.changeMode('simple_select', { featureIds: state.placedIds });
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+GamsMode.toDisplayFeatures = function (_state: GamsState, geojson: any, display: any) {
+  if (geojson.geometry.type === 'Polygon') {
+    const ring = geojson.geometry.coordinates?.[0];
+    if (!ring || ring.length < 4) return;
+  }
+  display(geojson);
+};
+
+GamsMode.onStop = function (state: GamsState) {
+  if (state.currentPolygon && (state.currentPolygon.coordinates[0]?.length ?? 0) < 3) {
+    this.deleteFeature(state.currentPolygon.id);
+  }
+  this.map.dragPan.enable();
+};
+
+export { GamsMode };

--- a/packages/frontend/src/features/lagekarte/drawing/custom-modes/rectangle.mode.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/custom-modes/rectangle.mode.ts
@@ -1,0 +1,83 @@
+/**
+ * Rechteck-Zeichenmodus für MapboxDraw
+ *
+ * Zeichnet ein Rechteck durch Klick (erste Ecke) + Drag (gegenüberliegende Ecke).
+ */
+
+import { erstelleRechteck } from '../../utils/geo-calculations';
+
+/** Interner State des Rechteck-Modus */
+interface RectangleState {
+  polygon: {
+    id: string;
+    properties: Record<string, unknown>;
+    coordinates: number[][][];
+    incomingCoords: (coords: number[][][]) => void;
+    toGeoJSON: () => GeoJSON.Feature;
+  };
+  corner: [number, number] | null;
+  isDrawing: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const RectangleMode: any = {};
+
+RectangleMode.onSetup = function (): RectangleState {
+  const polygon = this.newFeature({
+    type: 'Feature',
+    geometry: { type: 'Polygon', coordinates: [[]] },
+    properties: { featureType: 'drawing', shapeType: 'rectangle' },
+  });
+  this.addFeature(polygon);
+  this.setActionableState({ trash: true, combineFeatures: false, uncombineFeatures: false });
+  this.map.dragPan.disable();
+  return { polygon, corner: null, isDrawing: false };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+RectangleMode.onMouseDown = function (state: RectangleState, e: any) {
+  state.corner = [e.lngLat.lng, e.lngLat.lat];
+  state.isDrawing = true;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+RectangleMode.onDrag = function (state: RectangleState, e: any) {
+  if (!state.isDrawing || !state.corner) return;
+
+  const current: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+  const coords = erstelleRechteck(state.corner, current);
+  state.polygon.incomingCoords(coords);
+};
+
+RectangleMode.onMouseUp = function (state: RectangleState) {
+  if (!state.isDrawing || !state.corner) return;
+  state.isDrawing = false;
+  this.map.dragPan.enable();
+
+  if ((state.polygon.coordinates[0]?.length ?? 0) < 4) {
+    this.deleteFeature(state.polygon.id);
+    this.changeMode('simple_select');
+    return;
+  }
+
+  this.fire('draw.create', { features: [state.polygon.toGeoJSON()] });
+  this.changeMode('simple_select', { featureIds: [state.polygon.id] });
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+RectangleMode.toDisplayFeatures = function (_state: RectangleState, geojson: any, display: any) {
+  if (geojson.geometry.type === 'Polygon') {
+    const ring = geojson.geometry.coordinates?.[0];
+    if (!ring || ring.length < 4) return;
+  }
+  display(geojson);
+};
+
+RectangleMode.onStop = function (state: RectangleState) {
+  if ((state.polygon.coordinates[0]?.length ?? 0) < 4) {
+    this.deleteFeature(state.polygon.id);
+  }
+  this.map.dragPan.enable();
+};
+
+export { RectangleMode };

--- a/packages/frontend/src/features/lagekarte/drawing/custom-modes/sector.mode.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/custom-modes/sector.mode.ts
@@ -1,0 +1,112 @@
+/**
+ * Sektor/Ausbreitungskegel-Zeichenmodus für MapboxDraw
+ *
+ * Zeichnet einen Kreissektor durch Klick (Mittelpunkt) + Drag (Richtung + Radius).
+ * Die Drag-Richtung bestimmt den Bearing, die Distanz den Radius.
+ * Standard-Öffnungswinkel: 60°.
+ */
+
+import { berechneAbstand, berechneBearing, erstelleSektor } from '../../utils/geo-calculations';
+
+/** Standard-Öffnungswinkel in Grad */
+const DEFAULT_OPENING_ANGLE = 60;
+
+/** Interner State des Sektor-Modus */
+interface SectorState {
+  polygon: {
+    id: string;
+    properties: Record<string, unknown>;
+    coordinates: number[][][];
+    incomingCoords: (coords: number[][][]) => void;
+    toGeoJSON: () => GeoJSON.Feature;
+  };
+  center: [number, number] | null;
+  isDrawing: boolean;
+  openingAngle: number;
+  currentRadius: number;
+  currentBearing: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const SectorMode: any = {};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+SectorMode.onSetup = function (options?: any): SectorState {
+  const polygon = this.newFeature({
+    type: 'Feature',
+    geometry: { type: 'Polygon', coordinates: [[]] },
+    properties: { featureType: 'drawing', shapeType: 'sector' },
+  });
+  this.addFeature(polygon);
+  this.setActionableState({ trash: true, combineFeatures: false, uncombineFeatures: false });
+  this.map.dragPan.disable();
+  return {
+    polygon,
+    center: null,
+    isDrawing: false,
+    openingAngle: options?.openingAngle ?? DEFAULT_OPENING_ANGLE,
+    currentRadius: 0,
+    currentBearing: 0,
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+SectorMode.onMouseDown = function (state: SectorState, e: any) {
+  state.center = [e.lngLat.lng, e.lngLat.lat];
+  state.isDrawing = true;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+SectorMode.onDrag = function (state: SectorState, e: any) {
+  if (!state.isDrawing || !state.center) return;
+
+  const current: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+  const radius = berechneAbstand(state.center, current);
+  if (radius < 1) return;
+
+  const bearing = berechneBearing(state.center, current);
+  state.currentRadius = radius;
+  state.currentBearing = bearing;
+
+  const coords = erstelleSektor(state.center, radius, bearing, state.openingAngle);
+  state.polygon.incomingCoords(coords);
+};
+
+SectorMode.onMouseUp = function (state: SectorState) {
+  if (!state.isDrawing || !state.center) return;
+  state.isDrawing = false;
+  this.map.dragPan.enable();
+
+  if ((state.polygon.coordinates[0]?.length ?? 0) < 3) {
+    this.deleteFeature(state.polygon.id);
+    this.changeMode('simple_select');
+    return;
+  }
+
+  // Shape-Properties direkt am Feature setzen (vor draw.create)
+  state.polygon.properties.shapeCenter = JSON.stringify(state.center);
+  state.polygon.properties.shapeRadius = state.currentRadius;
+  state.polygon.properties.shapeBearing = state.currentBearing;
+  state.polygon.properties.shapeOpeningAngle = state.openingAngle;
+
+  this.fire('draw.create', { features: [state.polygon.toGeoJSON()] });
+  this.changeMode('simple_select', { featureIds: [state.polygon.id] });
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+SectorMode.toDisplayFeatures = function (_state: SectorState, geojson: any, display: any) {
+  if (geojson.geometry.type === 'Polygon') {
+    const ring = geojson.geometry.coordinates?.[0];
+    if (!ring || ring.length < 4) return;
+  }
+  display(geojson);
+};
+
+SectorMode.onStop = function (state: SectorState) {
+  if ((state.polygon.coordinates[0]?.length ?? 0) < 3) {
+    this.deleteFeature(state.polygon.id);
+  }
+  this.map.dragPan.enable();
+};
+
+export { SectorMode };

--- a/packages/frontend/src/features/lagekarte/drawing/snap-indicator-styles.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/snap-indicator-styles.ts
@@ -1,0 +1,24 @@
+/**
+ * MapLibre Layer-Definition für den Snap-Punkt-Indikator
+ *
+ * Zeigt einen hervorgehobenen Punkt an der Snap-Position.
+ */
+
+import type { LayerSpecification } from 'maplibre-gl';
+
+export const SNAP_INDICATOR_SOURCE_ID = 'snap-indicator-source';
+export const SNAP_INDICATOR_LAYER_ID = 'snap-indicator-layer';
+
+/** Layer-Spec für den Snap-Indikator (weißer Punkt mit blauem Rand) */
+export const SNAP_INDICATOR_LAYER: LayerSpecification = {
+  id: SNAP_INDICATOR_LAYER_ID,
+  type: 'circle',
+  source: SNAP_INDICATOR_SOURCE_ID,
+  paint: {
+    'circle-radius': 6,
+    'circle-color': '#ffffff',
+    'circle-stroke-width': 2.5,
+    'circle-stroke-color': '#3b82f6',
+    'circle-opacity': 0.9,
+  },
+};

--- a/packages/frontend/src/features/lagekarte/drawing/types.ts
+++ b/packages/frontend/src/features/lagekarte/drawing/types.ts
@@ -5,7 +5,19 @@
  */
 
 /** Verfügbare Zeichenmodi */
-export type DrawMode = 'idle' | 'select' | 'draw_point' | 'draw_line_string' | 'draw_polygon' | 'draw_freehand' | 'draw_text' | 'osm_mark';
+export type DrawMode =
+  | 'idle'
+  | 'select'
+  | 'draw_point'
+  | 'draw_line_string'
+  | 'draw_polygon'
+  | 'draw_freehand'
+  | 'draw_text'
+  | 'osm_mark'
+  | 'draw_circle'
+  | 'draw_rectangle'
+  | 'draw_sector'
+  | 'draw_gams';
 
 /** Status einer OSM-Markierung */
 export type OsmMarkierungStatus = 'betroffen' | 'gesperrt' | 'evakuiert';
@@ -71,14 +83,33 @@ export interface DrawFeatureProperties {
   /** Beschriftung (für Text-Features) */
   label?: string;
   /** Typ des Features */
-  featureType: 'drawing' | 'osm_marking';
+  featureType: 'drawing' | 'osm_marking' | 'gams_zone';
   /** OSM-Feature-ID (nur für OSM-Markierungen) */
   osmFeatureId?: string;
   /** OSM-Layer-ID (nur für OSM-Markierungen) */
   osmLayerId?: string;
   /** Markierungsstatus (nur für OSM-Markierungen) */
   osmStatus?: OsmMarkierungStatus;
+  /** Shape-Typ für parametrische Formen (Kreis, Rechteck, Sektor) */
+  shapeType?: 'circle' | 'rectangle' | 'sector';
+  /** Mittelpunkt als JSON-String "[lng, lat]" (MapboxDraw erlaubt nur Primitive) */
+  shapeCenter?: string;
+  /** Radius in Metern (für Kreis/Sektor) */
+  shapeRadius?: number;
+  /** Kompasswinkel in Grad (für Sektor) */
+  shapeBearing?: number;
+  /** Öffnungswinkel in Grad (für Sektor) */
+  shapeOpeningAngle?: number;
 }
+
+/** Standard-Radien für GAMS-Zonen in Metern [Rot, Orange, Gelb, Grün] */
+export const GAMS_DEFAULT_RADIEN: [number, number, number, number] = [50, 100, 300, 500];
+
+/** Farbzuordnung für GAMS-Zonen */
+export const GAMS_ZONEN_FARBEN = ['#ef4444', '#f97316', '#eab308', '#22c55e'] as const;
+
+/** Namen der GAMS-Zonen */
+export const GAMS_ZONEN_NAMEN = ['Gefahrenzone (Rot)', 'Absperrbereich (Orange)', 'Warnbereich (Gelb)', 'Äußerer Bereich (Grün)'] as const;
 
 /** Farbzuordnung für OSM-Markierungsstatus */
 export const OSM_MARKING_COLORS: Record<OsmMarkierungStatus, string> = {

--- a/packages/frontend/src/features/lagekarte/hooks/index.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/index.ts
@@ -4,3 +4,5 @@ export * from './use-lagekarte-permissions';
 export * from './use-draw-control';
 export * from './use-osm-markierung';
 export * from './use-feature-measurement';
+export * from './use-gams-zonen';
+export * from './use-snap-control';

--- a/packages/frontend/src/features/lagekarte/hooks/index.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './use-map-detail';
 export * from './use-lagekarte-permissions';
 export * from './use-draw-control';
 export * from './use-osm-markierung';
+export * from './use-feature-measurement';

--- a/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-draw-control.ts
@@ -16,8 +16,14 @@ import { useLagekarte } from '../api/use-lagekarte';
 import { DRAW_FEATURE_LIMIT } from '../utils/map-config';
 import { CUSTOM_DRAW_STYLES } from '../drawing/draw-styles';
 import { FreehandMode } from '../drawing/custom-modes/freehand.mode';
+import { CircleMode } from '../drawing/custom-modes/circle.mode';
+import { RectangleMode } from '../drawing/custom-modes/rectangle.mode';
+import { SectorMode } from '../drawing/custom-modes/sector.mode';
+import { GamsMode } from '../drawing/custom-modes/gams.mode';
+import { CustomDirectSelect } from '../drawing/custom-modes/direct-select.mode';
 import type { DrawMode, DrawingStyle } from '../drawing/types';
 import { ensureHatchImage } from '../drawing/hatch-patterns';
+import { toggleSnapEnabled } from '../stores/draw.store';
 
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 
@@ -39,6 +45,10 @@ const DRAW_MODE_MAP: Record<DrawMode, string> = {
   draw_freehand: 'draw_freehand',
   draw_text: 'draw_point',
   osm_mark: 'simple_select',
+  draw_circle: 'draw_circle',
+  draw_rectangle: 'draw_rectangle',
+  draw_sector: 'draw_sector',
+  draw_gams: 'draw_gams',
 };
 
 interface UseDrawControlOptions {
@@ -149,7 +159,12 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, active
       userProperties: true,
       modes: {
         ...MapboxDraw.modes,
+        direct_select: CustomDirectSelect,
         draw_freehand: FreehandMode,
+        draw_circle: CircleMode,
+        draw_rectangle: RectangleMode,
+        draw_sector: SectorMode,
+        draw_gams: GamsMode,
       },
       styles: CUSTOM_DRAW_STYLES,
     });
@@ -189,7 +204,9 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, active
       }
 
       // Aktuellen Stil auf das neue Feature anwenden
-      if (e.features?.length > 0) {
+      // GAMS-Zonen bringen eigene Farben mit → Style-Override überspringen
+      const isGamsMode = drawModeRef.current === 'draw_gams';
+      if (e.features?.length > 0 && !isGamsMode) {
         const featureId = String(e.features[0].id);
         const currentStyle = activeStyleRef.current;
         draw.setFeatureProperty(featureId, 'color', currentStyle.color);
@@ -221,7 +238,7 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, active
       // Zeichenmodus nach Feature-Erstellung erneut aktivieren (kontinuierliches Zeichnen).
       // Text-Modus ausgenommen: Feature bleibt selektiert für Label-Bearbeitung.
       const currentMode = drawModeRef.current;
-      const continuousModes: DrawMode[] = ['draw_point', 'draw_line_string', 'draw_polygon', 'draw_freehand'];
+      const continuousModes: DrawMode[] = ['draw_point', 'draw_line_string', 'draw_polygon', 'draw_freehand', 'draw_circle', 'draw_rectangle', 'draw_sector'];
       if (continuousModes.includes(currentMode)) {
         const targetMapboxMode = DRAW_MODE_MAP[currentMode];
         setTimeout(() => {
@@ -428,6 +445,12 @@ export function useDrawControl({ mapRef, einsatzId, canDraw, isMapLoaded, active
       }
 
       const isMeta = e.metaKey || e.ctrlKey;
+
+      // S → Snap-Toggle (nur ohne Modifier)
+      if (e.key === 's' && !isMeta && !e.shiftKey && !e.altKey) {
+        toggleSnapEnabled();
+        return;
+      }
 
       // Escape → Idle-Modus
       if (e.key === 'Escape') {

--- a/packages/frontend/src/features/lagekarte/hooks/use-feature-measurement.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-feature-measurement.ts
@@ -1,0 +1,152 @@
+/**
+ * Hook für Geo-Messungen von Lagekarte-Features
+ *
+ * Berechnet Fläche (Polygone), Länge (Linien) und Koordinaten (Punkte)
+ * sowohl für selektierte Features als auch live während des Zeichnens.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { MapRef } from 'react-map-gl/maplibre';
+import type MapboxDraw from '@mapbox/mapbox-gl-draw';
+import { useStore } from '@tanstack/react-store';
+import { drawStore } from '../stores/draw.store';
+import type { FeatureMeasurement } from '../utils/geo-calculations';
+import { measureFeature } from '../utils/geo-calculations';
+import type { DrawMode } from '../drawing/types';
+
+interface UseFeatureMeasurementOptions {
+  /** Referenz auf die MapLibre-GL-Instanz */
+  mapRef: React.RefObject<MapRef | null>;
+  /** Referenz auf die MapboxDraw-Instanz */
+  drawRef: React.RefObject<MapboxDraw | null>;
+  /** Ob die Karte geladen ist */
+  isMapLoaded: boolean;
+}
+
+interface UseFeatureMeasurementReturn {
+  /** Messung des aktuell selektierten Features */
+  selectedMeasurement: FeatureMeasurement | null;
+  /** Live-Messung während des Zeichnens */
+  liveMeasurement: FeatureMeasurement | null;
+}
+
+/** Zeichenmodi in denen Live-Messung sinnvoll ist */
+const LIVE_DRAW_MODES: DrawMode[] = ['draw_polygon', 'draw_line_string', 'draw_freehand'];
+
+/**
+ * Berechnet Messungen für selektierte und aktuell gezeichnete Features.
+ *
+ * - selectedMeasurement: Aktualisiert sich bei Feature-Selektion und Vertex-Bearbeitung
+ * - liveMeasurement: Aktualisiert sich bei jedem Render-Cycle während des Zeichnens
+ */
+export function useFeatureMeasurement({ mapRef, drawRef, isMapLoaded }: UseFeatureMeasurementOptions): UseFeatureMeasurementReturn {
+  const [selectedMeasurement, setSelectedMeasurement] = useState<FeatureMeasurement | null>(null);
+  const [liveMeasurement, setLiveMeasurement] = useState<FeatureMeasurement | null>(null);
+
+  const selectedFeatureIds = useStore(drawStore, (s) => s.selectedFeatureIds);
+  const drawMode = useStore(drawStore, (s) => s.drawMode);
+
+  // Ref für drawMode in Event-Handlern (vermeidet Stale-Closure)
+  const drawModeRef = useRef(drawMode);
+  useEffect(() => {
+    drawModeRef.current = drawMode;
+  }, [drawMode]);
+
+  /**
+   * Messung für ein Feature aus der Draw-Instanz berechnen
+   */
+  const measureDrawFeature = useCallback(
+    (featureId: string): FeatureMeasurement | null => {
+      const draw = drawRef.current;
+      if (!draw) return null;
+      const feature = draw.get(featureId);
+      if (!feature?.geometry) return null;
+      return measureFeature(feature.geometry);
+    },
+    [drawRef],
+  );
+
+  // Messung bei Selektionsänderung aktualisieren
+  useEffect(() => {
+    if (selectedFeatureIds.length === 0) {
+      setSelectedMeasurement(null);
+      return;
+    }
+    setSelectedMeasurement(measureDrawFeature(selectedFeatureIds[0]));
+  }, [selectedFeatureIds, measureDrawFeature]);
+
+  // Live-Messung bei Modus-Wechsel zurücksetzen
+  useEffect(() => {
+    if (!LIVE_DRAW_MODES.includes(drawMode)) {
+      setLiveMeasurement(null);
+    }
+  }, [drawMode]);
+
+  // Event-Listener für draw.update (Vertex-Verschiebung) und draw.render (Live-Zeichnung)
+  useEffect(() => {
+    const map = mapRef.current?.getMap();
+    if (!map || !isMapLoaded) return;
+
+    /**
+     * draw.update: Feature wurde bearbeitet (Vertex verschoben, Feature bewegt).
+     * Aktualisiert die selectedMeasurement.
+     */
+    const handleUpdate = () => {
+      const draw = drawRef.current;
+      if (!draw) return;
+
+      const selected = draw.getSelectedIds();
+      if (selected.length > 0) {
+        const feature = draw.get(selected[0]);
+        if (feature?.geometry) {
+          setSelectedMeasurement(measureFeature(feature.geometry));
+        }
+      }
+    };
+
+    /**
+     * draw.render: Feuert bei jedem MapboxDraw-Render (auch während des Zeichnens).
+     * MapboxDraw trackt das in-progress Feature ab dem ersten Vertex in seiner
+     * internen Collection — es erscheint als letztes Feature in getAll().
+     */
+    const handleRender = () => {
+      const mode = drawModeRef.current;
+      if (!LIVE_DRAW_MODES.includes(mode)) return;
+
+      const draw = drawRef.current;
+      if (!draw) return;
+
+      const all = draw.getAll();
+      if (all.features.length === 0) {
+        setLiveMeasurement(null);
+        return;
+      }
+
+      // Das in-progress Feature ist das letzte in der Collection.
+      // Für Polygone brauchen wir mind. 3 Vertices für eine sinnvolle Fläche,
+      // für Linien mind. 2 Vertices für eine Länge.
+      const lastFeature = all.features[all.features.length - 1];
+      if (!lastFeature?.geometry) {
+        setLiveMeasurement(null);
+        return;
+      }
+
+      try {
+        setLiveMeasurement(measureFeature(lastFeature.geometry));
+      } catch {
+        // Unvollständige Geometrie während des Zeichnens
+        setLiveMeasurement(null);
+      }
+    };
+
+    map.on('draw.update', handleUpdate);
+    map.on('draw.render', handleRender);
+
+    return () => {
+      map.off('draw.update', handleUpdate);
+      map.off('draw.render', handleRender);
+    };
+  }, [mapRef, drawRef, isMapLoaded]);
+
+  return { selectedMeasurement, liveMeasurement };
+}

--- a/packages/frontend/src/features/lagekarte/hooks/use-feature-measurement.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-feature-measurement.ts
@@ -31,7 +31,7 @@ interface UseFeatureMeasurementReturn {
 }
 
 /** Zeichenmodi in denen Live-Messung sinnvoll ist */
-const LIVE_DRAW_MODES: DrawMode[] = ['draw_polygon', 'draw_line_string', 'draw_freehand'];
+const LIVE_DRAW_MODES: DrawMode[] = ['draw_polygon', 'draw_line_string', 'draw_freehand', 'draw_circle', 'draw_rectangle', 'draw_sector'];
 
 /**
  * Berechnet Messungen für selektierte und aktuell gezeichnete Features.

--- a/packages/frontend/src/features/lagekarte/hooks/use-gams-zonen.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-gams-zonen.ts
@@ -1,0 +1,108 @@
+/**
+ * GAMS-Zonen Hook für die Lagekarte
+ *
+ * Verwaltet die Platzierung von GAMS-Gefahrenzonen (4 konzentrische Kreise).
+ * Folgt dem gleichen Pattern wie useOsmMarkierung: Event → Popup → Features erstellen.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { MapRef } from 'react-map-gl/maplibre';
+import type MapboxDraw from '@mapbox/mapbox-gl-draw';
+import { erstelleKreis } from '../utils/geo-calculations';
+import { GAMS_ZONEN_FARBEN } from '../drawing/types';
+import { setDrawMode } from '../stores/draw.store';
+
+interface UseGamsZonenOptions {
+  mapRef: React.RefObject<MapRef | null>;
+  drawRef: React.RefObject<MapboxDraw | null>;
+  isMapLoaded: boolean;
+  /** Auto-Save nach Feature-Erstellung auslösen */
+  scheduleAutoSave: () => void;
+}
+
+interface UseGamsZonenReturn {
+  /** Mittelpunkt der ausstehenden GAMS-Platzierung */
+  pendingGamsCenter: [number, number] | null;
+  /** GAMS-Zonen mit den angegebenen Radien platzieren */
+  confirmiereGamsZonen: (radien: [number, number, number, number]) => void;
+  /** Ausstehende GAMS-Platzierung abbrechen */
+  abbrechenGamsZonen: () => void;
+}
+
+/**
+ * Verwaltet GAMS-Gefahrenzonen: Event-Listener, Konfigurations-Popup, Feature-Erstellung.
+ */
+export function useGamsZonen({ mapRef, drawRef, isMapLoaded, scheduleAutoSave }: UseGamsZonenOptions): UseGamsZonenReturn {
+  const [pendingGamsCenter, setPendingGamsCenter] = useState<[number, number] | null>(null);
+  const scheduleAutoSaveRef = useRef(scheduleAutoSave);
+  useEffect(() => {
+    scheduleAutoSaveRef.current = scheduleAutoSave;
+  }, [scheduleAutoSave]);
+
+  // Auf gams.platzieren Event lauschen
+  useEffect(() => {
+    if (!isMapLoaded || !mapRef.current) return;
+    const map = mapRef.current.getMap();
+    if (!map) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleGamsPlatzieren = (e: any) => {
+      const center = e.center as [number, number];
+      if (center) {
+        setPendingGamsCenter(center);
+        // Store-Modus auf 'select' setzen (GAMS-Klick ist ein One-Shot)
+        setDrawMode('select');
+      }
+    };
+
+    map.on('gams.platzieren', handleGamsPlatzieren);
+    return () => {
+      map.off('gams.platzieren', handleGamsPlatzieren);
+    };
+  }, [isMapLoaded, mapRef]);
+
+  const confirmiereGamsZonen = useCallback(
+    (radien: [number, number, number, number]) => {
+      const draw = drawRef.current;
+      if (!draw || !pendingGamsCenter) return;
+
+      // Zonen von außen nach innen erstellen (größter Kreis zuerst → Rendering-Reihenfolge)
+      const sortedIndices = [3, 2, 1, 0]; // Grün, Gelb, Orange, Rot
+
+      for (const i of sortedIndices) {
+        const radius = radien[i];
+        if (radius <= 0) continue;
+
+        const coords = erstelleKreis(pendingGamsCenter, radius);
+        const feature: GeoJSON.Feature = {
+          type: 'Feature',
+          geometry: { type: 'Polygon', coordinates: coords },
+          properties: {
+            featureType: 'gams_zone',
+            color: GAMS_ZONEN_FARBEN[i],
+            fillColor: GAMS_ZONEN_FARBEN[i],
+            fillEnabled: true,
+            fillOpacity: 0.15,
+            strokeWidth: 2,
+            shapeType: 'circle',
+            shapeCenter: JSON.stringify(pendingGamsCenter),
+            shapeRadius: radius,
+          },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        draw.add(feature as any);
+      }
+
+      scheduleAutoSaveRef.current();
+      setPendingGamsCenter(null);
+    },
+    [pendingGamsCenter, drawRef],
+  );
+
+  const abbrechenGamsZonen = useCallback(() => {
+    setPendingGamsCenter(null);
+  }, []);
+
+  return { pendingGamsCenter, confirmiereGamsZonen, abbrechenGamsZonen };
+}

--- a/packages/frontend/src/features/lagekarte/hooks/use-osm-markierung.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-osm-markierung.ts
@@ -10,6 +10,7 @@ import type { MapRef, MapLayerMouseEvent } from 'react-map-gl/maplibre';
 import type MapboxDraw from '@mapbox/mapbox-gl-draw';
 import type { OsmMarkierungStatus } from '../drawing/types';
 import { OSM_MARKING_COLORS } from '../drawing/types';
+import { berechneFlaeche, extractClickedGeometry } from '../utils/geo-calculations';
 
 /**
  * Ausstehende OSM-Markierung — zeigt Popup für Statusauswahl
@@ -77,98 +78,19 @@ function getLayerPriority(layerId: string): number {
 }
 
 /**
- * Prüft ob ein Punkt innerhalb eines Polygon-Rings liegt (Ray-Casting-Algorithmus).
+ * Berechnet die Fläche eines Features für die Sortierung.
+ * Gibt 0 zurück für Nicht-Polygon-Geometrien.
  */
-function isPointInRing(point: [number, number], ring: GeoJSON.Position[]): boolean {
-  const [x, y] = point;
-  let inside = false;
-  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
-    const xi = ring[i][0],
-      yi = ring[i][1];
-    const xj = ring[j][0],
-      yj = ring[j][1];
-    if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
-      inside = !inside;
+function getFeatureArea(geometry: GeoJSON.Geometry): number {
+  if (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+    try {
+      return berechneFlaeche(geometry);
+    } catch {
+      // Degenerierte Geometrien aus Vektor-Tiles (nicht-geschlossene Ringe etc.)
+      return 0;
     }
   }
-  return inside;
-}
-
-/**
- * Quadrierte Distanz zwischen Punkt und einem Liniensegment (A→B).
- * Vermeidet Math.sqrt für Performance.
- */
-function sqDistToSegment(p: [number, number], a: GeoJSON.Position, b: GeoJSON.Position): number {
-  let dx = b[0] - a[0];
-  let dy = b[1] - a[1];
-  if (dx !== 0 || dy !== 0) {
-    const t = Math.max(0, Math.min(1, ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / (dx * dx + dy * dy)));
-    dx = a[0] + t * dx - p[0];
-    dy = a[1] + t * dy - p[1];
-  } else {
-    dx = a[0] - p[0];
-    dy = a[1] - p[1];
-  }
-  return dx * dx + dy * dy;
-}
-
-/**
- * Minimale quadrierte Distanz von einem Punkt zu einer Linie (Array von Koordinaten).
- */
-function sqDistToLine(point: [number, number], line: GeoJSON.Position[]): number {
-  let minDist = Infinity;
-  for (let i = 0; i < line.length - 1; i++) {
-    minDist = Math.min(minDist, sqDistToSegment(point, line[i], line[i + 1]));
-  }
-  return minDist;
-}
-
-/**
- * Extrahiert die einzelne Geometrie am Klickpunkt aus Multi*-Geometrien.
- *
- * In Vektor-Tiles werden Features häufig pro Tile zu Multi*-Geometrien
- * zusammengefasst. Ohne diese Zerlegung würde ein Klick auf ein einzelnes
- * Gebäude/Straßensegment alle Features im Tile einfärben.
- */
-function extractClickedGeometry(geometry: GeoJSON.Geometry, clickPoint: [number, number]): GeoJSON.Geometry {
-  if (geometry.type === 'MultiPolygon') {
-    for (const polygonCoords of geometry.coordinates) {
-      if (isPointInRing(clickPoint, polygonCoords[0])) {
-        return { type: 'Polygon', coordinates: polygonCoords };
-      }
-    }
-    return geometry;
-  }
-
-  if (geometry.type === 'MultiLineString') {
-    let closestIdx = 0;
-    let closestDist = Infinity;
-    for (let i = 0; i < geometry.coordinates.length; i++) {
-      const dist = sqDistToLine(clickPoint, geometry.coordinates[i]);
-      if (dist < closestDist) {
-        closestDist = dist;
-        closestIdx = i;
-      }
-    }
-    return { type: 'LineString', coordinates: geometry.coordinates[closestIdx] };
-  }
-
-  if (geometry.type === 'MultiPoint') {
-    let closestIdx = 0;
-    let closestDist = Infinity;
-    for (let i = 0; i < geometry.coordinates.length; i++) {
-      const dx = geometry.coordinates[i][0] - clickPoint[0];
-      const dy = geometry.coordinates[i][1] - clickPoint[1];
-      const dist = dx * dx + dy * dy;
-      if (dist < closestDist) {
-        closestDist = dist;
-        closestIdx = i;
-      }
-    }
-    return { type: 'Point', coordinates: geometry.coordinates[closestIdx] };
-  }
-
-  return geometry;
+  return 0;
 }
 
 /**
@@ -214,7 +136,12 @@ export function useOsmMarkierung({ mapRef, drawRef, isVectorBaseLayer }: UseOsmM
 
       if (candidates.length === 0) return false;
 
-      candidates.sort((a, b) => getLayerPriority(a.layer?.id ?? '') - getLayerPriority(b.layer?.id ?? ''));
+      candidates.sort((a, b) => {
+        const priorityDiff = getLayerPriority(a.layer?.id ?? '') - getLayerPriority(b.layer?.id ?? '');
+        if (priorityDiff !== 0) return priorityDiff;
+        // Bei gleicher Layer-Priorität: kleinstes Feature bevorzugen
+        return getFeatureArea(a.geometry) - getFeatureArea(b.geometry);
+      });
 
       const match = candidates[0];
 

--- a/packages/frontend/src/features/lagekarte/hooks/use-snap-control.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-snap-control.ts
@@ -1,0 +1,161 @@
+/**
+ * Snap-Control Hook für die Lagekarte
+ *
+ * Verwaltet Node-Snapping: Registriert einen mousemove-Handler auf dem
+ * Map-Canvas, der Snap-Punkte berechnet und als MapLibre-Layer visualisiert.
+ * Die gesnappte Position wird über ein Custom-Event bereitgestellt,
+ * sodass Custom-Modes sie nutzen können.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import type { MapRef } from 'react-map-gl/maplibre';
+import type MapboxDraw from '@mapbox/mapbox-gl-draw';
+import { useStore } from '@tanstack/react-store';
+import { drawStore } from '../stores/draw.store';
+import { findSnapPoint } from '../utils/snap-calculations';
+import { SNAP_INDICATOR_LAYER, SNAP_INDICATOR_LAYER_ID, SNAP_INDICATOR_SOURCE_ID } from '../drawing/snap-indicator-styles';
+import type { GeoJSON as GeoJSONType } from 'geojson';
+
+/** Leere FeatureCollection für den Snap-Indikator */
+const EMPTY_FC: GeoJSONType.FeatureCollection = { type: 'FeatureCollection', features: [] };
+
+interface UseSnapControlOptions {
+  mapRef: React.RefObject<MapRef | null>;
+  drawRef: React.RefObject<MapboxDraw | null>;
+  isMapLoaded: boolean;
+}
+
+/**
+ * Verwaltet Node-Snapping mit visuellem Indikator.
+ * Snap-Punkte werden berechnet und als MapLibre-Layer angezeigt.
+ */
+export function useSnapControl({ mapRef, drawRef, isMapLoaded }: UseSnapControlOptions): void {
+  const snapEnabled = useStore(drawStore, (s) => s.snapEnabled);
+  const snapEnabledRef = useRef(snapEnabled);
+  useEffect(() => {
+    snapEnabledRef.current = snapEnabled;
+  }, [snapEnabled]);
+
+  /**
+   * Source-Daten aktualisieren (zeigt/versteckt den Snap-Indikator)
+   */
+  const updateIndicator = useCallback(
+    (lngLat: { lng: number; lat: number } | null) => {
+      const map = mapRef.current?.getMap();
+      if (!map) return;
+
+      const source = map.getSource(SNAP_INDICATOR_SOURCE_ID);
+      if (!source || source.type !== 'geojson') return;
+
+      if (lngLat) {
+        source.setData({
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: { type: 'Point', coordinates: [lngLat.lng, lngLat.lat] },
+              properties: {},
+            },
+          ],
+        });
+      } else {
+        source.setData(EMPTY_FC);
+      }
+    },
+    [mapRef],
+  );
+
+  // Source und Layer beim Map-Load registrieren
+  useEffect(() => {
+    if (!isMapLoaded || !mapRef.current) return;
+    const map = mapRef.current.getMap();
+    if (!map) return;
+
+    // Guard gegen Doppelregistrierung (React Strict Mode)
+    if (!map.getSource(SNAP_INDICATOR_SOURCE_ID)) {
+      map.addSource(SNAP_INDICATOR_SOURCE_ID, { type: 'geojson', data: EMPTY_FC });
+    }
+    if (!map.getLayer(SNAP_INDICATOR_LAYER_ID)) {
+      map.addLayer(SNAP_INDICATOR_LAYER);
+    }
+
+    // Bei Style-Wechsel Source/Layer erneut registrieren
+    const handleStyleLoad = () => {
+      if (!map.getSource(SNAP_INDICATOR_SOURCE_ID)) {
+        map.addSource(SNAP_INDICATOR_SOURCE_ID, { type: 'geojson', data: EMPTY_FC });
+      }
+      if (!map.getLayer(SNAP_INDICATOR_LAYER_ID)) {
+        map.addLayer(SNAP_INDICATOR_LAYER);
+      }
+    };
+
+    map.on('style.load', handleStyleLoad);
+
+    return () => {
+      map.off('style.load', handleStyleLoad);
+      try {
+        if (map.getLayer(SNAP_INDICATOR_LAYER_ID)) map.removeLayer(SNAP_INDICATOR_LAYER_ID);
+        if (map.getSource(SNAP_INDICATOR_SOURCE_ID)) map.removeSource(SNAP_INDICATOR_SOURCE_ID);
+      } catch {
+        // Map könnte bereits zerstört sein
+      }
+    };
+  }, [isMapLoaded, mapRef]);
+
+  // Mousemove-Handler auf Canvas (capture-Phase)
+  useEffect(() => {
+    if (!isMapLoaded || !mapRef.current) return;
+    const map = mapRef.current.getMap();
+    if (!map) return;
+    const canvas = map.getCanvas();
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!snapEnabledRef.current) {
+        updateIndicator(null);
+        return;
+      }
+
+      const draw = drawRef.current;
+      if (!draw) return;
+
+      // Im Freehand-Modus kein Snapping
+      try {
+        const currentMode = draw.getMode();
+        if (currentMode === 'draw_freehand') {
+          updateIndicator(null);
+          return;
+        }
+      } catch {
+        return;
+      }
+
+      // Aktuell bearbeitete Features vom Snapping ausschließen
+      const excludeIds = new Set<string>();
+      try {
+        for (const id of draw.getSelectedIds()) {
+          excludeIds.add(id);
+        }
+      } catch {
+        // Ignorieren
+      }
+
+      const rect = canvas.getBoundingClientRect();
+      const cursorPixel = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+
+      const features = draw.getAll()?.features ?? [];
+      const snap = findSnapPoint(cursorPixel, features, map, 12, excludeIds);
+
+      if (snap) {
+        updateIndicator(snap.lngLat);
+      } else {
+        updateIndicator(null);
+      }
+    };
+
+    canvas.addEventListener('mousemove', handleMouseMove, { capture: true });
+
+    return () => {
+      canvas.removeEventListener('mousemove', handleMouseMove, { capture: true } as EventListenerOptions);
+    };
+  }, [isMapLoaded, mapRef, drawRef, updateIndicator]);
+}

--- a/packages/frontend/src/features/lagekarte/stores/draw.store.ts
+++ b/packages/frontend/src/features/lagekarte/stores/draw.store.ts
@@ -20,6 +20,8 @@ export interface DrawStoreState {
   isDrawToolbarVisible: boolean;
   /** Ist MapboxDraw im Vertex-Bearbeitungsmodus (direct_select) */
   isDirectSelect: boolean;
+  /** Snap an Vertices/Kanten aktiviert */
+  snapEnabled: boolean;
 }
 
 const initialState: DrawStoreState = {
@@ -27,6 +29,7 @@ const initialState: DrawStoreState = {
   selectedFeatureIds: [],
   isDrawToolbarVisible: false,
   isDirectSelect: false,
+  snapEnabled: true,
 };
 
 /**
@@ -81,6 +84,16 @@ export const toggleDrawToolbar = () => {
     isDrawToolbarVisible: !state.isDrawToolbarVisible,
     // Beim Einklappen auf Select-Modus wechseln
     drawMode: !state.isDrawToolbarVisible ? state.drawMode : 'select',
+  }));
+};
+
+/**
+ * Schaltet Snap an Vertices/Kanten um
+ */
+export const toggleSnapEnabled = () => {
+  drawStore.setState((state) => ({
+    ...state,
+    snapEnabled: !state.snapEnabled,
   }));
 };
 

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawShortcutBar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawShortcutBar.molecule.tsx
@@ -8,8 +8,9 @@
 
 import { cn } from '@/shared/ui/cn';
 import { useMemo } from 'react';
-import { PiArrowClockwise, PiArrowCounterClockwise, PiTrash } from 'react-icons/pi';
+import { PiArrowClockwise, PiArrowCounterClockwise, PiRuler, PiTrash } from 'react-icons/pi';
 import type { DrawMode } from '../../drawing/types';
+import type { FeatureMeasurement } from '../../utils/geo-calculations';
 
 interface Hint {
   /** Tastenkürzel — leer für reine Texthinweise */
@@ -51,9 +52,11 @@ export interface DrawShortcutBarProps {
   onRedo: () => void;
   /** Selektierte Features löschen */
   onDeleteSelected: () => void;
+  /** Live-Messung während des Zeichnens */
+  liveMeasurement?: FeatureMeasurement | null;
 }
 
-export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, isDirectSelect, onUndo, onRedo, onDeleteSelected }: DrawShortcutBarProps) {
+export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, isDirectSelect, onUndo, onRedo, onDeleteSelected, liveMeasurement }: DrawShortcutBarProps) {
   const hints = useMemo<Hint[]>(() => {
     const isActive = activeMode !== 'idle';
     // Hinweise zeigen wenn ein Werkzeug aktiv ist ODER ein Feature selektiert ist
@@ -94,12 +97,24 @@ export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, is
   }, [activeMode, hasSelection, canUndo, canRedo, isDirectSelect]);
 
   const hasActions = canUndo || canRedo || hasSelection;
+  const showLiveMeasurement = liveMeasurement != null;
 
-  if (hints.length === 0 && !hasActions) return null;
+  if (hints.length === 0 && !hasActions && !showLiveMeasurement) return null;
 
   return (
     <div className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2">
       <div className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-panel/90 px-3 py-1.5 text-xs text-text-muted shadow-sm backdrop-blur-sm">
+        {/* Live-Messung während des Zeichnens */}
+        {showLiveMeasurement && (
+          <>
+            <span className="flex items-center gap-1.5 font-medium text-text-secondary tabular-nums">
+              <PiRuler className="h-3.5 w-3.5" aria-hidden="true" />
+              {liveMeasurement.label}
+            </span>
+            {hints.length > 0 && <span className="h-3 w-px bg-border-subtle" aria-hidden="true" />}
+          </>
+        )}
+
         {hints.map((hint, i) => (
           <span key={i} className="flex items-center gap-1.5">
             {i > 0 && <span className="mr-1.5 h-3 w-px bg-border-subtle" aria-hidden="true" />}

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawShortcutBar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawShortcutBar.molecule.tsx
@@ -8,7 +8,7 @@
 
 import { cn } from '@/shared/ui/cn';
 import { useMemo } from 'react';
-import { PiArrowClockwise, PiArrowCounterClockwise, PiRuler, PiTrash } from 'react-icons/pi';
+import { PiArrowClockwise, PiArrowCounterClockwise, PiMagnet, PiRuler, PiTrash } from 'react-icons/pi';
 import type { DrawMode } from '../../drawing/types';
 import type { FeatureMeasurement } from '../../utils/geo-calculations';
 
@@ -30,6 +30,10 @@ const MODE_HINTS: Partial<Record<DrawMode, string>> = {
   draw_freehand: 'Ziehen zum Zeichnen',
   draw_text: 'Klick zum Platzieren',
   osm_mark: 'Klick auf Objekt zum Markieren',
+  draw_circle: 'Klicken und ziehen für Radius',
+  draw_rectangle: 'Klicken und ziehen für Rechteck',
+  draw_sector: 'Klicken und ziehen für Richtung + Radius',
+  draw_gams: 'Klick + Ziehen für Zone · Nur Klick für Eingabe',
 };
 
 /** Gemeinsame Styles für Aktions-Buttons */
@@ -54,9 +58,13 @@ export interface DrawShortcutBarProps {
   onDeleteSelected: () => void;
   /** Live-Messung während des Zeichnens */
   liveMeasurement?: FeatureMeasurement | null;
+  /** Ob Snapping aktiv ist */
+  snapEnabled: boolean;
+  /** Snapping umschalten */
+  onToggleSnap: () => void;
 }
 
-export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, isDirectSelect, onUndo, onRedo, onDeleteSelected, liveMeasurement }: DrawShortcutBarProps) {
+export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, isDirectSelect, onUndo, onRedo, onDeleteSelected, liveMeasurement, snapEnabled, onToggleSnap }: DrawShortcutBarProps) {
   const hints = useMemo<Hint[]>(() => {
     const isActive = activeMode !== 'idle';
     // Hinweise zeigen wenn ein Werkzeug aktiv ist ODER ein Feature selektiert ist
@@ -98,8 +106,9 @@ export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, is
 
   const hasActions = canUndo || canRedo || hasSelection;
   const showLiveMeasurement = liveMeasurement != null;
+  const showSnapToggle = activeMode !== 'idle' || hasSelection;
 
-  if (hints.length === 0 && !hasActions && !showLiveMeasurement) return null;
+  if (hints.length === 0 && !hasActions && !showLiveMeasurement && !showSnapToggle) return null;
 
   return (
     <div className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2">
@@ -134,8 +143,24 @@ export function DrawShortcutBar({ activeMode, hasSelection, canUndo, canRedo, is
           </span>
         ))}
 
+        {/* Snap-Toggle */}
+        {showSnapToggle && (
+          <>
+            {(hints.length > 0 || showLiveMeasurement) && <span className="h-3 w-px bg-border-subtle" aria-hidden="true" />}
+            <button
+              type="button"
+              onClick={onToggleSnap}
+              aria-label={snapEnabled ? 'Einrasten deaktivieren (S)' : 'Einrasten aktivieren (S)'}
+              title={snapEnabled ? 'Einrasten aktiv (S)' : 'Einrasten inaktiv (S)'}
+              className={cn(actionButtonBase, snapEnabled ? 'text-action-primary' : 'text-text-muted hover:bg-action-secondary hover:text-text-primary')}
+            >
+              <PiMagnet className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          </>
+        )}
+
         {/* Aktions-Buttons */}
-        {hasActions && hints.length > 0 && <span className="h-3 w-px bg-border-subtle" aria-hidden="true" />}
+        {hasActions && (hints.length > 0 || showSnapToggle) && <span className="h-3 w-px bg-border-subtle" aria-hidden="true" />}
         {hasActions && (
           <span className="flex items-center gap-1">
             {canUndo && (

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawStylePanel.molecule.tsx
@@ -6,9 +6,11 @@
  */
 
 import { useState } from 'react';
+import { PiRuler } from 'react-icons/pi';
 import { cn } from '@/shared/ui/cn';
 import type { DrawingStyle, HatchConfig, HatchType } from '../../drawing/types';
 import { DEFAULT_HATCH } from '../../drawing/types';
+import type { FeatureMeasurement } from '../../utils/geo-calculations';
 
 /** Props für die DrawStylePanel-Komponente */
 export interface DrawStylePanelProps {
@@ -24,6 +26,8 @@ export interface DrawStylePanelProps {
   onLabelChange?: (label: string) => void;
   /** Geometrie-Typ des selektierten Features (steuert sichtbare Optionen) */
   geometryType?: string;
+  /** Messung des selektierten Features */
+  measurement?: FeatureMeasurement | null;
 }
 
 /** Vordefinierte Farben für die Farbauswahl */
@@ -108,7 +112,7 @@ function PatternIcon({ type }: { type: HatchType }) {
   );
 }
 
-export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabelChange, geometryType }: DrawStylePanelProps) {
+export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabelChange, geometryType, measurement }: DrawStylePanelProps) {
   const [hatchExpanded, setHatchExpanded] = useState(false);
 
   if (!isVisible) return null;
@@ -126,6 +130,14 @@ export function DrawStylePanel({ style, onStyleChange, isVisible, label, onLabel
 
   return (
     <div className={cn('absolute top-4 left-20 z-10 w-52 rounded-lg border border-border-subtle bg-surface-panel p-3 shadow-lg')}>
+      {/* Messanzeige */}
+      {measurement && (
+        <div className="bg-surface-secondary mb-3 flex items-center gap-1.5 rounded-md px-2 py-1.5">
+          <PiRuler className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+          <span className="text-xs font-medium text-text-secondary tabular-nums">{measurement.label}</span>
+        </div>
+      )}
+
       {/* Farbauswahl */}
       <div className={cn(showStrokeWidth || showFill || label !== undefined ? 'mb-3' : '')}>
         <div className="mb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Farbe</div>

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
@@ -9,7 +9,7 @@
 
 import { cn } from '@/shared/ui/cn';
 import { useStore } from '@tanstack/react-store';
-import { PiBuildings, PiCursor, PiLineSegment, PiMapPin, PiPencilSimple, PiPolygon, PiScribbleLoop, PiTextT } from 'react-icons/pi';
+import { PiArrowArcRight, PiBuildings, PiCircle, PiCursor, PiLineSegment, PiMapPin, PiPencilSimple, PiPolygon, PiRectangle, PiScribbleLoop, PiTarget, PiTextT } from 'react-icons/pi';
 import type { DrawMode } from '../../drawing/types';
 import { drawStore, toggleDrawToolbar } from '../../stores/draw.store';
 
@@ -27,7 +27,11 @@ const DRAW_MODE_BUTTONS: { mode: DrawMode; icon: React.ComponentType<{ className
   { mode: 'draw_point', icon: PiMapPin, label: 'Punkt zeichnen' },
   { mode: 'draw_line_string', icon: PiLineSegment, label: 'Linie zeichnen' },
   { mode: 'draw_polygon', icon: PiPolygon, label: 'Polygon zeichnen' },
+  { mode: 'draw_circle', icon: PiCircle, label: 'Kreis zeichnen' },
+  { mode: 'draw_rectangle', icon: PiRectangle, label: 'Rechteck zeichnen' },
   { mode: 'draw_freehand', icon: PiScribbleLoop, label: 'Freihand zeichnen' },
+  { mode: 'draw_sector', icon: PiArrowArcRight, label: 'Ausbreitungskegel zeichnen' },
+  { mode: 'draw_gams', icon: PiTarget, label: 'GAMS-Zonen platzieren' },
   { mode: 'draw_text', icon: PiTextT, label: 'Text platzieren' },
   { mode: 'osm_mark', icon: PiBuildings, label: 'OSM-Gebäude markieren' },
 ];

--- a/packages/frontend/src/features/lagekarte/ui/molecules/GamsZonenPanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/GamsZonenPanel.molecule.tsx
@@ -1,0 +1,61 @@
+/**
+ * GamsZonenPanel — Konfigurationspanel für GAMS-Gefahrenzonen-Radien
+ *
+ * Erscheint als Popup nach Klick auf die Karte im GAMS-Modus.
+ * Erlaubt die Anpassung der 4 Zonen-Radien vor der Platzierung.
+ */
+
+import { useState } from 'react';
+import { GAMS_DEFAULT_RADIEN, GAMS_ZONEN_FARBEN, GAMS_ZONEN_NAMEN } from '../../drawing/types';
+
+interface GamsZonenPanelProps {
+  /** Bestätigt die Platzierung mit den eingegebenen Radien */
+  onConfirm: (radien: [number, number, number, number]) => void;
+  /** Bricht die Platzierung ab */
+  onCancel: () => void;
+}
+
+export function GamsZonenPanel({ onConfirm, onCancel }: GamsZonenPanelProps) {
+  const [radien, setRadien] = useState<[number, number, number, number]>([...GAMS_DEFAULT_RADIEN]);
+
+  const updateRadius = (index: number, value: number) => {
+    setRadien((prev) => {
+      const next = [...prev] as [number, number, number, number];
+      next[index] = Math.max(0, value);
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex w-64 flex-col gap-3 p-1">
+      <p className="text-sm font-medium text-text-primary">GAMS-Gefahrenzonen</p>
+
+      {GAMS_ZONEN_NAMEN.map((name, i) => (
+        <label key={name} className="flex items-center gap-2">
+          <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: GAMS_ZONEN_FARBEN[i] }} />
+          <span className="min-w-0 flex-1 truncate text-xs text-text-secondary">{name}</span>
+          <div className="flex items-center gap-1">
+            <input
+              type="number"
+              min={0}
+              step={10}
+              value={radien[i]}
+              onChange={(e) => updateRadius(i, Number(e.target.value))}
+              className="bg-surface-secondary w-16 rounded border border-border-subtle px-1.5 py-0.5 text-right text-xs text-text-primary tabular-nums focus:border-action-primary focus:outline-none"
+            />
+            <span className="text-xs text-text-muted">m</span>
+          </div>
+        </label>
+      ))}
+
+      <div className="flex justify-end gap-2 border-t border-border-subtle pt-2">
+        <button type="button" onClick={onCancel} className="rounded px-2.5 py-1 text-xs text-text-muted transition-colors hover:bg-action-secondary hover:text-text-primary">
+          Abbrechen
+        </button>
+        <button type="button" onClick={() => onConfirm(radien)} className="rounded bg-action-primary px-2.5 py-1 text-xs text-white transition-colors hover:bg-action-primary/90">
+          Platzieren
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -3,6 +3,7 @@ import { useMapLayer } from '@/features/lagekarte/hooks/use-map-layer';
 import { useMapDetail } from '@/features/lagekarte/hooks/use-map-detail';
 import { useNinaMapData } from '@/features/lagekarte/api/use-nina-map-data';
 import { useDrawControl } from '@/features/lagekarte/hooks/use-draw-control';
+import { useFeatureMeasurement } from '@/features/lagekarte/hooks/use-feature-measurement';
 import { useLagekartePermissions } from '@/features/lagekarte/hooks/use-lagekarte-permissions';
 import { useOsmMarkierung } from '@/features/lagekarte/hooks/use-osm-markierung';
 import { drawStore } from '@/features/lagekarte/stores/draw.store';
@@ -75,6 +76,9 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   // OSM-Markierung (nur bei Vektor-Basislayer)
   const isVectorBaseLayer = selectedBaseLayer === 'osm';
   const { handleOsmClick, pendingOsmMark, confirmOsmMark, cancelOsmMark } = useOsmMarkierung({ mapRef, drawRef, isVectorBaseLayer });
+
+  // Feature-Messungen (Fläche, Länge, Koordinaten)
+  const { selectedMeasurement, liveMeasurement } = useFeatureMeasurement({ mapRef, drawRef, isMapLoaded });
 
   // I4: Stil des selektierten Features in das StylePanel laden
   useEffect(() => {
@@ -290,6 +294,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
             onUndo={undo}
             onRedo={redo}
             onDeleteSelected={deleteSelected}
+            liveMeasurement={liveMeasurement}
           />
         </>
       )}
@@ -302,6 +307,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
         label={selectedFeatureLabel}
         onLabelChange={handleLabelChange}
         geometryType={selectedFeatureGeometryType}
+        measurement={selectedMeasurement}
       />
 
       <MapLayerSwitcher availableLayers={availableLayers} selectedBaseLayer={selectedBaseLayer} dwdOverlayEnabled={dwdOverlayEnabled} ninaOverlays={ninaOverlays} />

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -6,7 +6,9 @@ import { useDrawControl } from '@/features/lagekarte/hooks/use-draw-control';
 import { useFeatureMeasurement } from '@/features/lagekarte/hooks/use-feature-measurement';
 import { useLagekartePermissions } from '@/features/lagekarte/hooks/use-lagekarte-permissions';
 import { useOsmMarkierung } from '@/features/lagekarte/hooks/use-osm-markierung';
-import { drawStore } from '@/features/lagekarte/stores/draw.store';
+import { useGamsZonen } from '@/features/lagekarte/hooks/use-gams-zonen';
+import { useSnapControl } from '@/features/lagekarte/hooks/use-snap-control';
+import { drawStore, toggleSnapEnabled } from '@/features/lagekarte/stores/draw.store';
 import { DEFAULT_DRAWING_STYLE } from '@/features/lagekarte/drawing/types';
 import type { DrawingStyle, HatchConfig } from '@/features/lagekarte/drawing/types';
 import { DEFAULT_HATCH } from '@/features/lagekarte/drawing/types';
@@ -26,6 +28,7 @@ import { DrawToolbar } from '../../molecules/DrawToolbar.molecule';
 import { DrawShortcutBar } from '../../molecules/DrawShortcutBar.molecule';
 import { DrawStylePanel } from '../../molecules/DrawStylePanel.molecule';
 import { OsmMarkierungPopup } from '../../molecules/OsmMarkierungPopup.molecule';
+import { GamsZonenPanel } from '../../molecules/GamsZonenPanel.molecule';
 import { FullscreenCloseButton } from '../FullscreenCloseButton/FullscreenCloseButton';
 import { NinaGeoJsonLayer } from '../../molecules/NinaGeoJsonLayer.molecule';
 import '@/features/lagekarte/detail-providers';
@@ -59,6 +62,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   const drawMode = useStore(drawStore, (s) => s.drawMode);
   const selectedFeatureIds = useStore(drawStore, (s) => s.selectedFeatureIds);
   const isDirectSelect = useStore(drawStore, (s) => s.isDirectSelect);
+  const snapEnabled = useStore(drawStore, (s) => s.snapEnabled);
 
   // Map-Ladezustand
   const isMapLoaded = !isLoading;
@@ -76,6 +80,12 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   // OSM-Markierung (nur bei Vektor-Basislayer)
   const isVectorBaseLayer = selectedBaseLayer === 'osm';
   const { handleOsmClick, pendingOsmMark, confirmOsmMark, cancelOsmMark } = useOsmMarkierung({ mapRef, drawRef, isVectorBaseLayer });
+
+  // GAMS-Zonen (konzentrische Gefahrenzonen)
+  const { pendingGamsCenter, confirmiereGamsZonen, abbrechenGamsZonen } = useGamsZonen({ mapRef, drawRef, isMapLoaded, scheduleAutoSave });
+
+  // Node-Snapping
+  useSnapControl({ mapRef, drawRef, isMapLoaded });
 
   // Feature-Messungen (Fläche, Länge, Koordinaten)
   const { selectedMeasurement, liveMeasurement } = useFeatureMeasurement({ mapRef, drawRef, isMapLoaded });
@@ -279,6 +289,13 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
             <OsmMarkierungPopup pendingMark={pendingOsmMark} onConfirm={confirmOsmMark} onCancel={cancelOsmMark} />
           </Popup>
         )}
+
+        {/* GAMS-Zonen-Konfiguration */}
+        {pendingGamsCenter && (
+          <Popup longitude={pendingGamsCenter[0]} latitude={pendingGamsCenter[1]} onClose={abbrechenGamsZonen} closeOnClick={false} anchor="bottom">
+            <GamsZonenPanel onConfirm={confirmiereGamsZonen} onCancel={abbrechenGamsZonen} />
+          </Popup>
+        )}
       </Map>
 
       {/* Draw-Toolbar */}
@@ -295,6 +312,8 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
             onRedo={redo}
             onDeleteSelected={deleteSelected}
             liveMeasurement={liveMeasurement}
+            snapEnabled={snapEnabled}
+            onToggleSnap={toggleSnapEnabled}
           />
         </>
       )}

--- a/packages/frontend/src/features/lagekarte/utils/geo-calculations.ts
+++ b/packages/frontend/src/features/lagekarte/utils/geo-calculations.ts
@@ -1,0 +1,167 @@
+/**
+ * Geo-Berechnungen für die Lagekarte
+ *
+ * Kapselt alle @turf/turf-Aufrufe hinter domänenspezifischen Funktionen.
+ * Einzige Datei im Feature, die direkt von turf importiert.
+ */
+
+import * as turf from '@turf/turf';
+
+// ============================================
+// Berechnungen
+// ============================================
+
+/**
+ * Berechnet die Fläche einer Polygon-Geometrie in Quadratmetern.
+ */
+export function berechneFlaeche(geometry: GeoJSON.Polygon | GeoJSON.MultiPolygon): number {
+  return turf.area(turf.feature(geometry));
+}
+
+/**
+ * Berechnet die Länge einer Linien-Geometrie in Metern.
+ */
+export function berechneLaenge(geometry: GeoJSON.LineString | GeoJSON.MultiLineString): number {
+  return turf.length(turf.feature(geometry), { units: 'meters' });
+}
+
+// ============================================
+// Formatierung (automatisch skaliert)
+// ============================================
+
+/**
+ * Formatiert Quadratmeter als lesbaren String.
+ * Unter 10.000 m² → "1.234 m²", darüber → "1,23 km²"
+ */
+export function formatiereFlaeche(m2: number): string {
+  if (m2 < 10_000) {
+    return `${Math.round(m2).toLocaleString('de-DE')} m²`;
+  }
+  const km2 = m2 / 1_000_000;
+  return `${km2.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} km²`;
+}
+
+/**
+ * Formatiert Meter als lesbaren String.
+ * Unter 1.000 m → "450 m", darüber → "1,23 km"
+ */
+export function formatiereLaenge(meter: number): string {
+  if (meter < 1_000) {
+    return `${Math.round(meter).toLocaleString('de-DE')} m`;
+  }
+  const km = meter / 1_000;
+  return `${km.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} km`;
+}
+
+/**
+ * Formatiert Koordinaten als lesbaren String (Dezimalgrad).
+ */
+export function formatiereKoordinaten(lng: number, lat: number): string {
+  const latDir = lat >= 0 ? 'N' : 'S';
+  const lngDir = lng >= 0 ? 'E' : 'W';
+  return `${Math.abs(lat).toFixed(5)}° ${latDir}, ${Math.abs(lng).toFixed(5)}° ${lngDir}`;
+}
+
+// ============================================
+// Feature-Messung (Dispatch nach Geometrie-Typ)
+// ============================================
+
+/** Ergebnis einer Feature-Messung */
+export interface FeatureMeasurement {
+  /** Anzeige-String, z.B. "1,23 km²", "450 m" */
+  label: string;
+  /** Art der Messung */
+  type: 'area' | 'length' | 'point';
+  /** Roher Wert (m² oder m, null für Punkte) */
+  rawValue: number | null;
+}
+
+/**
+ * Berechnet die passende Messung für eine beliebige GeoJSON-Geometrie.
+ * Gibt null zurück für GeometryCollections oder unbekannte Typen.
+ */
+export function measureFeature(geometry: GeoJSON.Geometry): FeatureMeasurement | null {
+  switch (geometry.type) {
+    case 'Polygon':
+    case 'MultiPolygon': {
+      const m2 = berechneFlaeche(geometry);
+      return { label: formatiereFlaeche(m2), type: 'area', rawValue: m2 };
+    }
+    case 'LineString':
+    case 'MultiLineString': {
+      const meter = berechneLaenge(geometry);
+      return { label: formatiereLaenge(meter), type: 'length', rawValue: meter };
+    }
+    case 'Point': {
+      const [lng, lat] = geometry.coordinates;
+      return { label: formatiereKoordinaten(lng, lat), type: 'point', rawValue: null };
+    }
+    case 'MultiPoint': {
+      const [lng, lat] = geometry.coordinates[0] ?? [0, 0];
+      return { label: formatiereKoordinaten(lng, lat), type: 'point', rawValue: null };
+    }
+    default:
+      return null;
+  }
+}
+
+// ============================================
+// Geo-Algorithmen (Ersatz für manuelle Implementierungen)
+// ============================================
+
+/**
+ * Prüft ob ein Punkt innerhalb eines Polygons liegt.
+ * Ersetzt die manuelle isPointInRing-Implementierung.
+ */
+export function istPunktInPolygon(point: [number, number], polygonCoords: GeoJSON.Position[][]): boolean {
+  return turf.booleanPointInPolygon(turf.point(point), turf.polygon(polygonCoords));
+}
+
+/**
+ * Berechnet die Distanz (in Metern) von einem Punkt zur nächsten Stelle auf einer Linie.
+ * Gibt Infinity zurück für degenerierte Linien (< 2 Koordinaten).
+ */
+export function distanzZuLinie(point: [number, number], line: GeoJSON.Position[]): number {
+  if (line.length < 2) return Infinity;
+  const snapped = turf.nearestPointOnLine(turf.lineString(line), turf.point(point), { units: 'meters' });
+  return snapped.properties.dist ?? 0;
+}
+
+/**
+ * Extrahiert die einzelne Geometrie am Klickpunkt aus Multi*-Geometrien.
+ *
+ * In Vektor-Tiles werden Features häufig pro Tile zu Multi*-Geometrien
+ * zusammengefasst. Ohne diese Zerlegung würde ein Klick auf ein einzelnes
+ * Gebäude/Straßensegment alle Features im Tile einfärben.
+ */
+export function extractClickedGeometry(geometry: GeoJSON.Geometry, clickPoint: [number, number]): GeoJSON.Geometry {
+  if (geometry.type === 'MultiPolygon') {
+    for (const polygonCoords of geometry.coordinates) {
+      if (istPunktInPolygon(clickPoint, polygonCoords)) {
+        return { type: 'Polygon', coordinates: polygonCoords };
+      }
+    }
+    return geometry;
+  }
+
+  if (geometry.type === 'MultiLineString') {
+    let closestIdx = 0;
+    let closestDist = Infinity;
+    for (let i = 0; i < geometry.coordinates.length; i++) {
+      const dist = distanzZuLinie(clickPoint, geometry.coordinates[i]);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestIdx = i;
+      }
+    }
+    return { type: 'LineString', coordinates: geometry.coordinates[closestIdx] };
+  }
+
+  if (geometry.type === 'MultiPoint') {
+    const nearest = turf.nearestPoint(turf.point(clickPoint), turf.featureCollection(geometry.coordinates.map((c) => turf.point(c))));
+    const idx = nearest.properties.featureIndex ?? 0;
+    return { type: 'Point', coordinates: geometry.coordinates[idx] };
+  }
+
+  return geometry;
+}

--- a/packages/frontend/src/features/lagekarte/utils/geo-calculations.ts
+++ b/packages/frontend/src/features/lagekarte/utils/geo-calculations.ts
@@ -106,6 +106,78 @@ export function measureFeature(geometry: GeoJSON.Geometry): FeatureMeasurement |
 }
 
 // ============================================
+// Geometrie-Erzeugung (parametrische Formen)
+// ============================================
+
+/**
+ * Erzeugt einen Kreis als Polygon (64-Punkt-Approximation).
+ * @param center - [lng, lat]
+ * @param radiusMeters - Radius in Metern
+ */
+export function erstelleKreis(center: [number, number], radiusMeters: number): GeoJSON.Position[][] {
+  const circle = turf.circle(turf.point(center), radiusMeters, { steps: 64, units: 'meters' });
+  return circle.geometry.coordinates;
+}
+
+/**
+ * Erzeugt ein Rechteck aus zwei gegenüberliegenden Ecken.
+ */
+export function erstelleRechteck(corner1: [number, number], corner2: [number, number]): GeoJSON.Position[][] {
+  const [lng1, lat1] = corner1;
+  const [lng2, lat2] = corner2;
+  return [
+    [
+      [lng1, lat1],
+      [lng2, lat1],
+      [lng2, lat2],
+      [lng1, lat2],
+      [lng1, lat1],
+    ],
+  ];
+}
+
+/**
+ * Erzeugt einen Kreissektor (Kegel/Fächer) als Polygon.
+ * @param center - [lng, lat]
+ * @param radiusMeters - Radius in Metern
+ * @param bearing - Hauptrichtung in Grad (0=Nord, 90=Ost)
+ * @param openingAngle - Öffnungswinkel in Grad (symmetrisch um bearing)
+ */
+export function erstelleSektor(center: [number, number], radiusMeters: number, bearing: number, openingAngle: number): GeoJSON.Position[][] {
+  const half = openingAngle / 2;
+  const sector = turf.sector(turf.point(center), radiusMeters, bearing - half, bearing + half, { units: 'meters', steps: 32 });
+  return sector.geometry.coordinates;
+}
+
+/**
+ * Berechnet den Abstand zwischen zwei Koordinaten in Metern.
+ */
+export function berechneAbstand(from: [number, number], to: [number, number]): number {
+  return turf.distance(turf.point(from), turf.point(to), { units: 'meters' });
+}
+
+/**
+ * Berechnet einen Zielpunkt ausgehend von einem Startpunkt, einer Distanz und einem Bearing.
+ * @param from - Startpunkt [lng, lat]
+ * @param distanceMeters - Entfernung in Metern
+ * @param bearing - Kompassrichtung in Grad (0=Nord, 90=Ost)
+ * @returns Zielpunkt [lng, lat]
+ */
+export function berechneZielpunkt(from: [number, number], distanceMeters: number, bearing: number): [number, number] {
+  const dest = turf.destination(turf.point(from), distanceMeters, bearing, { units: 'meters' });
+  return dest.geometry.coordinates as [number, number];
+}
+
+/**
+ * Berechnet den Kompasswinkel (Bearing) von einem Punkt zum anderen.
+ * @returns Bearing in Grad (0–360)
+ */
+export function berechneBearing(from: [number, number], to: [number, number]): number {
+  const raw = turf.bearing(turf.point(from), turf.point(to));
+  return (raw + 360) % 360;
+}
+
+// ============================================
 // Geo-Algorithmen (Ersatz für manuelle Implementierungen)
 // ============================================
 

--- a/packages/frontend/src/features/lagekarte/utils/index.ts
+++ b/packages/frontend/src/features/lagekarte/utils/index.ts
@@ -2,3 +2,4 @@ export * from './poi-icons';
 export * from './formatPoiTypeLabel';
 export * from './map-config';
 export * from './geo-calculations';
+export * from './snap-calculations';

--- a/packages/frontend/src/features/lagekarte/utils/index.ts
+++ b/packages/frontend/src/features/lagekarte/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './poi-icons';
 export * from './formatPoiTypeLabel';
 export * from './map-config';
+export * from './geo-calculations';

--- a/packages/frontend/src/features/lagekarte/utils/snap-calculations.ts
+++ b/packages/frontend/src/features/lagekarte/utils/snap-calculations.ts
@@ -1,0 +1,134 @@
+/**
+ * Snap-Berechnungen für die Lagekarte
+ *
+ * Findet den nächsten Snap-Punkt (Vertex oder Kante) auf existierenden
+ * Features innerhalb einer Pixel-Toleranz.
+ */
+
+import * as turf from '@turf/turf';
+import type maplibregl from 'maplibre-gl';
+
+/** Ergebnis eines Snap-Vorgangs */
+export interface SnapResult {
+  /** Gesnappte Position */
+  lngLat: { lng: number; lat: number };
+  /** Typ des Snap-Targets */
+  type: 'vertex' | 'edge';
+}
+
+/**
+ * Extrahiert alle Koordinaten aus einer GeoJSON-Geometrie als flaches Array.
+ */
+function extractCoordinates(geometry: GeoJSON.Geometry): GeoJSON.Position[] {
+  switch (geometry.type) {
+    case 'Point':
+      return [geometry.coordinates];
+    case 'MultiPoint':
+    case 'LineString':
+      return geometry.coordinates;
+    case 'MultiLineString':
+    case 'Polygon':
+      return geometry.coordinates.flat();
+    case 'MultiPolygon':
+      return geometry.coordinates.flat(2);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Extrahiert alle Linien-Segmente (für Edge-Snapping) aus einer Geometrie.
+ */
+function extractLineSegments(geometry: GeoJSON.Geometry): GeoJSON.Position[][] {
+  switch (geometry.type) {
+    case 'LineString':
+      return [geometry.coordinates];
+    case 'MultiLineString':
+      return geometry.coordinates;
+    case 'Polygon':
+      return geometry.coordinates;
+    case 'MultiPolygon':
+      return geometry.coordinates.flat();
+    default:
+      return [];
+  }
+}
+
+/**
+ * Berechnet die euklidische Pixel-Distanz zwischen zwei Punkten.
+ */
+function pixelDistance(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Findet den nächsten Snap-Punkt unter allen Features.
+ *
+ * Prüft zuerst Vertices (exakte Punkte), dann Kanten (nächster Punkt auf Linie).
+ * Gibt null zurück wenn kein Feature innerhalb der Pixel-Toleranz liegt.
+ *
+ * @param cursorPixel - Cursor-Position in Pixel
+ * @param features - Alle Features zum Snappen
+ * @param map - MapLibre-Instanz für Koordinaten-Projektion
+ * @param snapPxThreshold - Snap-Distanz in Pixel (default 12)
+ * @param excludeFeatureIds - Feature-IDs die vom Snapping ausgeschlossen werden (z.B. aktuell bearbeitetes Feature)
+ */
+export function findSnapPoint(
+  cursorPixel: { x: number; y: number },
+  features: GeoJSON.Feature[],
+  map: maplibregl.Map,
+  snapPxThreshold = 12,
+  excludeFeatureIds: Set<string> = new Set(),
+): SnapResult | null {
+  let bestVertex: SnapResult | null = null;
+  let bestVertexDist = snapPxThreshold;
+
+  // Phase 1: Vertex-Snapping (exakte Punkte)
+  for (const feature of features) {
+    if (excludeFeatureIds.has(String(feature.id ?? ''))) continue;
+
+    const coords = extractCoordinates(feature.geometry);
+    for (const coord of coords) {
+      const projected = map.project([coord[0], coord[1]]);
+      const dist = pixelDistance(cursorPixel, projected);
+      if (dist < bestVertexDist) {
+        bestVertexDist = dist;
+        bestVertex = { lngLat: { lng: coord[0], lat: coord[1] }, type: 'vertex' };
+      }
+    }
+  }
+
+  // Vertex-Treffer hat Vorrang
+  if (bestVertex) return bestVertex;
+
+  // Phase 2: Edge-Snapping (nächster Punkt auf Linie)
+  let bestEdge: SnapResult | null = null;
+  let bestEdgeDist = snapPxThreshold;
+
+  // Cursor in Geo-Koordinaten einmalig berechnen
+  const cursorLngLat = map.unproject(cursorPixel);
+  const cursorTurfPoint = turf.point([cursorLngLat.lng, cursorLngLat.lat]);
+
+  for (const feature of features) {
+    if (excludeFeatureIds.has(String(feature.id ?? ''))) continue;
+
+    const lines = extractLineSegments(feature.geometry);
+    for (const line of lines) {
+      if (line.length < 2) continue;
+
+      const snapped = turf.nearestPointOnLine(turf.lineString(line), cursorTurfPoint);
+      const snappedCoord = snapped.geometry.coordinates;
+      const projected = map.project([snappedCoord[0], snappedCoord[1]]);
+      const dist = pixelDistance(cursorPixel, projected);
+
+      if (dist < bestEdgeDist) {
+        bestEdgeDist = dist;
+        bestEdge = { lngLat: { lng: snappedCoord[0], lat: snappedCoord[1] }, type: 'edge' };
+      }
+    }
+  }
+
+  return bestEdge;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
       '@tauri-apps/plugin-store':
         specifier: ^2.4.2
         version: 2.4.2
+      '@turf/turf':
+        specifier: ^7.3.4
+        version: 7.3.4
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4696,17 +4699,350 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@turf/along@7.3.4':
+    resolution: {integrity: sha512-PvIoXin0I1t3nRwJz7uqR6fsxDMqdGwJq90qGOeqkNwlZqlF+5o2wKHPwYwi0RXZhLvxRP5qlbNIvV8ADdbWxw==}
+
+  '@turf/angle@7.3.4':
+    resolution: {integrity: sha512-235JAfbrNMjHQXQfd/p+fYnlfCHsQsKHda5Eeyc+/jIY0s5mKvhcxgFaOEnigA2q1n+PrVOExs3BViGTKnWhAg==}
+
+  '@turf/area@7.3.4':
+    resolution: {integrity: sha512-UEQQFw2XwHpozSBAMEtZI3jDsAad4NnHL/poF7/S6zeDCjEBCkt3MYd6DSGH/cvgcOozxH/ky3/rIVSMZdx4vA==}
+
+  '@turf/bbox-clip@7.3.4':
+    resolution: {integrity: sha512-HCn0q/WPVEE9Dztg7tCvClOPrrh9MoxNUk73byHvcZLBcvziN6F84f/ZbFcbQSh8hgOeVMs/keeqWMqsICcNLg==}
+
+  '@turf/bbox-polygon@7.3.4':
+    resolution: {integrity: sha512-XCDYQwCA41Bum3R1xX0Na1nR4ozoe/pCYy5bxqrzyMs87kPJUIfBrD5IWxjnZyLqFpfEpolMHJz5ed1uA2PanQ==}
+
+  '@turf/bbox@7.3.4':
+    resolution: {integrity: sha512-D5ErVWtfQbEPh11yzI69uxqrcJmbPU/9Y59f1uTapgwAwQHQztDWgsYpnL3ns8r1GmPWLP8sGJLVTIk2TZSiYA==}
+
+  '@turf/bearing@7.3.4':
+    resolution: {integrity: sha512-zvFjapyFaOrM8nBtAND7f4yb0BJV0jyj6cyoXyTYqLY+3Hn0eHgL0M8lwxDLbTom5KfqYDHDVDQC3+VSfypoEA==}
+
+  '@turf/bezier-spline@7.3.4':
+    resolution: {integrity: sha512-+iDUeiBKByIs/6K5WW8pG6IDxrRLJHFLM80zSpzk2xBtgy3mq36NZwwt67Pu7EJAkc9GUXKIm9SkspoKue9aYQ==}
+
+  '@turf/boolean-clockwise@7.3.4':
+    resolution: {integrity: sha512-X/O+u/OsoJ99mujhlqviuB7HX0tdJ5931TBjNSseps43XtROVuB5PwBDgwKfu5lY1B4DSGAxbbxJ795RmPnguQ==}
+
+  '@turf/boolean-concave@7.3.4':
+    resolution: {integrity: sha512-SHuAzjqaAes6ELDZcN/FKZWCQZsqwYv3gMosoLRFWTwKyBQe8i29e4y6XnXakDr1uklVUeRRcdhZ5oKtX9ABPQ==}
+
+  '@turf/boolean-contains@7.3.4':
+    resolution: {integrity: sha512-AJMGbtC6HiXgHvq0RNlTfsDB58Qf9Js45MP/APbhGTH4AiLZ8VMDISywVFNd7qN6oppNlDd3xApVR28+ti8bNg==}
+
+  '@turf/boolean-crosses@7.3.4':
+    resolution: {integrity: sha512-v/U3SuGdkexfLTMhho6Vj0OjqPUeYdThxp8zggGJ1VHow27fvLLez0DjUR3AftHjjHM6bRzZoNsu2qUlEe5hjw==}
+
+  '@turf/boolean-disjoint@7.3.4':
+    resolution: {integrity: sha512-Dl4O27ygi2NqskGQuvSlDLJYlJ2SPkHb3A9T/v6eAudjlMiKdEY6bMxKUfU5y+Px1WiCZxd+9rXGXJgGC3WiQg==}
+
+  '@turf/boolean-equal@7.3.4':
+    resolution: {integrity: sha512-AhWqe7D1o0wp3d3QQRSqgWDI8s1JfTFKFe9rU5mrSxYPGlmaQsJC07RCaYfFiGym9lACd1lxBJiPidCbLaPOfw==}
+
+  '@turf/boolean-intersects@7.3.4':
+    resolution: {integrity: sha512-sxi41NXkb5hrJgOvpm32hyBLhW8fem0vn2XxR4+jyRg1rM/v3ziF10/VqC9KDZuDNZkt9JjL9B0825Cf7AN6Lg==}
+
+  '@turf/boolean-overlap@7.3.4':
+    resolution: {integrity: sha512-Q3dlswIuqffSiMfln7xa36YDnN1TWtERMF/155rzjglm4NTUG/6S+gNsb8s6qpLjc+hN6btCq1ZjxAWurPf8Vg==}
+
+  '@turf/boolean-parallel@7.3.4':
+    resolution: {integrity: sha512-sTNMqsUkLPnSJEqc2IZ5ig3nHRoubyOH2HW1LILqOybCJI630FEM9UoYP1pZniF5nwTyCjQWnXA1FxusVILuFQ==}
+
+  '@turf/boolean-point-in-polygon@7.3.4':
+    resolution: {integrity: sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==}
+
+  '@turf/boolean-point-on-line@7.3.4':
+    resolution: {integrity: sha512-70gm5x6YQOZKcw0b/O4jjMwVWnFj+Zb6TXozLgZFDZShc8pgTQtZku7K+HKZ7Eya+7usHIB4IimZauomOMa+iw==}
+
+  '@turf/boolean-touches@7.3.4':
+    resolution: {integrity: sha512-XOwhjc0oCWhnBUB+l4drpXcg7mkNXPX3SuSz/Xv7gvLH/yRrBwzVGllzK1AHlGU9BVkGVBJIZGYX7jgTM681NQ==}
+
+  '@turf/boolean-valid@7.3.4':
+    resolution: {integrity: sha512-P6M9BtRvzFF2N5g+1/DTIbYGpEbwQ2sv/Pw+uj11P3NYAA9VE8mvrxFYf+CowFdSfY6bY4ejhuqKhrTmAMv7wA==}
+
+  '@turf/boolean-within@7.3.4':
+    resolution: {integrity: sha512-eLgi803gz0KcYkyxnnqnz9Vd6tw2/0eAExe/Rq8sO0dqypaSiomSumxjqu89d/yo24Qz8gW7c0kJ6YihNbMYxA==}
+
+  '@turf/buffer@7.3.4':
+    resolution: {integrity: sha512-MVOCBDuOl3KGDsh2stW12RmiFaFeSkVjeUbZ+ADUtIVnv+jlFsmjBpFtsEw8s9YQn5g0667QppOshm0FBHA57Q==}
+
+  '@turf/center-mean@7.3.4':
+    resolution: {integrity: sha512-6foVk5HLjlSPr48EI686Eis6/bYrJiHjKQlwY/7YlJc1uDitsIjPw2LjUCGIUZDEd6PdNUgg1+LgI7klXYvW3A==}
+
+  '@turf/center-median@7.3.4':
+    resolution: {integrity: sha512-Bz6rDr0plQOGSXgT3X3t941pYd44a5vIY8OEt4Y11H1BsgpmzFc6g7L5mr7FXW/uiYGxOewAfNcVUYUdJf9kMg==}
+
+  '@turf/center-of-mass@7.3.4':
+    resolution: {integrity: sha512-mOSupDF5qxQTA/kOWYletHcBJQ3S2gVl/IRgrBH/YY9yiFq6UGRpZ0sNcIML4H06u/1DY/jqqG+d1nc/1yIA6Q==}
+
+  '@turf/center@7.3.4':
+    resolution: {integrity: sha512-4SsLMDHWthXbyIHsczgFCo4fx+8tC8w2+B5HdEuY+P+cSOOL4T+6QQzd7WWjuN/Y3ndowFssUmwRrvXuwVRxQA==}
+
+  '@turf/centroid@7.3.4':
+    resolution: {integrity: sha512-6c3kyTSKBrmiPMe75UkHw6MgedroZ6eR5usEvdlDhXgA3MudFPXIZkMFmMd1h9XeJ9xFfkmq+HPCdF0cOzvztA==}
+
+  '@turf/circle@7.3.4':
+    resolution: {integrity: sha512-6ccr5iT51/XONF+pbpkqoRxKX4ZVWLubXb1frGCnClv2suo1UIY9SIlINNctVDupXd2P9PpqZCbrXATrcrokPg==}
+
+  '@turf/clean-coords@7.3.4':
+    resolution: {integrity: sha512-S61aJXLvPN/uZHtjzmJbLv7xhi28Sq3PshCIZSvno4Mo45bvl79Vg4aZskrG05AaSSbipplqfH+MZrkW9Xboeg==}
+
   '@turf/clone@7.3.4':
     resolution: {integrity: sha512-pwQ+RyQw986uu7IulY/18NRAebwZZScb084bvVqVkTrllwLSv4oVBqUxmUMiwtp+PNdiRGRFOvNyZqtRsiD+Jw==}
+
+  '@turf/clusters-dbscan@7.3.4':
+    resolution: {integrity: sha512-RkuXf767Shk0AfY+fh0PASVw8YR4H8zYR7XQrCgWd/bCuh6CXs7rWZ6UTLu/PiA6y6WsIhyAQv4LhNH5kCzpbA==}
+
+  '@turf/clusters-kmeans@7.3.4':
+    resolution: {integrity: sha512-89mlwhcb+vyZAKX0eBa3LQ8VyIKLayrzJpKGb90sEkIu0hDua9JCE+zlbaPoUAvAqflEiX+poFFuh7pngtsBMg==}
+
+  '@turf/clusters@7.3.4':
+    resolution: {integrity: sha512-+zoSyiF0LilXy4Tr0/lC7IgqbTMZZ2wwP3iSrqre58b61pUtdhCnBcjA2r8FkcW7z3GMbGf5XkIWhO+b+vDSsw==}
+
+  '@turf/collect@7.3.4':
+    resolution: {integrity: sha512-fG28oDZK4HCXC/AhF0pmHKLtI9DWwdJr/ktuWolrqzA5b1G7eawrXwDu8B5I3sXhdWonNRMcuLbIuz+XQscHKw==}
+
+  '@turf/combine@7.3.4':
+    resolution: {integrity: sha512-wNp9ar4FfpTfQXLZWXQ/jUBBoUFOwRN/mmlv5xrhoYFpP/F5SNy7GVDMZXaBfHdUUplfJUPF5hIKQlCUR8+k3A==}
+
+  '@turf/concave@7.3.4':
+    resolution: {integrity: sha512-HZa1CV2pv4Xpcoe3t5S3ZW6j9jVbc27exzKwZWF7MlFxSz4BKRirWiME8Fku8nvQcGafpfLc+Lwpma+nGvg06w==}
+
+  '@turf/convex@7.3.4':
+    resolution: {integrity: sha512-zeNv0fFdOoHuOQB7nl6OLb0DyjvzDvm0e3zlFkph50GF9pEKOmkCSmlniw681aWL2aRBdWZBnON3rRzOS+9C7Q==}
+
+  '@turf/destination@7.3.4':
+    resolution: {integrity: sha512-YxoUJwkKmTHiRFQxMQOP0tz8Vy+ga5EXl+C+F/WubjDLwT1AJu5y8CNIjLvWyjPWckj/vZG4u/1js5bx6MLADA==}
+
+  '@turf/difference@7.3.4':
+    resolution: {integrity: sha512-kIxizNQrYLO2rtqUIeed0tPycicrXoipy/g9d4mjv91kzBEbwpyojz9zi8U9G1ISBfCEgA7wsViQD0r+8qzxXw==}
+
+  '@turf/dissolve@7.3.4':
+    resolution: {integrity: sha512-xjGY1gQ4icWhDgsW0YfU2KQtij1+ru34AfvtkVMQEgI86O9EwjW2r9Jq5DJY2PMKPbor3kz9yM/RTOiDP7f3Jg==}
+
+  '@turf/distance-weight@7.3.4':
+    resolution: {integrity: sha512-dVMNEmIluKgn7iQTmzJJOe0UASRNmmSdFX1boAev5MISaW3AvPiURCCOV+lTIeoaQbWRpEAESbAp6JIimXFr8Q==}
+
+  '@turf/distance@7.3.4':
+    resolution: {integrity: sha512-9drWgd46uHPPyzgrcRQLgSvdS/SjVlQ6ZIBoRQagS5P2kSjUbcOXHIMeOSPwfxwlKhEtobLyr+IiR2ns1TfF8w==}
+
+  '@turf/ellipse@7.3.4':
+    resolution: {integrity: sha512-SMgbERZl12j7H8YaIofmnf0NwAvdF5Wly4tjI/eUhj/sFOKrKXOS1lvCSBJ6uSV9tFijl3ecGOVOlTpURdZ30g==}
+
+  '@turf/envelope@7.3.4':
+    resolution: {integrity: sha512-anXSjYMXGAyXT7rpO74VyRI0q/rPAbKE/MYvou+QvG0U/Oa7el0yF4JNNi9wKEAxXg/10aWm9kHp8s2caeLg6A==}
+
+  '@turf/explode@7.3.4':
+    resolution: {integrity: sha512-7QWhp3f8jhrWjvArhJ74hXBFHMaiJr/2Y1PzHCWue2/pC5MbbTV0o7peehwrrrJC/1uD6CVb3hlcb77IxtMQkw==}
+
+  '@turf/flatten@7.3.4':
+    resolution: {integrity: sha512-Yt3HCh/qeNaXS4LYhXczFhBfTeaKlTBoxEw1OICb9RT3SiGU0XCxuK7H0W26OLo7XxB0qP7GPs2L3FZbiri6wQ==}
+
+  '@turf/flip@7.3.4':
+    resolution: {integrity: sha512-HME+kVMTyvcsYVY6dC6DTvuzq8vvDpw+C7PviEqpuT3KcVlBCoGPAqlWRdyWYOb9MDciOqNxvvJF/okpb/GQcg==}
+
+  '@turf/geojson-rbush@7.3.4':
+    resolution: {integrity: sha512-aDG/5mMCgKduqBwZ3XpLOdlE2hizV3fM+5dHCWyrBepCQLeM/QRvvpBDCdQKDWKpoIBmrGGYDNiOofnf3QmGhg==}
+
+  '@turf/great-circle@7.3.4':
+    resolution: {integrity: sha512-JvfzWFL9efP+xKtOnKzGvwEIXfaN0CLZoPPxNnWa/cVisLs9FVMlC9PWnuL3/3aqH5VhBHPddmU8ipzNE6KIIA==}
 
   '@turf/helpers@7.3.4':
     resolution: {integrity: sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==}
 
+  '@turf/hex-grid@7.3.4':
+    resolution: {integrity: sha512-TDCgBykFdsrP3IOOfToiiLpYkbUb3eEEhM9riIqWht0ubKUY61LN7qVs9bxZD83hG6XaDB6uY7SWkxK1zIEopQ==}
+
+  '@turf/interpolate@7.3.4':
+    resolution: {integrity: sha512-lwYSMbHxsXYEWObv0tyBCjwTLXyfsTvOLn/NFhlsGrNCYEXn8I1VPtLGwuxbSdF3hVRgurn8qftkB1npHrNs6Q==}
+
+  '@turf/intersect@7.3.4':
+    resolution: {integrity: sha512-VsqMEMeRWWs2mjwI7sTlUgH1cEfugTGhQ0nF8ncHG7YKd9HUUTzIKpn9FJeoguPWIYITcy1ar4yJEOU/hteBVw==}
+
+  '@turf/invariant@7.3.4':
+    resolution: {integrity: sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==}
+
+  '@turf/isobands@7.3.4':
+    resolution: {integrity: sha512-SFYefwjQdQfF0MV0zfaSwNg9J1wD7mfPP8scGcScKGM3admbwS2A3V8rqPADBfYLD2eCPBDFnySxcl9SHbPung==}
+
+  '@turf/isolines@7.3.4':
+    resolution: {integrity: sha512-UFRIULkIgkZOmrhLxExWvguixbzfoCgVcXIqo2Cp68do4v+nwc3pTM7MTt4DBVFloIdX0Usrn4K44LQ/V05gxg==}
+
+  '@turf/jsts@2.7.2':
+    resolution: {integrity: sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==}
+
+  '@turf/kinks@7.3.4':
+    resolution: {integrity: sha512-LZTKELWxvXl0vc9ZxVgi0v07fO9+2FrZOam2B10fz/eGjy3oKNazU5gjggbnc499wEIcJS4hN+VyjQZrmsJAdQ==}
+
+  '@turf/length@7.3.4':
+    resolution: {integrity: sha512-Dg1GnQ/B2go5NIWXt91N4L7XTjIgIWCftBSYIXkrpIM7QGjItzglek0Z5caytvb8ZRWXzZOGs8//+Q5we91WuQ==}
+
+  '@turf/line-arc@7.3.4':
+    resolution: {integrity: sha512-nqZ+JKjDVIrvREFHgtJIP9Ps4WbWw3eStqdIzAPolrzoXyAZnpIKquyfRTxpJFYUUjDmf+uQ/SFWsPP4SOWAqQ==}
+
+  '@turf/line-chunk@7.3.4':
+    resolution: {integrity: sha512-xWEHR99EpUO5ZPEZhMfa0QvnFZC0W+QLxB1GcJcSeJAQ5ZMXUXY8doKF1Nztk0eppawMprEEO3nQWLvQoR4z2g==}
+
+  '@turf/line-intersect@7.3.4':
+    resolution: {integrity: sha512-XygbTvHa6A+v6l2ZKYtS8AAWxwmrPxKxfBbdH75uED1JvdytSLWYTKGlcU3soxd9sYb4x/g9sDvRIVyU6Lucrg==}
+
+  '@turf/line-offset@7.3.4':
+    resolution: {integrity: sha512-CSrg3njde9Tx+C0oL+BHUpZYpgD+PEmzp0ldDNis5ZQiTe5tUrwiIyG7A/QXf9eDnGhtV1WhCAycX0Wjged4pg==}
+
+  '@turf/line-overlap@7.3.4':
+    resolution: {integrity: sha512-3GBECiwNAQ2MmSwiqAHMweIl+EiePK0Jx4fXxF1KFE+NGCDv/MbGcEYfAbmsTg8mg6oRI9D8fJZzrT44DHpHXA==}
+
+  '@turf/line-segment@7.3.4':
+    resolution: {integrity: sha512-UeISzf/JHoWEY5yeoyvKwA5epWcvJMCpCwbIMolvfTC5pp+IVozjHPVCRvRWuzmbmAvetcW0unL5bjqi0ADmuQ==}
+
+  '@turf/line-slice-along@7.3.4':
+    resolution: {integrity: sha512-RT5HydNy8+m9Y3u39USeYZauG2EyMqCYoLnTpWcAxbZGdq9WjIwdzAwYir3d8eJkOzjlR6Khz071VM4Ufqs0Kg==}
+
+  '@turf/line-slice@7.3.4':
+    resolution: {integrity: sha512-6Vt4Eptdr2C5T+jtpbo8D4v8b6X7KqYonPPyMB6huv+Kcg3nz4JRI9OQCDCaon9rWvU3ffWwjsjcbJCQS9o0sA==}
+
+  '@turf/line-split@7.3.4':
+    resolution: {integrity: sha512-l1zmCSUnGsiN4gf22Aw91a2VnYs5DZS67FdkYqKgr+wPEAL/gpQgIBBWSTmhwY8zb3NEqty+f/gMEe8EJAWYng==}
+
+  '@turf/line-to-polygon@7.3.4':
+    resolution: {integrity: sha512-vRnDHjzwOroC74/fsJEU+dUeGhiR/B2bG0/HeEWRBplAjmwVPptRBmDGtXKTz8sbA6or17/XtOITp3zTU0lBZw==}
+
+  '@turf/mask@7.3.4':
+    resolution: {integrity: sha512-FJIlSk8m0AiqzNoLSMdYuhDRif6aeOYVdW/WxjEjpUoMalwy2w5MMlZqJB9zxt/xSrMq6lvTWJgZfZfGL2s4ZQ==}
+
   '@turf/meta@7.3.4':
     resolution: {integrity: sha512-tlmw9/Hs1p2n0uoHVm1w3ugw1I6L8jv9YZrcdQa4SH5FX5UY0ATrKeIvfA55FlL//PGuYppJp+eyg/0eb4goqw==}
 
+  '@turf/midpoint@7.3.4':
+    resolution: {integrity: sha512-/XAeGvsz8l5HaqcP7TUlexzGfibqXozQgBZ8rH7az6op2Dfm3pL/Z7bKLHoVavM0ccBg0Pt7g6j9NM54kZWdKA==}
+
+  '@turf/moran-index@7.3.4':
+    resolution: {integrity: sha512-SNb16szwEG0OiyNn3z9zvSnk3M3tfwvvN8i//9UIC32APEApI+MRXCl93H/qZkKMhhh/cHA0pF0pjYZwl5z8Ow==}
+
+  '@turf/nearest-neighbor-analysis@7.3.4':
+    resolution: {integrity: sha512-8EZlDy5poU0t7BDy8KTzOmfiGsAs2kWuB3/kgI4sMdbThKVk2P4hHKuToCSGvqAzwSy3B2qKYM1N6JeVWytu+w==}
+
+  '@turf/nearest-point-on-line@7.3.4':
+    resolution: {integrity: sha512-DQrP3lRju83rIXFN68tUEpc7ki/eRwdwBkK2CTT4RAcyCxbcH2NGJPQv8dYiww/Ar77u1WLVn+aINXZH904dWw==}
+
+  '@turf/nearest-point-to-line@7.3.4':
+    resolution: {integrity: sha512-Nzp3ojQt0gDACNYG+oNWymRXAUCey0LzdiSezYtRwdA0/+FQCtuxP8Lbc8FftV10JL8D78/CRlmt7omaXLLXCg==}
+
+  '@turf/nearest-point@7.3.4':
+    resolution: {integrity: sha512-WfI09f2bX0nKx/jkO7zCt3tUrJulyAlUYQtZHP7lWYMCOmZ6Pq26D6lKWjpfs2it0OHbhlx1XF/UupEUaz830w==}
+
+  '@turf/planepoint@7.3.4':
+    resolution: {integrity: sha512-KAhMAnddbuWIEZuk2bK//g+xTeKn8aV9N2AaE27x6JMJyV/wqvatIuVVqEIXI3SkAFbhiVBpVuarvPYhrJ+fhg==}
+
+  '@turf/point-grid@7.3.4':
+    resolution: {integrity: sha512-9CL3OJ4dEt266+fxYlOQeRFqAY3XtsAuak2Gpk+K8k+Y3yGv8pvyn3QaAQ6P2npbiKt0zfG8Md/+HBAPOMPQ0A==}
+
+  '@turf/point-on-feature@7.3.4':
+    resolution: {integrity: sha512-tQfIxsJUxZqyO7OeJC25y3DqN9i4fmrAt4TBrPvZcIIwymgN7aMrElJKlg/dfi7JDihKp3h/CkWMjtMQA14Vwg==}
+
+  '@turf/point-to-line-distance@7.3.4':
+    resolution: {integrity: sha512-IdPAxlAQZj7FCZg+ObyVHlNdqwLL/oxYoQjpxMNJ511gNxokCtEv0aeRZQjYOYIxr9Ss97v3yo3ILJaF9V2kPw==}
+
+  '@turf/point-to-polygon-distance@7.3.4':
+    resolution: {integrity: sha512-VxbkgHyzCkYWSxirqSUqw+lzbYmTf2qFhVZ/T5dprhwyXWcgalpupvgRzmZmjKkgsoJ017vrvCNKZRaCCn+Z7Q==}
+
+  '@turf/points-within-polygon@7.3.4':
+    resolution: {integrity: sha512-HfT83Iw99zywDfCp+nJwS+JDzH+GdNug0sut9WDjGEznHKoZyAcOk+hGKL/ja8TeCLx9VsZHOiVCQFm+NTgvgA==}
+
+  '@turf/polygon-smooth@7.3.4':
+    resolution: {integrity: sha512-AnpaGgNYVvP/dfz10id3AotDrUh9O+4unXCk3es1ff51VrpUhVgH3H+zyTSbVL4zAXN/ejPb8UnKCxDvNOQs4g==}
+
+  '@turf/polygon-tangents@7.3.4':
+    resolution: {integrity: sha512-D1IFocXJYF8PUMZ+BmnOstyRrzklqC86FgakYVk9O61F9Ki8LhMGaRfF+6reKMD473KvHvEf1M2EgmGt+OHDRw==}
+
+  '@turf/polygon-to-line@7.3.4':
+    resolution: {integrity: sha512-xhmOZ5rHZAKLUDLeYKWMsX84ip8CCGOcGLBHtPPYOjdIDHddMV6Sxt5kVgkmlZpK6NEWEmOD6lYR4obxHcHlGA==}
+
+  '@turf/polygonize@7.3.4':
+    resolution: {integrity: sha512-kmj05rkJ4tE8LvbQ4GVsL5GOrRiX/F5W4RIdxo8gPGTw1Y5oLG/1vFk6Hg6x63L1WcdNtF0sq6AdEI0G9BXWXA==}
+
   '@turf/projection@7.3.4':
     resolution: {integrity: sha512-p91zOaLmzoBHzU/2H6Ot1tOhTmAom85n1P7I4Oo0V9xU8hmJXWfNnomLFf/6rnkKDIFZkncLQIBz4iIecZ61sA==}
+
+  '@turf/quadrat-analysis@7.3.4':
+    resolution: {integrity: sha512-Yxqq8wgrDiXIX+s0uOZ2exmYfRwTIcUX8J7j4P+sbyLVbyN8W3AjN2s5ZX21P0aFf3v24FBd2fNWlm5VmMUAdg==}
+
+  '@turf/random@7.3.4':
+    resolution: {integrity: sha512-CXMS5XDoI5x0zc1aCYbn3t603k8hjaFHNsSOvGBW20z68cwP0UwMQQr0KLqFPqI4J1O7dMX+urn8IHH27RXFYg==}
+
+  '@turf/rectangle-grid@7.3.4':
+    resolution: {integrity: sha512-qM7vujJ4wndB4MKZlEcnUSawgvs5wXpSEFf4f+LWRIfmGhtv6serzDqFzWcmy8kF8hg5J465PMktRmAFWq/a+w==}
+
+  '@turf/rewind@7.3.4':
+    resolution: {integrity: sha512-4BZ8MHMujl4NAT7XnIs7JoOuDhpR96oDTB0RtqTeIP4onioIedVnw1ZA3Uq08sILGpR0qKLuDsvdz4x9jtbptg==}
+
+  '@turf/rhumb-bearing@7.3.4':
+    resolution: {integrity: sha512-tvX1toSo80q0iL0cUMMXpSKsCCfOjRqDGCmOdR6B9shhk6xP1ZM2PLQDr+MFPBFeGyQuyY4CNFkV2+3DF49vYw==}
+
+  '@turf/rhumb-destination@7.3.4':
+    resolution: {integrity: sha512-6HikEb5nm2A18FQWk6vVLMQkc099I/7c69j47RYM27xQK8J8uBCNk1zLYyMPcZTh24xcNSbZ1iPHDsDOqw6wWQ==}
+
+  '@turf/rhumb-distance@7.3.4':
+    resolution: {integrity: sha512-phwskeijdgYMsR3qDQmytfsg2iZcp3uWK7UFc76wKTEpxozbDGFI4enX5gXvZPpyI1iD7gsktGqHsO33AjnFDA==}
+
+  '@turf/sample@7.3.4':
+    resolution: {integrity: sha512-XzAATg09c2XYAXkIBbg8lktSrU1tXNjJYXtbVwF6jLp1q2wTRpwb+mZpTEPAwzZwVF81uR5c0CsdQyr5UHINVw==}
+
+  '@turf/sector@7.3.4':
+    resolution: {integrity: sha512-x2tNAXl21HRcF302ghU5ohE/vmmfDcXpQKgoWHyi7o5Q9kDRBwy7kbvr5YxbT3vwW/kAWUDYM7FoXNH42bXgCw==}
+
+  '@turf/shortest-path@7.3.4':
+    resolution: {integrity: sha512-xbK/oM+JRL+lJCHkAdZ3QPgoivT40J9WKJ0d1Ddt8LXTpzX2YeJVgcwOZaBPG9ncZUzHfHIWS1rUjc54clnZcg==}
+
+  '@turf/simplify@7.3.4':
+    resolution: {integrity: sha512-OoSwu3vI0H9P+GzLDaOJIL9v0V8ubeP8wQjM8GeMEZrq6U2uh9JWQnAU+jviT3ODcKF5H+88snpiMik585L0wA==}
+
+  '@turf/square-grid@7.3.4':
+    resolution: {integrity: sha512-MgjlVRklQYFfQm9yJNha9kXothLPliVdeycNdmn4lWLH3SOZe1rqJPB5Z9+dhmJELT3BJraDq3W5ik5taEpKyQ==}
+
+  '@turf/square@7.3.4':
+    resolution: {integrity: sha512-vJ+NeiEaOVsb8YiUExtyIgvH+ZybthHszl2TASZn5q340ioKHPb2JeHGlbgrB2x8pEMh3MVhoqxAbXDuND/cnw==}
+
+  '@turf/standard-deviational-ellipse@7.3.4':
+    resolution: {integrity: sha512-+BaetOKN8zA2mQCVTcRWMcfidNR3JkjmYj0r5iGRncK0J+pdxIjX2q6sF6yBMOOxMoEMy393P7j07HdBIPbibw==}
+
+  '@turf/tag@7.3.4':
+    resolution: {integrity: sha512-ienLhLzBLeChtKhbJMmU3/vGg0hWzi6Wh/q0n39W4CmdNb+yAoGQhlYjcCbPOJT4IcdFlWE3OhbP9EmH/xPgfg==}
+
+  '@turf/tesselate@7.3.4':
+    resolution: {integrity: sha512-NnDgVb5ZchJEhEpq1je2hktS5UhnHMfeeumxZQgnIoMeGILpJtcOL//b/1biBBUVSJ0ZZg5zxiHdQc1PgK2gxA==}
+
+  '@turf/tin@7.3.4':
+    resolution: {integrity: sha512-tuegrGlbKPp6Dm8r5SuYDtQ2EVzdXVVxelqI1agnzj9N+l8oTBIKLRxRbBkLsizeVIDnlmVHCQB6cRc3v+u8JQ==}
+
+  '@turf/transform-rotate@7.3.4':
+    resolution: {integrity: sha512-pbUG6QLwyJvvitq4aAq4IQH79X8T0NmEPUGDUEEP69yW7t4+UZjDBAVbCKwpOc8gtsK0K5yvxlZ0e2CdtpNmEw==}
+
+  '@turf/transform-scale@7.3.4':
+    resolution: {integrity: sha512-7gUIFFHaU3Ewj3rCzIu5Yo7Zjfv4R2ypjh6UWiMJnDavb7RQ8fn0AKKcNMA/vF/yxuncp2l3zoa2gygv4AKM8A==}
+
+  '@turf/transform-translate@7.3.4':
+    resolution: {integrity: sha512-qbSIEueOR8mNB7p4EB88vHvUAyuSBM8zxP68UiiTNV3Gh+OZF2VXTFiu3EFYMTaD9sE6Lxmzvv3fjW8N2q82pw==}
+
+  '@turf/triangle-grid@7.3.4':
+    resolution: {integrity: sha512-0bki10XwYvNcPzDcSs5kUh3niOogdVeFtawJEz5FdlyTAUohbNlC+Vb40K//OqEyTrGII+q1/dE4q+1J6ZCmDA==}
+
+  '@turf/truncate@7.3.4':
+    resolution: {integrity: sha512-VPXdae9+RLLM19FMrJgt7QANBikm7DxPbfp/dXgzE4Ca7v+mJ4T1fYc7gCZDaqOrWMccHKbvv4iSuW7YZWdIIA==}
+
+  '@turf/turf@7.3.4':
+    resolution: {integrity: sha512-uMAKLYt2tWJj8xIepq4vExF1r8fzJviP/5l/elDHuRyauI2mASy/Gox6kSFlrN0t0p8AT4Cs8o//4GuJTXyC+Q==}
+
+  '@turf/union@7.3.4':
+    resolution: {integrity: sha512-JJYyPMmGcrTa9sPv2ief2QU9Hb//cEAU1zgKu/OfoCMa9a8Imp5QVm9UTAkhGlc+4qm/N/X16iJ+cvVWaxPjkg==}
+
+  '@turf/unkink-polygon@7.3.4':
+    resolution: {integrity: sha512-dFIqTLAnLL5D3OANPJtRb5OvmOM81GlNCjwgjlLQy0xdpYgKwGdE+gNXjygDrPUUXNc22xnaj3EfAfC3Pq7W4Q==}
+
+  '@turf/voronoi@7.3.4':
+    resolution: {integrity: sha512-cwKSiDzDHRnA7yafQ1zOhWxRuMzp+fYFFzadCdByBAG1jAD7UlFwKhS1fjNPBNs67Fl5X3LL5ahCLW5gEdFgmg==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -4782,6 +5118,9 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/d3-voronoi@1.1.12':
+    resolution: {integrity: sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -4805,6 +5144,9 @@ packages:
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/geokdbush@1.1.5':
+    resolution: {integrity: sha512-jIsYnXY+RQ/YCyBqeEHxYN9mh+7PqKJUJUp84wLfZ7T2kqyVPNaXwZuvf1A2uQUkrvVqEbsG94ff8jH32AlLvA==}
 
   '@types/hammerjs@2.0.46':
     resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
@@ -4832,6 +5174,12 @@ packages:
 
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/kdbush@1.0.7':
+    resolution: {integrity: sha512-QM5iB8m/0mnGOjUKshErIZQ0LseyTieRSYc3yaOpmrRM0xbWiOuJUWlduJx+TPNK7/VFMWphUGwx3nus7eT1Wg==}
+
+  '@types/kdbush@3.0.5':
+    resolution: {integrity: sha512-tdJz7jaWFu4nR+8b2B+CdPZ6811ighYylWsu2hpsivapzW058yP0KdfZuNY89IiRe5jbKvBGXN3LQdN2KPXVdQ==}
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
@@ -5446,6 +5794,10 @@ packages:
 
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
+  arc@0.2.0:
+    resolution: {integrity: sha512-8NFOo126uYKQJyXNSLY/jSklgfLQL+XWAcPXGo876JwEQ8nSOPXWNI3TV2jLZMN8QEw8uksJ1ZwS4npjBca8MA==}
+    engines: {node: '>=0.4.0'}
 
   arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
@@ -6065,6 +6417,9 @@ packages:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
 
+  concaveman@1.2.1:
+    resolution: {integrity: sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==}
+
   concurrently@9.2.1:
     resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
     engines: {node: '>=18'}
@@ -6235,6 +6590,9 @@ packages:
   csv-parse@4.16.3:
     resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
 
+  d3-array@1.2.4:
+    resolution: {integrity: sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==}
+
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
@@ -6250,6 +6608,9 @@ packages:
   d3-format@3.1.2:
     resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
     engines: {node: '>=12'}
+
+  d3-geo@1.7.1:
+    resolution: {integrity: sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==}
 
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
@@ -6278,6 +6639,9 @@ packages:
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
+
+  d3-voronoi@1.1.2:
+    resolution: {integrity: sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==}
 
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
@@ -6567,6 +6931,9 @@ packages:
 
   dynamic-dedupe@0.3.0:
     resolution: {integrity: sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==}
+
+  earcut@2.2.4:
+    resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
 
   earcut@3.0.2:
     resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
@@ -7095,8 +7462,17 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  geojson-equality-ts@1.0.2:
+    resolution: {integrity: sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==}
+
+  geojson-polygon-self-intersections@1.2.2:
+    resolution: {integrity: sha512-6XRNF4CsRHYmR9z5YuIk5f/aOototnDf0dgMqYGcS7y1l57ttt6MAIAxl3rXyas6lq1HEbTuLMh4PgvO+OV42w==}
+
   geojson-vt@4.0.2:
     resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
+
+  geokdbush@2.1.0:
+    resolution: {integrity: sha512-bMc7mu+SeUxtHwRpVvZ36qnZa/x8YAGuaPNeGDxd9bxp/jYuJ5GrUirUPz6UNiT+nn/79IQ4gCNan0y4alEUxw==}
 
   get-amd-module-type@6.0.1:
     resolution: {integrity: sha512-MtjsmYiCXcYDDrGqtNbeIYdAl85n+5mSv2r3FbzER/YV3ZILw4HNNIw34HuV5pyl0jzs6GFYU1VHVEefhgcNHQ==}
@@ -7937,6 +8313,10 @@ packages:
 
   jsqr@1.4.0:
     resolution: {integrity: sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==}
+
+  jsts@2.7.1:
+    resolution: {integrity: sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==}
+    engines: {node: '>= 12'}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -9124,8 +9504,17 @@ packages:
   png-js@1.0.0:
     resolution: {integrity: sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==}
 
+  point-in-polygon-hao@1.2.4:
+    resolution: {integrity: sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==}
+
+  point-in-polygon@1.1.0:
+    resolution: {integrity: sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==}
+
   polka@0.5.2:
     resolution: {integrity: sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==}
+
+  polyclip-ts@0.16.8:
+    resolution: {integrity: sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==}
 
   postcss-values-parser@6.0.2:
     resolution: {integrity: sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==}
@@ -9300,6 +9689,12 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  quickselect@1.1.1:
+    resolution: {integrity: sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==}
+
+  quickselect@2.0.0:
+    resolution: {integrity: sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==}
+
   quickselect@3.0.0:
     resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
@@ -9316,6 +9711,12 @@ packages:
   raw-body@3.0.1:
     resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
     engines: {node: '>= 0.10'}
+
+  rbush@2.0.2:
+    resolution: {integrity: sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==}
+
+  rbush@3.0.1:
+    resolution: {integrity: sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==}
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -9600,6 +10001,9 @@ packages:
   robust-predicates@2.0.4:
     resolution: {integrity: sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9801,6 +10205,9 @@ packages:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
 
+  skmeans@0.9.7:
+    resolution: {integrity: sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -9900,6 +10307,9 @@ packages:
 
   spdx-license-ids@3.0.21:
     resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
+
+  splaytree-ts@1.0.2:
+    resolution: {integrity: sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==}
 
   splaytree@0.1.4:
     resolution: {integrity: sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==}
@@ -10105,6 +10515,9 @@ packages:
   swagger-ui-dist@5.31.0:
     resolution: {integrity: sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==}
 
+  sweepline-intersections@1.5.0:
+    resolution: {integrity: sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==}
+
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
@@ -10217,6 +10630,9 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  tinyqueue@2.0.3:
+    resolution: {integrity: sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==}
+
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
@@ -10252,6 +10668,14 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  topojson-client@3.1.0:
+    resolution: {integrity: sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==}
+    hasBin: true
+
+  topojson-server@3.0.1:
+    resolution: {integrity: sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==}
+    hasBin: true
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -16721,10 +17145,434 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@turf/along@7.3.4':
+    dependencies:
+      '@turf/bearing': 7.3.4
+      '@turf/destination': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/angle@7.3.4':
+    dependencies:
+      '@turf/bearing': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/rhumb-bearing': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/area@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/bbox-clip@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/bbox-polygon@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/bbox@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/bearing@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/bezier-spline@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-clockwise@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-concave@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-contains@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/boolean-point-on-line': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/line-split': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-crosses@7.3.4':
+    dependencies:
+      '@turf/boolean-equal': 7.3.4
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/line-intersect': 7.3.4
+      '@turf/polygon-to-line': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-disjoint@7.3.4':
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/line-intersect': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/polygon-to-line': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-equal@7.3.4':
+    dependencies:
+      '@turf/clean-coords': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      geojson-equality-ts: 1.0.2
+      tslib: 2.8.1
+
+  '@turf/boolean-intersects@7.3.4':
+    dependencies:
+      '@turf/boolean-disjoint': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-overlap@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/line-intersect': 7.3.4
+      '@turf/line-overlap': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      geojson-equality-ts: 1.0.2
+      tslib: 2.8.1
+
+  '@turf/boolean-parallel@7.3.4':
+    dependencies:
+      '@turf/clean-coords': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/line-segment': 7.3.4
+      '@turf/rhumb-bearing': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-point-in-polygon@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      point-in-polygon-hao: 1.2.4
+      tslib: 2.8.1
+
+  '@turf/boolean-point-on-line@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-touches@7.3.4':
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/boolean-point-on-line': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/boolean-valid@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/boolean-crosses': 7.3.4
+      '@turf/boolean-disjoint': 7.3.4
+      '@turf/boolean-overlap': 7.3.4
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/boolean-point-on-line': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/line-intersect': 7.3.4
+      '@types/geojson': 7946.0.16
+      geojson-polygon-self-intersections: 1.2.2
+      tslib: 2.8.1
+
+  '@turf/boolean-within@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/boolean-point-on-line': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/line-split': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/buffer@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/center': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/jsts': 2.7.2
+      '@turf/meta': 7.3.4
+      '@turf/projection': 7.3.4
+      '@types/geojson': 7946.0.16
+      d3-geo: 1.7.1
+
+  '@turf/center-mean@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/center-median@7.3.4':
+    dependencies:
+      '@turf/center-mean': 7.3.4
+      '@turf/centroid': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/center-of-mass@7.3.4':
+    dependencies:
+      '@turf/centroid': 7.3.4
+      '@turf/convex': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/center@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/centroid@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/circle@7.3.4':
+    dependencies:
+      '@turf/destination': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/clean-coords@7.3.4':
+    dependencies:
+      '@turf/boolean-point-on-line': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@turf/clone@7.3.4':
     dependencies:
       '@turf/helpers': 7.3.4
       '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/clusters-dbscan@7.3.4':
+    dependencies:
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      '@types/geokdbush': 1.1.5
+      geokdbush: 2.1.0
+      kdbush: 4.0.2
+      tslib: 2.8.1
+
+  '@turf/clusters-kmeans@7.3.4':
+    dependencies:
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      skmeans: 0.9.7
+      tslib: 2.8.1
+
+  '@turf/clusters@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/collect@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      rbush: 3.0.1
+      tslib: 2.8.1
+
+  '@turf/combine@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/concave@7.3.4':
+    dependencies:
+      '@turf/clone': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/tin': 7.3.4
+      '@types/geojson': 7946.0.16
+      topojson-client: 3.1.0
+      topojson-server: 3.0.1
+      tslib: 2.8.1
+
+  '@turf/convex@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      concaveman: 1.2.1
+      tslib: 2.8.1
+
+  '@turf/destination@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/difference@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
+
+  '@turf/dissolve@7.3.4':
+    dependencies:
+      '@turf/flatten': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
+
+  '@turf/distance-weight@7.3.4':
+    dependencies:
+      '@turf/centroid': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/distance@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/ellipse@7.3.4':
+    dependencies:
+      '@turf/destination': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/transform-rotate': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/envelope@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/bbox-polygon': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/explode@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/flatten@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/flip@7.3.4':
+    dependencies:
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/geojson-rbush@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      rbush: 3.0.1
+      tslib: 2.8.1
+
+  '@turf/great-circle@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      arc: 0.2.0
       tslib: 2.8.1
 
   '@turf/helpers@7.3.4':
@@ -16732,9 +17580,339 @@ snapshots:
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 
+  '@turf/hex-grid@7.3.4':
+    dependencies:
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/intersect': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/interpolate@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/centroid': 7.3.4
+      '@turf/clone': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/hex-grid': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/point-grid': 7.3.4
+      '@turf/square-grid': 7.3.4
+      '@turf/triangle-grid': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/intersect@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
+
+  '@turf/invariant@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/isobands@7.3.4':
+    dependencies:
+      '@turf/area': 7.3.4
+      '@turf/bbox': 7.3.4
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/explode': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/isolines@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/jsts@2.7.2':
+    dependencies:
+      jsts: 2.7.1
+
+  '@turf/kinks@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/length@7.3.4':
+    dependencies:
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/line-arc@7.3.4':
+    dependencies:
+      '@turf/circle': 7.3.4
+      '@turf/destination': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/line-chunk@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/length': 7.3.4
+      '@turf/line-slice-along': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/line-intersect@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      sweepline-intersections: 1.5.0
+      tslib: 2.8.1
+
+  '@turf/line-offset@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/line-overlap@7.3.4':
+    dependencies:
+      '@turf/boolean-point-on-line': 7.3.4
+      '@turf/geojson-rbush': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/line-segment': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/nearest-point-on-line': 7.3.4
+      '@types/geojson': 7946.0.16
+      fast-deep-equal: 3.1.3
+      tslib: 2.8.1
+
+  '@turf/line-segment@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/line-slice-along@7.3.4':
+    dependencies:
+      '@turf/bearing': 7.3.4
+      '@turf/destination': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/line-slice@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/nearest-point-on-line': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/line-split@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/geojson-rbush': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/line-intersect': 7.3.4
+      '@turf/line-segment': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/nearest-point-on-line': 7.3.4
+      '@turf/truncate': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/line-to-polygon@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/mask@7.3.4':
+    dependencies:
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
+
   '@turf/meta@7.3.4':
     dependencies:
       '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/midpoint@7.3.4':
+    dependencies:
+      '@turf/bearing': 7.3.4
+      '@turf/destination': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/moran-index@7.3.4':
+    dependencies:
+      '@turf/distance-weight': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/nearest-neighbor-analysis@7.3.4':
+    dependencies:
+      '@turf/area': 7.3.4
+      '@turf/bbox': 7.3.4
+      '@turf/bbox-polygon': 7.3.4
+      '@turf/centroid': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/nearest-point': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/nearest-point-on-line@7.3.4':
+    dependencies:
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/nearest-point-to-line@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/point-to-line-distance': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/nearest-point@7.3.4':
+    dependencies:
+      '@turf/clone': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/planepoint@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/point-grid@7.3.4':
+    dependencies:
+      '@turf/boolean-within': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/point-on-feature@7.3.4':
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/center': 7.3.4
+      '@turf/explode': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/nearest-point': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/point-to-line-distance@7.3.4':
+    dependencies:
+      '@turf/bearing': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/nearest-point-on-line': 7.3.4
+      '@turf/projection': 7.3.4
+      '@turf/rhumb-bearing': 7.3.4
+      '@turf/rhumb-distance': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/point-to-polygon-distance@7.3.4':
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/point-to-line-distance': 7.3.4
+      '@turf/polygon-to-line': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/points-within-polygon@7.3.4':
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/polygon-smooth@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/polygon-tangents@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/boolean-within': 7.3.4
+      '@turf/explode': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/nearest-point': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/polygon-to-line@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/polygonize@7.3.4':
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/envelope': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 
@@ -16744,6 +17922,351 @@ snapshots:
       '@turf/helpers': 7.3.4
       '@turf/meta': 7.3.4
       '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/quadrat-analysis@7.3.4':
+    dependencies:
+      '@turf/area': 7.3.4
+      '@turf/bbox': 7.3.4
+      '@turf/bbox-polygon': 7.3.4
+      '@turf/centroid': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/point-grid': 7.3.4
+      '@turf/random': 7.3.4
+      '@turf/square-grid': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/random@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/rectangle-grid@7.3.4':
+    dependencies:
+      '@turf/boolean-intersects': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/rewind@7.3.4':
+    dependencies:
+      '@turf/boolean-clockwise': 7.3.4
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/rhumb-bearing@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/rhumb-destination@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/rhumb-distance@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/sample@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/sector@7.3.4':
+    dependencies:
+      '@turf/circle': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/line-arc': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/shortest-path@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/bbox-polygon': 7.3.4
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/clean-coords': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/transform-scale': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/simplify@7.3.4':
+    dependencies:
+      '@turf/clean-coords': 7.3.4
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/square-grid@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/rectangle-grid': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/square@7.3.4':
+    dependencies:
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/standard-deviational-ellipse@7.3.4':
+    dependencies:
+      '@turf/center-mean': 7.3.4
+      '@turf/ellipse': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/points-within-polygon': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/tag@7.3.4':
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/tesselate@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      earcut: 2.2.4
+      tslib: 2.8.1
+
+  '@turf/tin@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/transform-rotate@7.3.4':
+    dependencies:
+      '@turf/centroid': 7.3.4
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/rhumb-bearing': 7.3.4
+      '@turf/rhumb-destination': 7.3.4
+      '@turf/rhumb-distance': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/transform-scale@7.3.4':
+    dependencies:
+      '@turf/bbox': 7.3.4
+      '@turf/center': 7.3.4
+      '@turf/centroid': 7.3.4
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/rhumb-bearing': 7.3.4
+      '@turf/rhumb-destination': 7.3.4
+      '@turf/rhumb-distance': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/transform-translate@7.3.4':
+    dependencies:
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/rhumb-destination': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/triangle-grid@7.3.4':
+    dependencies:
+      '@turf/distance': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/intersect': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/truncate@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/turf@7.3.4':
+    dependencies:
+      '@turf/along': 7.3.4
+      '@turf/angle': 7.3.4
+      '@turf/area': 7.3.4
+      '@turf/bbox': 7.3.4
+      '@turf/bbox-clip': 7.3.4
+      '@turf/bbox-polygon': 7.3.4
+      '@turf/bearing': 7.3.4
+      '@turf/bezier-spline': 7.3.4
+      '@turf/boolean-clockwise': 7.3.4
+      '@turf/boolean-concave': 7.3.4
+      '@turf/boolean-contains': 7.3.4
+      '@turf/boolean-crosses': 7.3.4
+      '@turf/boolean-disjoint': 7.3.4
+      '@turf/boolean-equal': 7.3.4
+      '@turf/boolean-intersects': 7.3.4
+      '@turf/boolean-overlap': 7.3.4
+      '@turf/boolean-parallel': 7.3.4
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/boolean-point-on-line': 7.3.4
+      '@turf/boolean-touches': 7.3.4
+      '@turf/boolean-valid': 7.3.4
+      '@turf/boolean-within': 7.3.4
+      '@turf/buffer': 7.3.4
+      '@turf/center': 7.3.4
+      '@turf/center-mean': 7.3.4
+      '@turf/center-median': 7.3.4
+      '@turf/center-of-mass': 7.3.4
+      '@turf/centroid': 7.3.4
+      '@turf/circle': 7.3.4
+      '@turf/clean-coords': 7.3.4
+      '@turf/clone': 7.3.4
+      '@turf/clusters': 7.3.4
+      '@turf/clusters-dbscan': 7.3.4
+      '@turf/clusters-kmeans': 7.3.4
+      '@turf/collect': 7.3.4
+      '@turf/combine': 7.3.4
+      '@turf/concave': 7.3.4
+      '@turf/convex': 7.3.4
+      '@turf/destination': 7.3.4
+      '@turf/difference': 7.3.4
+      '@turf/dissolve': 7.3.4
+      '@turf/distance': 7.3.4
+      '@turf/distance-weight': 7.3.4
+      '@turf/ellipse': 7.3.4
+      '@turf/envelope': 7.3.4
+      '@turf/explode': 7.3.4
+      '@turf/flatten': 7.3.4
+      '@turf/flip': 7.3.4
+      '@turf/geojson-rbush': 7.3.4
+      '@turf/great-circle': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/hex-grid': 7.3.4
+      '@turf/interpolate': 7.3.4
+      '@turf/intersect': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/isobands': 7.3.4
+      '@turf/isolines': 7.3.4
+      '@turf/kinks': 7.3.4
+      '@turf/length': 7.3.4
+      '@turf/line-arc': 7.3.4
+      '@turf/line-chunk': 7.3.4
+      '@turf/line-intersect': 7.3.4
+      '@turf/line-offset': 7.3.4
+      '@turf/line-overlap': 7.3.4
+      '@turf/line-segment': 7.3.4
+      '@turf/line-slice': 7.3.4
+      '@turf/line-slice-along': 7.3.4
+      '@turf/line-split': 7.3.4
+      '@turf/line-to-polygon': 7.3.4
+      '@turf/mask': 7.3.4
+      '@turf/meta': 7.3.4
+      '@turf/midpoint': 7.3.4
+      '@turf/moran-index': 7.3.4
+      '@turf/nearest-neighbor-analysis': 7.3.4
+      '@turf/nearest-point': 7.3.4
+      '@turf/nearest-point-on-line': 7.3.4
+      '@turf/nearest-point-to-line': 7.3.4
+      '@turf/planepoint': 7.3.4
+      '@turf/point-grid': 7.3.4
+      '@turf/point-on-feature': 7.3.4
+      '@turf/point-to-line-distance': 7.3.4
+      '@turf/point-to-polygon-distance': 7.3.4
+      '@turf/points-within-polygon': 7.3.4
+      '@turf/polygon-smooth': 7.3.4
+      '@turf/polygon-tangents': 7.3.4
+      '@turf/polygon-to-line': 7.3.4
+      '@turf/polygonize': 7.3.4
+      '@turf/projection': 7.3.4
+      '@turf/quadrat-analysis': 7.3.4
+      '@turf/random': 7.3.4
+      '@turf/rectangle-grid': 7.3.4
+      '@turf/rewind': 7.3.4
+      '@turf/rhumb-bearing': 7.3.4
+      '@turf/rhumb-destination': 7.3.4
+      '@turf/rhumb-distance': 7.3.4
+      '@turf/sample': 7.3.4
+      '@turf/sector': 7.3.4
+      '@turf/shortest-path': 7.3.4
+      '@turf/simplify': 7.3.4
+      '@turf/square': 7.3.4
+      '@turf/square-grid': 7.3.4
+      '@turf/standard-deviational-ellipse': 7.3.4
+      '@turf/tag': 7.3.4
+      '@turf/tesselate': 7.3.4
+      '@turf/tin': 7.3.4
+      '@turf/transform-rotate': 7.3.4
+      '@turf/transform-scale': 7.3.4
+      '@turf/transform-translate': 7.3.4
+      '@turf/triangle-grid': 7.3.4
+      '@turf/truncate': 7.3.4
+      '@turf/union': 7.3.4
+      '@turf/unkink-polygon': 7.3.4
+      '@turf/voronoi': 7.3.4
+      '@types/geojson': 7946.0.16
+      '@types/kdbush': 3.0.5
+      tslib: 2.8.1
+
+  '@turf/union@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      polyclip-ts: 0.16.8
+      tslib: 2.8.1
+
+  '@turf/unkink-polygon@7.3.4':
+    dependencies:
+      '@turf/area': 7.3.4
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      rbush: 3.0.1
+      tslib: 2.8.1
+
+  '@turf/voronoi@7.3.4':
+    dependencies:
+      '@turf/clone': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/d3-voronoi': 1.1.12
+      '@types/geojson': 7946.0.16
+      d3-voronoi: 1.1.2
       tslib: 2.8.1
 
   '@tybys/wasm-util@0.10.1':
@@ -16837,6 +18360,8 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/d3-voronoi@1.1.12': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
@@ -16870,6 +18395,10 @@ snapshots:
 
   '@types/geojson@7946.0.16': {}
 
+  '@types/geokdbush@1.1.5':
+    dependencies:
+      '@types/kdbush': 1.0.7
+
   '@types/hammerjs@2.0.46': {}
 
   '@types/http-cache-semantics@4.0.4': {}
@@ -16897,6 +18426,10 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
       '@types/node': 25.5.2
+
+  '@types/kdbush@1.0.7': {}
+
+  '@types/kdbush@3.0.5': {}
 
   '@types/keyv@3.1.4':
     dependencies:
@@ -17669,6 +19202,8 @@ snapshots:
   app-module-path@2.2.0: {}
 
   append-field@1.0.0: {}
+
+  arc@0.2.0: {}
 
   arch@2.2.0: {}
 
@@ -18460,6 +19995,13 @@ snapshots:
       readable-stream: 3.6.2
       typedarray: 0.0.6
 
+  concaveman@1.2.1:
+    dependencies:
+      point-in-polygon: 1.1.0
+      rbush: 3.0.1
+      robust-predicates: 2.0.4
+      tinyqueue: 2.0.3
+
   concurrently@9.2.1:
     dependencies:
       chalk: 4.1.2
@@ -18642,6 +20184,8 @@ snapshots:
 
   csv-parse@4.16.3: {}
 
+  d3-array@1.2.4: {}
+
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
@@ -18651,6 +20195,10 @@ snapshots:
   d3-ease@3.0.1: {}
 
   d3-format@3.1.2: {}
+
+  d3-geo@1.7.1:
+    dependencies:
+      d3-array: 1.2.4
 
   d3-interpolate@3.0.1:
     dependencies:
@@ -18679,6 +20227,8 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-voronoi@1.1.2: {}
 
   data-uri-to-buffer@6.0.2: {}
 
@@ -18944,6 +20494,8 @@ snapshots:
   dynamic-dedupe@0.3.0:
     dependencies:
       xtend: 4.0.2
+
+  earcut@2.2.4: {}
 
   earcut@3.0.2: {}
 
@@ -19585,7 +21137,19 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  geojson-equality-ts@1.0.2:
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  geojson-polygon-self-intersections@1.2.2:
+    dependencies:
+      rbush: 2.0.2
+
   geojson-vt@4.0.2: {}
+
+  geokdbush@2.1.0:
+    dependencies:
+      tinyqueue: 3.0.0
 
   get-amd-module-type@6.0.1:
     dependencies:
@@ -20611,6 +22175,8 @@ snapshots:
       semver: 7.7.4
 
   jsqr@1.4.0: {}
+
+  jsts@2.7.1: {}
 
   jwa@2.0.1:
     dependencies:
@@ -21723,10 +23289,21 @@ snapshots:
 
   png-js@1.0.0: {}
 
+  point-in-polygon-hao@1.2.4:
+    dependencies:
+      robust-predicates: 3.0.3
+
+  point-in-polygon@1.1.0: {}
+
   polka@0.5.2:
     dependencies:
       '@polka/url': 0.5.0
       trouter: 2.0.1
+
+  polyclip-ts@0.16.8:
+    dependencies:
+      bignumber.js: 9.3.1
+      splaytree-ts: 1.0.2
 
   postcss-values-parser@6.0.2(postcss@8.5.8):
     dependencies:
@@ -21925,6 +23502,10 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  quickselect@1.1.1: {}
+
+  quickselect@2.0.0: {}
+
   quickselect@3.0.0: {}
 
   quote-unquote@1.0.0: {}
@@ -21940,6 +23521,14 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       unpipe: 1.0.0
+
+  rbush@2.0.2:
+    dependencies:
+      quickselect: 1.1.1
+
+  rbush@3.0.1:
+    dependencies:
+      quickselect: 2.0.0
 
   rc9@2.1.2:
     dependencies:
@@ -22227,6 +23816,8 @@ snapshots:
 
   robust-predicates@2.0.4: {}
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
     dependencies:
       '@oxc-project/types': 0.122.0
@@ -22510,6 +24101,8 @@ snapshots:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
 
+  skmeans@0.9.7: {}
+
   slash@3.0.0: {}
 
   slice-ansi@7.1.2:
@@ -22637,6 +24230,8 @@ snapshots:
       spdx-license-ids: 3.0.21
 
   spdx-license-ids@3.0.21: {}
+
+  splaytree-ts@1.0.2: {}
 
   splaytree@0.1.4: {}
 
@@ -22841,6 +24436,10 @@ snapshots:
     dependencies:
       '@scarf/scarf': 1.4.0
 
+  sweepline-intersections@1.5.0:
+    dependencies:
+      tinyqueue: 2.0.3
+
   symbol-observable@4.0.0: {}
 
   symbol-tree@3.2.4: {}
@@ -22944,6 +24543,8 @@ snapshots:
 
   tinypool@2.1.0: {}
 
+  tinyqueue@2.0.3: {}
+
   tinyqueue@3.0.0: {}
 
   tinyrainbow@3.1.0: {}
@@ -22973,6 +24574,14 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  topojson-client@3.1.0:
+    dependencies:
+      commander: 2.20.3
+
+  topojson-server@3.0.1:
+    dependencies:
+      commander: 2.20.3
 
   totalist@3.0.1: {}
 


### PR DESCRIPTION
## Summary

- Neue Zeichenwerkzeuge für die Lagekarte: Kreis, Rechteck, Ausbreitungskegel (Sektor) und GAMS-Gefahrenzonen
- Node-Snapping mit visuellem Indikator an Vertices/Kanten existierender Features
- Turf.js-Integration für Geo-Berechnungen (Fläche, Länge, Kreise, Sektoren)

## Changes

### Frontend — Neue Custom MapboxDraw-Modi
- `circle.mode.ts` — Kreis per Klick+Drag (Mittelpunkt + Radius), 64-Punkt-Polygon via `turf.circle()`
- `rectangle.mode.ts` — Rechteck per Klick+Drag (Ecke zu Ecke)
- `sector.mode.ts` — Ausbreitungskegel per Klick+Drag (Richtung = Windrichtung, 60° Default)
- `gams.mode.ts` — GAMS-Gefahrenzonen: Klick+Drag für nacheinander 4 Zonen aufziehen, oder Klick für Popup mit Zahleneingabe
- `direct-select.mode.ts` — Custom DirectSelect: Nur ein Resize-Knob für Kreise/Sektoren (statt 64 Vertices), GAMS-Radius beschränkt zwischen Nachbar-Zonen

### Frontend — Node-Snapping
- `snap-calculations.ts` — Vertex- und Edge-Snapping via `map.project()` + `turf.nearestPointOnLine()`
- `use-snap-control.ts` — Mousemove-Handler mit visuellem Snap-Indikator (MapLibre Circle-Layer)
- `snap-indicator-styles.ts` — Layer-Definition für den Snap-Punkt
- Toggle per `S`-Taste oder Magnet-Button in der ShortcutBar

### Frontend — Geo-Berechnungen
- `geo-calculations.ts` — `erstelleKreis`, `erstelleRechteck`, `erstelleSektor`, `berechneAbstand`, `berechneBearing`, `berechneZielpunkt`
- `use-feature-measurement.ts` — Live-Messung für neue Modi erweitert

### Frontend — UI
- `DrawToolbar` — 4 neue Buttons (Kreis, Rechteck, Sektor, GAMS)
- `DrawShortcutBar` — Snap-Toggle + Modi-Hints für neue Werkzeuge
- `GamsZonenPanel.molecule.tsx` — Popup für GAMS-Radien-Eingabe
- `DrawStoreState` — `snapEnabled` State + Toggle-Action

## Test plan

- [ ] Kreis zeichnen: Klick+Drag auf Karte, Vorschau beim Ziehen, Fläche in ShortcutBar
- [ ] Rechteck zeichnen: Klick+Drag, korrekte Proportionen
- [ ] Ausbreitungskegel: Klick+Drag, Richtung folgt Mausposition, 60° Öffnungswinkel
- [ ] GAMS-Zonen aufziehen: 4 Zonen nacheinander (Rot→Orange→Gelb→Grün)
- [ ] GAMS-Zonen per Popup: Klick ohne Drag → Zahleneingabe → Platzieren
- [ ] GAMS Resize: Doppelklick → nur 1 Knob, Radius zwischen Nachbarzonen beschränkt
- [ ] Sektor/Kreis Resize: Doppelklick → nur 1 Resize-Knob statt 64 Vertices
- [ ] Snap-Indikator: Magnet-Icon + S-Taste zum Umschalten
- [ ] Undo/Redo: Für alle neuen Modi korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #643 