### PR TITLE
✨(frontend): Lagekarte Platzausnutzung + Zeichen-Details #666

### DIFF
--- a/docs/superpowers/plans/2026-04-13-zeichen-detail-panel.md
+++ b/docs/superpowers/plans/2026-04-13-zeichen-detail-panel.md
@@ -1,0 +1,502 @@
+# Zeichen-Detail-Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Zeichen auf der Lagekarte erhalten ein klickbares Detail-Panel mit Vorschau, editierbarem Label/Notiz, Komposition, Position, Metadaten und Lösch-Aktion.
+
+**Architecture:** Eigenes `Dialog.SlideIn`-Panel (kein Detail-Provider), gesteuert über `selectedZeichenId` im `drawStore`. Klick auf Zeichen → Store-Update → Panel öffnet sich. Label/Notiz inline editierbar mit Debounce-Auto-Save via `useUpdateZeichen`.
+
+**Tech Stack:** React, @tanstack/react-store, @tanstack/react-query, Dialog.SlideIn (Headless UI), react-icons/pi (Phosphor Icons), taktische-zeichen-core (SVG-Rendering)
+
+---
+
+### Task 1: Draw-Store erweitern — `selectedZeichenId` State + Actions
+
+**Files:**
+- Modify: `packages/frontend/src/features/lagekarte/stores/draw.store.ts`
+
+- [ ] **Step 1: State-Feld hinzufügen**
+
+In `DrawStoreState` Interface und `initialState` ergänzen:
+
+```typescript
+// In DrawStoreState Interface (nach pendingZeichenPlacement):
+/** ID des aktuell im Detail-Panel angezeigten Zeichens (null = Panel geschlossen) */
+selectedZeichenId: string | null;
+```
+
+```typescript
+// In initialState (nach pendingZeichenPlacement: null):
+selectedZeichenId: null,
+```
+
+- [ ] **Step 2: Actions hinzufügen**
+
+Zwei neue exportierte Funktionen am Ende der Actions-Sektion (vor `resetDrawStore`):
+
+```typescript
+/**
+ * Öffnet das Zeichen-Detail-Panel für ein bestimmtes Zeichen.
+ * Schließt dabei die Zeichen-Sidebar und bricht wartende Platzierungen ab.
+ */
+export const openZeichenDetail = (zeichenId: string) => {
+  drawStore.setState((state) => ({
+    ...state,
+    selectedZeichenId: zeichenId,
+    isZeichenSidebarVisible: false,
+    pendingZeichenPlacement: null,
+  }));
+};
+
+/**
+ * Schließt das Zeichen-Detail-Panel
+ */
+export const closeZeichenDetail = () => {
+  drawStore.setState((state) => ({
+    ...state,
+    selectedZeichenId: null,
+  }));
+};
+```
+
+- [ ] **Step 3: resetDrawStore anpassen**
+
+`resetDrawStore` setzt bereits `initialState` zurück — da `selectedZeichenId: null` im `initialState` steht, ist kein zusätzlicher Code nötig. Verifizieren, dass `initialState` das neue Feld enthält.
+
+- [ ] **Step 4: TypeScript-Check**
+
+Run: `pnpm --filter @bluelight-hub/frontend exec tsc --noEmit --pretty 2>&1 | tail -5`
+Expected: Keine Fehler (leere Ausgabe)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/stores/draw.store.ts
+git commit -m "✨(frontend): Draw-Store um selectedZeichenId State + Actions erweitern"
+```
+
+---
+
+### Task 2: ZeichenDetailContent — Die 6 Sektionen als Presentational Component
+
+**Files:**
+- Create: `packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailContent.tsx`
+
+- [ ] **Step 1: Datei erstellen mit allen 6 Sektionen**
+
+```typescript
+/**
+ * ZeichenDetailContent - Inhalt des Zeichen-Detail-Panels
+ *
+ * 6 Sektionen: Vorschau, Label/Notiz (editierbar), Komposition, Position, Metadaten, Aktionen.
+ * Visueller Stil konsistent mit DwdPanelContent / NinaPanelContent.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { PiClock, PiMapPin, PiNotePencil, PiPuzzlePiece, PiTrash } from 'react-icons/pi';
+import type { TaktischesZeichenResponseDto } from '@bluelight-hub/shared/client';
+import { ZeichenPreview } from '@/features/taktische-zeichen';
+import type { ZeichenDefinition } from '@/features/taktische-zeichen';
+import { Button } from '@/shared/ui/atoms/button.atom';
+
+/** Labels für die Kompositions-Felder */
+const KOMPOSITION_LABELS: { key: keyof TaktischesZeichenResponseDto['zeichenDefinition']; label: string }[] = [
+  { key: 'grundzeichen', label: 'Grundzeichen' },
+  { key: 'organisation', label: 'Organisation' },
+  { key: 'fachaufgabe', label: 'Fachaufgabe' },
+  { key: 'einheit', label: 'Einheit' },
+  { key: 'verwaltungsstufe', label: 'Verwaltungsstufe' },
+];
+
+function formatDateTime(iso: string): string {
+  return new Intl.DateTimeFormat('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(iso));
+}
+
+interface ZeichenDetailContentProps {
+  zeichen: TaktischesZeichenResponseDto;
+  onUpdateLabel: (label: string) => void;
+  onUpdateNotiz: (notiz: string) => void;
+  onRemove: () => void;
+  isRemoving: boolean;
+}
+
+export function ZeichenDetailContent({ zeichen, onUpdateLabel, onUpdateNotiz, onRemove, isRemoving }: ZeichenDetailContentProps) {
+  // Lokaler State für sofortige Input-Reaktion + Debounce
+  const [label, setLabel] = useState(zeichen.label ?? '');
+  const [notiz, setNotiz] = useState(zeichen.notiz ?? '');
+
+  // Sync wenn sich das Zeichen extern ändert (z.B. nach Mutation-Response)
+  useEffect(() => {
+    setLabel(zeichen.label ?? '');
+  }, [zeichen.label]);
+
+  useEffect(() => {
+    setNotiz(zeichen.notiz ?? '');
+  }, [zeichen.notiz]);
+
+  // Debounced Save für Label
+  useEffect(() => {
+    if (label === (zeichen.label ?? '')) return;
+    const timer = setTimeout(() => onUpdateLabel(label), 500);
+    return () => clearTimeout(timer);
+  }, [label, zeichen.label, onUpdateLabel]);
+
+  // Debounced Save für Notiz
+  useEffect(() => {
+    if (notiz === (zeichen.notiz ?? '')) return;
+    const timer = setTimeout(() => onUpdateNotiz(notiz), 500);
+    return () => clearTimeout(timer);
+  }, [notiz, zeichen.notiz, onUpdateNotiz]);
+
+  const definition: ZeichenDefinition = zeichen.zeichenDefinition;
+
+  return (
+    <div className="space-y-0">
+      {/* 1. Zeichen-Vorschau */}
+      <div className="flex flex-col items-center pb-4">
+        <ZeichenPreview definition={definition} size="lg" />
+        <h3 className="mt-2 text-base font-semibold text-text-primary">{zeichen.label || definition.grundzeichen}</h3>
+        <p className="mt-0.5 text-xs text-text-muted">
+          {[definition.grundzeichen, definition.organisation, definition.fachaufgabe].filter(Boolean).join(' · ')}
+        </p>
+      </div>
+
+      {/* 2. Label & Notiz (editierbar) */}
+      <section className="space-y-3.5 border-t border-border-subtle pt-3">
+        <div>
+          <div className="flex items-center gap-1.5">
+            <PiNotePencil className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+            <h4 className="text-[10px] font-semibold tracking-wider text-text-muted uppercase">Label & Notiz</h4>
+          </div>
+          <div className="mt-2 space-y-2">
+            <div>
+              <label htmlFor="zeichen-label" className="text-xs text-text-muted">Label</label>
+              <input
+                id="zeichen-label"
+                type="text"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="Bezeichnung eingeben..."
+                className="mt-0.5 w-full rounded-md border border-border-subtle bg-surface-raised px-2.5 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:border-action-primary focus:outline-none focus:ring-1 focus:ring-action-primary"
+              />
+            </div>
+            <div>
+              <label htmlFor="zeichen-notiz" className="text-xs text-text-muted">Notiz</label>
+              <textarea
+                id="zeichen-notiz"
+                value={notiz}
+                onChange={(e) => setNotiz(e.target.value)}
+                placeholder="Notiz hinzufügen..."
+                rows={3}
+                className="mt-0.5 w-full resize-y rounded-md border border-border-subtle bg-surface-raised px-2.5 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:border-action-primary focus:outline-none focus:ring-1 focus:ring-action-primary"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 3. Zeichen-Komposition */}
+      <section className="space-y-3.5 border-t border-border-subtle pt-3">
+        <div>
+          <div className="flex items-center gap-1.5">
+            <PiPuzzlePiece className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+            <h4 className="text-[10px] font-semibold tracking-wider text-text-muted uppercase">Zeichen-Komposition</h4>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {KOMPOSITION_LABELS.map(({ key, label: fieldLabel }) => {
+              const value = definition[key];
+              if (!value) return null;
+              return (
+                <span
+                  key={key}
+                  className="inline-flex items-center rounded-full border border-border-subtle bg-surface-raised px-2.5 py-0.5 text-body-xs text-text-secondary"
+                >
+                  <span className="mr-1 text-text-muted">{fieldLabel}:</span>
+                  {value}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* 4. Position */}
+      {zeichen.istPlatziert && zeichen.lat != null && zeichen.lng != null && (
+        <section className="space-y-3.5 border-t border-border-subtle pt-3">
+          <div>
+            <div className="flex items-center gap-1.5">
+              <PiMapPin className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+              <h4 className="text-[10px] font-semibold tracking-wider text-text-muted uppercase">Position</h4>
+            </div>
+            <div className="mt-1 grid grid-cols-2 gap-2 text-sm text-text-primary">
+              <div>
+                <span className="text-xs text-text-muted">Lat: </span>
+                {zeichen.lat.toFixed(5)}°
+              </div>
+              <div>
+                <span className="text-xs text-text-muted">Lng: </span>
+                {zeichen.lng.toFixed(5)}°
+              </div>
+            </div>
+            {zeichen.mgrs && (
+              <div className="mt-1 text-sm text-text-primary">
+                <span className="text-xs text-text-muted">MGRS: </span>
+                <span className="font-mono">{zeichen.mgrs}</span>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* 5. Metadaten */}
+      <section className="space-y-3.5 border-t border-border-subtle pt-3">
+        <div>
+          <div className="flex items-center gap-1.5">
+            <PiClock className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+            <h4 className="text-[10px] font-semibold tracking-wider text-text-muted uppercase">Metadaten</h4>
+          </div>
+          <div className="mt-1 text-xs leading-relaxed text-text-muted">
+            <p>Erstellt von <span className="text-text-secondary">{zeichen.createdBy}</span> · {formatDateTime(zeichen.createdAt)}</p>
+            {zeichen.updatedBy && <p>Geändert von <span className="text-text-secondary">{zeichen.updatedBy}</span> · {formatDateTime(zeichen.updatedAt)}</p>}
+          </div>
+        </div>
+      </section>
+
+      {/* 6. Aktionen */}
+      <section className="border-t border-border-subtle pt-3">
+        <Button
+          intent="danger"
+          size="sm"
+          className="w-full"
+          onClick={onRemove}
+          loading={isRemoving}
+          disabled={isRemoving}
+        >
+          <PiTrash className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          Von Karte entfernen
+        </Button>
+      </section>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: TypeScript-Check**
+
+Run: `pnpm --filter @bluelight-hub/frontend exec tsc --noEmit --pretty 2>&1 | tail -10`
+Expected: Keine Fehler
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailContent.tsx
+git commit -m "✨(frontend): ZeichenDetailContent mit 6 Sektionen (Vorschau, Label/Notiz, Komposition, Position, Metadaten, Aktionen)"
+```
+
+---
+
+### Task 3: ZeichenDetailPanel — Wrapper mit Dialog.SlideIn + Mutations
+
+**Files:**
+- Create: `packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailPanel.molecule.tsx`
+
+- [ ] **Step 1: Panel-Komponente erstellen**
+
+```typescript
+/**
+ * ZeichenDetailPanel - Slide-In Panel für taktische Zeichen
+ *
+ * Wrapper um ZeichenDetailContent: Lädt Zeichen aus dem Query-Cache,
+ * stellt Mutations (Update, Remove) bereit, steuert Dialog.SlideIn.
+ */
+
+import { useCallback } from 'react';
+import type { TaktischesZeichenResponseDto } from '@bluelight-hub/shared/client';
+import { useUpdateZeichen, useRemoveZeichen } from '@/features/taktische-zeichen';
+import { Dialog } from '@/shared/ui/molecules/dialog.molecule';
+import { ZeichenDetailContent } from './ZeichenDetailContent';
+
+interface ZeichenDetailPanelProps {
+  /** Das anzuzeigende Zeichen (null = Panel geschlossen) */
+  zeichen: TaktischesZeichenResponseDto | undefined;
+  /** Einsatz-ID für Mutations */
+  einsatzId: string;
+  /** Ist das Panel geöffnet? */
+  isOpen: boolean;
+  /** Callback zum Schließen */
+  onClose: () => void;
+}
+
+export function ZeichenDetailPanel({ zeichen, einsatzId, isOpen, onClose }: ZeichenDetailPanelProps) {
+  const { mutate: updateZeichen } = useUpdateZeichen(einsatzId);
+  const { mutate: removeZeichen, isPending: isRemoving } = useRemoveZeichen(einsatzId);
+
+  const handleUpdateLabel = useCallback(
+    (label: string) => {
+      if (!zeichen) return;
+      updateZeichen({ zeichenId: zeichen.id, dto: { label: label || undefined } });
+    },
+    [zeichen, updateZeichen],
+  );
+
+  const handleUpdateNotiz = useCallback(
+    (notiz: string) => {
+      if (!zeichen) return;
+      updateZeichen({ zeichenId: zeichen.id, dto: { notiz: notiz || undefined } });
+    },
+    [zeichen, updateZeichen],
+  );
+
+  const handleRemove = useCallback(() => {
+    if (!zeichen) return;
+    removeZeichen(zeichen.id, { onSuccess: onClose });
+  }, [zeichen, removeZeichen, onClose]);
+
+  if (!zeichen) return null;
+
+  const title = zeichen.label || zeichen.zeichenDefinition.grundzeichen;
+
+  return (
+    <Dialog.SlideIn isOpen={isOpen} onClose={onClose} title={title} size="md">
+      <ZeichenDetailContent
+        zeichen={zeichen}
+        onUpdateLabel={handleUpdateLabel}
+        onUpdateNotiz={handleUpdateNotiz}
+        onRemove={handleRemove}
+        isRemoving={isRemoving}
+      />
+    </Dialog.SlideIn>
+  );
+}
+```
+
+- [ ] **Step 2: TypeScript-Check**
+
+Run: `pnpm --filter @bluelight-hub/frontend exec tsc --noEmit --pretty 2>&1 | tail -10`
+Expected: Keine Fehler
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailPanel.molecule.tsx
+git commit -m "✨(frontend): ZeichenDetailPanel Wrapper mit Dialog.SlideIn und Mutations"
+```
+
+---
+
+### Task 4: LagekarteView — Panel einbinden + onZeichenClick verdrahten
+
+**Files:**
+- Modify: `packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx`
+
+- [ ] **Step 1: Imports hinzufügen**
+
+Ergänze in den bestehenden Import-Blöcken:
+
+```typescript
+// Beim drawStore Import (Zeile 15) die neuen Actions hinzufügen:
+import { drawStore, toggleSnapEnabled, toggleSymbolPanel, toggleTemplatePanel, clearPendingZeichenPlacement, openZeichenDetail, closeZeichenDetail } from '@/features/lagekarte/stores/draw.store';
+
+// Neuer Import für das Panel (nach den anderen Molecule-Imports):
+import { ZeichenDetailPanel } from '../../molecules/ZeichenDetailPanel.molecule';
+```
+
+- [ ] **Step 2: Store-Selektor für selectedZeichenId hinzufügen**
+
+Nach dem bestehenden `pendingZeichenPlacement` Selektor (Zeile 99) hinzufügen:
+
+```typescript
+const selectedZeichenId = useStore(drawStore, (s) => s.selectedZeichenId);
+```
+
+- [ ] **Step 3: Zeichen-Lookup aus dem Cache ableiten**
+
+Nach `const isMapLoaded = !isLoading;` (Zeile 102) hinzufügen:
+
+```typescript
+// Zeichen für Detail-Panel aus Cache ableiten
+const selectedZeichen = selectedZeichenId ? einsatzZeichen.find((z) => z.id === selectedZeichenId) : undefined;
+```
+
+- [ ] **Step 4: onZeichenClick Handler für TaktischeZeichenLayer setzen**
+
+Die `<TaktischeZeichenLayer>` Komponente (Zeile 476) erhält das neue Prop:
+
+```tsx
+<TaktischeZeichenLayer
+  mapRef={mapRef}
+  isMapLoaded={isMapLoaded}
+  zeichen={einsatzZeichen}
+  onZeichenClick={(z) => openZeichenDetail(z.id)}
+/>
+```
+
+- [ ] **Step 5: ZeichenDetailPanel im JSX einbinden**
+
+Nach dem bestehenden `<MapDetailPanel ... />` (Zeile 542) einfügen:
+
+```tsx
+{/* Zeichen-Detail-Panel (Slide-In von rechts) */}
+<ZeichenDetailPanel
+  zeichen={selectedZeichen}
+  einsatzId={einsatzId}
+  isOpen={selectedZeichenId !== null}
+  onClose={closeZeichenDetail}
+/>
+```
+
+- [ ] **Step 6: TypeScript-Check**
+
+Run: `pnpm --filter @bluelight-hub/frontend exec tsc --noEmit --pretty 2>&1 | tail -10`
+Expected: Keine Fehler
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+git commit -m "✨(frontend): ZeichenDetailPanel in LagekarteView einbinden + onZeichenClick verdrahten"
+```
+
+---
+
+### Task 5: Manueller Browser-Test
+
+- [ ] **Step 1: Dev-Server starten (falls nicht bereits laufend)**
+
+Run: `pnpm -r dev`
+
+- [ ] **Step 2: Funktionstest im Browser**
+
+Öffne `localhost:3090`, navigiere zu einem Einsatz → Lagekarte. Teste:
+
+1. **Zeichen erstellen:** Über Karten-Zeichen-Sidebar ein Zeichen aus dem Katalog erstellen und auf der Karte platzieren
+2. **Klick auf Zeichen:** Klick auf das platzierte Zeichen → Detail-Panel öffnet sich als Slide-In von rechts
+3. **Vorschau:** SVG-Vorschau des Zeichens wird korrekt angezeigt
+4. **Label bearbeiten:** Label-Feld ändern → nach ~500ms Auto-Save (Query-Cache invalidiert, Karten-Label aktualisiert)
+5. **Notiz bearbeiten:** Notiz-Feld ändern → Auto-Save funktioniert
+6. **Komposition:** Pill-Badges zeigen nur gesetzte Felder (Grundzeichen, Organisation etc.)
+7. **Position:** Lat/Lng + MGRS werden korrekt angezeigt
+8. **Metadaten:** Ersteller + Zeitstempel sichtbar
+9. **Von Karte entfernen:** Danger-Button klicken → Zeichen wird gelöscht, Panel schließt sich
+10. **Panel schließen:** ESC oder Backdrop-Klick schließt das Panel
+11. **Zeichen-Sidebar-Interaktion:** Panel schließt die Zeichen-Sidebar beim Öffnen (und umgekehrt funktioniert die Sidebar noch)
+
+- [ ] **Step 3: Edge Cases prüfen**
+
+- Zeichen ohne Label (nur Grundzeichen als Titel)
+- Zeichen ohne Notiz (Placeholder-Text sichtbar)
+- Zeichen ohne MGRS (Position-Sektion zeigt nur Lat/Lng)
+- Schnelles Tippen im Label-Feld (Debounce verhindert Spam-Requests)
+
+- [ ] **Step 4: Abschluss-Commit (falls Korrekturen nötig waren)**
+
+```bash
+git add -u
+git commit -m "🐛(frontend): Zeichen-Detail-Panel Korrekturen aus manuellem Test"
+```

--- a/docs/superpowers/specs/2026-04-13-zeichen-detail-panel-design.md
+++ b/docs/superpowers/specs/2026-04-13-zeichen-detail-panel-design.md
@@ -1,0 +1,113 @@
+# Zeichen-Detail-Panel — Design Spec
+
+## Kontext
+
+Die Lagekarte zeigt taktische Zeichen als Symbol-Layer auf der Karte. Beim Klick auf Layer-Elemente (DWD-Warnungen, NINA-Meldungen) öffnet sich ein Detail-Panel via Provider-System. Taktische Zeichen haben bisher kein vergleichbares Detail-Panel. Dieses Feature ergänzt ein Detail-Panel für Zeichen — inline editierbar (Label, Notiz), visuell konsistent mit den bestehenden Layer-Detail-Panels.
+
+## Integrationsansatz
+
+**Eigenes Panel, kein Detail-Provider.** Das bestehende Provider-System (`LayerDetailProvider`) ist für read-only, koordinaten-basierte Abfragen konzipiert. Zeichen unterscheiden sich:
+
+- Das konkrete Zeichen ist durch `onZeichenClick` bereits bekannt (kein Coordinate-Query nötig)
+- Das Panel muss editierbar sein (Label, Notiz)
+- Mutations (Update, Remove) erfordern Zugriff auf den vollen Zeichen-DTO
+
+Stattdessen: `Dialog.SlideIn` direkt, gesteuert über State im `drawStore`. Visuell identisch mit den Layer-Detail-Panels (gleiche CSS-Klassen, Sektions-Struktur, Icon-Patterns).
+
+## Neue Dateien
+
+| Datei | Zweck |
+|-------|-------|
+| `lagekarte/ui/molecules/ZeichenDetailPanel.molecule.tsx` | Wrapper: `Dialog.SlideIn` + Datenladung |
+| `lagekarte/ui/molecules/ZeichenDetailContent.tsx` | Die 6 Sektionen (Vorschau, Label/Notiz, Komposition, Position, Metadaten, Aktionen) |
+
+## Geänderte Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `lagekarte/stores/draw.store.ts` | Neues Feld `selectedZeichenId: string \| null`, Actions `openZeichenDetail(id)` / `closeZeichenDetail()` |
+| `lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx` | `<ZeichenDetailPanel>` einbinden, `onZeichenClick` an `openZeichenDetail` verdrahten |
+
+## Datenfluss
+
+```
+Klick auf Zeichen (Karte)
+  → TaktischeZeichenLayer.onZeichenClick(zeichen)
+  → drawStore.openZeichenDetail(zeichen.id)
+  → LagekarteView rendert <ZeichenDetailPanel zeichenId={selectedZeichenId} />
+  → Panel findet Zeichen in useEinsatzZeichen()-Cache
+  → Anzeige der 6 Sektionen
+
+Label/Notiz bearbeiten:
+  → Input onChange → Debounce (500ms) → useUpdateZeichen() Mutation
+  → Optimistic Update im Query-Cache
+  → Invalidate useEinsatzZeichen()
+
+"Von Karte entfernen":
+  → useRemoveZeichen() Mutation (setzt istPlatziert=false, lat/lng=null)
+  → drawStore.closeZeichenDetail()
+  → Zeichen verschwindet von der Karte
+```
+
+## Panel-Sektionen
+
+### 1. Zeichen-Vorschau (read-only)
+
+- Gerendertes SVG des taktischen Zeichens (via `zeichen-image-cache` / `phjardas-adapter`)
+- Label als Titel darunter (`text-base font-semibold`)
+- Subtitle mit Kompositions-Zusammenfassung (`text-xs text-text-muted`)
+
+### 2. Label & Notiz (editierbar)
+
+- Sektions-Header: Stift-Icon + "LABEL & NOTIZ" (wie DWD/NINA-Sektions-Pattern)
+- Label: Text-Input mit bestehendem Wert, Debounce-Auto-Save
+- Notiz: Textarea, gleicher Auto-Save-Mechanismus
+- Kein expliziter Save-Button — Änderungen speichern automatisch nach 500ms Inaktivität
+
+### 3. Zeichen-Komposition (read-only)
+
+- Sektions-Header: Puzzle-Icon + "ZEICHEN-KOMPOSITION"
+- Pill-Badges für jedes gesetzte Feld: Grundzeichen, Organisation, Fachaufgabe, Einheit, Verwaltungsstufe
+- Nur gesetzte Felder anzeigen (keine leeren Badges)
+- Badge-Style: `rounded-full border border-border-subtle bg-surface-raised px-2.5 py-0.5 text-body-xs`
+
+### 4. Position (read-only)
+
+- Sektions-Header: Pin-Icon + "POSITION"
+- Grid 2-Spaltig: Lat / Lng
+- Darunter: MGRS (falls vorhanden), monospace Font
+
+### 5. Metadaten (read-only)
+
+- Sektions-Header: Uhr-Icon + "METADATEN"
+- Kompakte Darstellung: "Erstellt von {name} · {datum}" / "Geändert · {datum}"
+- `text-xs text-text-muted`
+
+### 6. Aktionen
+
+- "Von Karte entfernen" — Danger-Button (`intent="danger"`)
+- Entfernt das Zeichen von der Karte (setzt `istPlatziert=false`), löscht es aber nicht
+- Schließt das Panel nach Ausführung
+
+## State-Erweiterung (draw.store.ts)
+
+```typescript
+// Neues Feld im State
+selectedZeichenId: string | null;
+
+// Neue Actions
+openZeichenDetail(zeichenId: string): void;
+closeZeichenDetail(): void;
+```
+
+`openZeichenDetail` setzt `selectedZeichenId` und schließt ggf. andere offene Panels (KartenZeichenSidebar). `closeZeichenDetail` setzt `selectedZeichenId` zurück auf `null`.
+
+## Visueller Stil
+
+Konsistent mit DWD/NINA-Panel-Content:
+
+- Sektions-Header: `text-[10px] font-semibold tracking-wider text-text-muted uppercase` mit Icon `h-3.5 w-3.5 text-text-muted`
+- Sektions-Trenner: `border-t border-border-subtle pt-3`
+- Container: `space-y-3.5`
+- Icons: Phosphor Icons (`react-icons/pi`)
+- Panel-Container: `Dialog.SlideIn` mit `size="md"`

--- a/packages/frontend/src/features/lagekarte/hooks/use-zeichen-drag.ts
+++ b/packages/frontend/src/features/lagekarte/hooks/use-zeichen-drag.ts
@@ -1,171 +1,304 @@
 /**
- * Hook für Drag & Drop von taktischen Zeichen auf der Lagekarte.
+ * Hook für Auswahl & Drag von taktischen Zeichen auf der Lagekarte.
  *
- * Ermöglicht das Verschieben platzierter Zeichen durch:
- * 1. mousedown auf einen Zeichen-Symbol → Drag-Start
- * 2. mousemove → optimistische Positions-Aktualisierung in der GeoJSON-Source
- * 3. mouseup → API-Call via usePlaceZeichen zur persistenten Speicherung
+ * Zweistufiges Verschieben:
+ * 1. Klick auf Symbol → Auswahl (visuelles Highlight)
+ * 2. Drag auf ausgewähltes Symbol → Ghost folgt dem Cursor, Original bleibt gedimmt
  *
- * Während des Drags wird die Karte nicht bewegt (dragPan deaktiviert).
+ * Klick auf leere Karte oder anderes Symbol → Auswahl wechseln/aufheben.
  */
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
 import type { TaktischesZeichenResponseDto } from '@bluelight-hub/shared/client';
 import { TAKTISCHE_ZEICHEN_LAYER_ID, TAKTISCHE_ZEICHEN_SOURCE_ID } from '@/features/lagekarte/ui/molecules/TaktischeZeichenLayer.molecule';
 import type { ZeichenFeatureProperties } from './use-zeichen-layer';
 import { usePlaceZeichen } from '@/features/taktische-zeichen';
 
+const DRAG_THRESHOLD_PX = 5;
+
+const DRAG_GHOST_SOURCE = 'drag-ghost-source';
+const DRAG_GHOST_LAYER = 'drag-ghost-layer';
+
 interface UseZeichenDragOptions {
-  /** Referenz auf die MapLibre-GL-Instanz */
   mapRef: React.RefObject<MapRef | null>;
-  /** Ob die Karte vollständig geladen ist */
   isMapLoaded: boolean;
-  /** Alle taktischen Zeichen des Einsatzes */
   zeichen: TaktischesZeichenResponseDto[];
-  /** Einsatz-ID für den API-Call */
   einsatzId: string;
-  /** Ob das Zeichen verschieben erlaubt ist (Berechtigungs-Guard) */
   canDrag?: boolean;
+  /** Wird aufgerufen wenn ein Zeichen selektiert/deselektiert wird */
+  onSelect?: (zeichenId: string | null) => void;
 }
 
-/**
- * Aktiviert Drag & Drop für platzierte taktische Zeichen.
- *
- * @returns isDragging — true während ein Zeichen aktiv verschoben wird
- */
-export function useZeichenDrag({ mapRef, isMapLoaded, zeichen, einsatzId, canDrag = true }: UseZeichenDragOptions): { isDragging: boolean } {
+export function useZeichenDrag({ mapRef, isMapLoaded, zeichen, einsatzId, canDrag = true, onSelect }: UseZeichenDragOptions) {
   const { mutate: placeZeichen } = usePlaceZeichen(einsatzId);
+  const [selectedZeichenId, setSelectedZeichenId] = useState<string | null>(null);
 
-  // Aktueller Drag-Zustand (kein Re-Render nötig — direkte DOM-Interaktion)
   const dragStateRef = useRef<{
     zeichenId: string;
     lagekarteId: string;
+    originLng: number;
+    originLat: number;
+    imageId: string;
   } | null>(null);
   const isDraggingRef = useRef(false);
+  const isPendingRef = useRef(false);
+  const startPointRef = useRef<{ x: number; y: number } | null>(null);
+  const selectedIdRef = useRef<string | null>(null);
 
-  // Stable ref für zeichen-Array (Lookup ohne Effect-Dependency)
+  useEffect(() => {
+    selectedIdRef.current = selectedZeichenId;
+  }, [selectedZeichenId]);
+
   const zeichenRef = useRef<TaktischesZeichenResponseDto[]>(zeichen);
   useEffect(() => {
     zeichenRef.current = zeichen;
   }, [zeichen]);
 
-  const setupDragHandlers = useCallback(() => {
+  const setFeatureState = useCallback(
+    (zeichenId: string, state: Record<string, boolean>) => {
+      const map = mapRef.current?.getMap();
+      if (!map) return;
+      try {
+        map.setFeatureState({ source: TAKTISCHE_ZEICHEN_SOURCE_ID, id: zeichenId }, state);
+      } catch {
+        // Feature evtl. noch nicht in der Source
+      }
+    },
+    [mapRef],
+  );
+
+  const onSelectRef = useRef(onSelect);
+  useEffect(() => {
+    onSelectRef.current = onSelect;
+  }, [onSelect]);
+
+  const selectZeichen = useCallback(
+    (zeichenId: string | null) => {
+      if (selectedIdRef.current && selectedIdRef.current !== zeichenId) {
+        setFeatureState(selectedIdRef.current, { selected: false });
+      }
+      if (zeichenId) {
+        setFeatureState(zeichenId, { selected: true });
+      }
+      setSelectedZeichenId(zeichenId);
+      onSelectRef.current?.(zeichenId);
+    },
+    [setFeatureState],
+  );
+
+  /** Ghost-Symbol am Cursor anzeigen (halbtransparenter Klon) */
+  const showGhost = useCallback(
+    (lng: number, lat: number, imageId: string) => {
+      const map = mapRef.current?.getMap();
+      if (!map) return;
+
+      const data: GeoJSON.FeatureCollection = {
+        type: 'FeatureCollection',
+        features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: [lng, lat] }, properties: { imageId } }],
+      };
+
+      const source = map.getSource(DRAG_GHOST_SOURCE) as maplibregl.GeoJSONSource | undefined;
+      if (source) {
+        source.setData(data);
+      } else {
+        map.addSource(DRAG_GHOST_SOURCE, { type: 'geojson', data });
+        map.addLayer({
+          id: DRAG_GHOST_LAYER,
+          source: DRAG_GHOST_SOURCE,
+          type: 'symbol',
+          layout: {
+            'icon-image': ['get', 'imageId'],
+            'icon-size': 0.5,
+            'icon-allow-overlap': true,
+            'icon-anchor': 'bottom',
+          },
+          paint: {
+            'icon-opacity': 0.5,
+          },
+        });
+      }
+    },
+    [mapRef],
+  );
+
+  /** Ghost-Position aktualisieren */
+  const updateGhost = useCallback(
+    (lng: number, lat: number, imageId: string) => {
+      const map = mapRef.current?.getMap();
+      if (!map) return;
+
+      const source = map.getSource(DRAG_GHOST_SOURCE) as maplibregl.GeoJSONSource | undefined;
+      if (source) {
+        source.setData({
+          type: 'FeatureCollection',
+          features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: [lng, lat] }, properties: { imageId } }],
+        });
+      }
+    },
+    [mapRef],
+  );
+
+  /** Ghost ausblenden */
+  const hideGhost = useCallback(() => {
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    if (map.getLayer(DRAG_GHOST_LAYER)) {
+      map.removeLayer(DRAG_GHOST_LAYER);
+    }
+    if (map.getSource(DRAG_GHOST_SOURCE)) {
+      map.removeSource(DRAG_GHOST_SOURCE);
+    }
+  }, [mapRef]);
+
+  const setupHandlers = useCallback(() => {
     const map = mapRef.current?.getMap();
     if (!map || !canDrag) return;
 
-    /** Cursor anpassen wenn Maus über einen Zeichen-Symbol fährt */
-    const handleMouseEnter = () => {
-      map.getCanvas().style.cursor = 'grab';
+    const handleMouseEnter = (e: maplibregl.MapMouseEvent) => {
+      if (isDraggingRef.current) return;
+      const features = map.queryRenderedFeatures(e.point, { layers: [TAKTISCHE_ZEICHEN_LAYER_ID] });
+      if (!features.length) return;
+      const props = features[0].properties as ZeichenFeatureProperties;
+      map.getCanvas().style.cursor = props.zeichenId === selectedIdRef.current ? 'grab' : 'pointer';
     };
+
     const handleMouseLeave = () => {
       if (!isDraggingRef.current) {
         map.getCanvas().style.cursor = '';
       }
     };
 
-    /** Drag-Start: Zeichen-Feature unter dem Cursor ermitteln */
-    const handleMouseDown = (e: maplibregl.MapMouseEvent) => {
-      if (!canDrag) return;
-      const features = map.queryRenderedFeatures(e.point, {
-        layers: [TAKTISCHE_ZEICHEN_LAYER_ID],
-      });
+    /** Mousedown: Drag nur für ausgewähltes Symbol vorbereiten */
+    const handleLayerMouseDown = (e: maplibregl.MapMouseEvent) => {
+      const features = map.queryRenderedFeatures(e.point, { layers: [TAKTISCHE_ZEICHEN_LAYER_ID] });
       if (!features.length) return;
 
       const props = features[0].properties as ZeichenFeatureProperties;
-      const foundZeichen = zeichenRef.current.find((z) => z.id === props.zeichenId);
-      if (!foundZeichen?.lagekarteId) return;
+      if (props.zeichenId !== selectedIdRef.current) return;
 
-      // Drag starten
+      const foundZeichen = zeichenRef.current.find((z) => z.id === props.zeichenId);
+      if (!foundZeichen?.lagekarteId || foundZeichen.lng == null || foundZeichen.lat == null) return;
+
       dragStateRef.current = {
         zeichenId: foundZeichen.id,
         lagekarteId: foundZeichen.lagekarteId,
+        originLng: foundZeichen.lng,
+        originLat: foundZeichen.lat,
+        imageId: props.imageId,
       };
-      isDraggingRef.current = true;
+      isPendingRef.current = true;
+      startPointRef.current = { x: e.point.x, y: e.point.y };
 
-      // Karten-Pan deaktivieren während des Drags
       map.dragPan.disable();
-      map.getCanvas().style.cursor = 'grabbing';
-
-      // Browser-Default verhindern (verhindert Text-Selektion)
       e.originalEvent.preventDefault();
     };
 
-    /** Drag-Move: GeoJSON-Source optimistisch aktualisieren */
+    /** Mousemove: Threshold prüfen, Ghost aktualisieren */
     const handleMouseMove = (e: maplibregl.MapMouseEvent) => {
-      if (!isDraggingRef.current || !dragStateRef.current) return;
+      if (!dragStateRef.current) return;
 
-      const source = map.getSource(TAKTISCHE_ZEICHEN_SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
-      if (!source) return;
+      if (isPendingRef.current && startPointRef.current) {
+        const dx = e.point.x - startPointRef.current.x;
+        const dy = e.point.y - startPointRef.current.y;
+        if (Math.sqrt(dx * dx + dy * dy) < DRAG_THRESHOLD_PX) return;
 
-      // Aktuelle GeoJSON-Daten laden und das gezogene Feature verschieben
-      // Da die Source eine FeatureCollection ist, müssen wir sie aktualisieren
-      const { lng, lat } = e.lngLat;
-      const { zeichenId } = dragStateRef.current;
+        // Drag aktivieren — Original dimmen, Ghost starten
+        isPendingRef.current = false;
+        isDraggingRef.current = true;
+        map.getCanvas().style.cursor = 'grabbing';
+        setFeatureState(dragStateRef.current.zeichenId, { selected: true, dragging: true });
+        showGhost(e.lngLat.lng, e.lngLat.lat, dragStateRef.current.imageId);
+      }
 
-      // @ts-expect-error — _data ist intern, aber stabil in MapLibre
-      const currentData = source._data as GeoJSON.FeatureCollection<GeoJSON.Point, ZeichenFeatureProperties> | undefined;
-      if (!currentData) return;
+      if (!isDraggingRef.current) return;
 
-      const updatedFeatures = currentData.features.map((feature) => {
-        if (feature.properties.zeichenId === zeichenId) {
-          return {
-            ...feature,
-            geometry: { ...feature.geometry, coordinates: [lng, lat] },
-          };
-        }
-        return feature;
-      });
-
-      source.setData({ ...currentData, features: updatedFeatures });
+      // Ghost dem Cursor folgen lassen (Original bleibt am Ursprung)
+      updateGhost(e.lngLat.lng, e.lngLat.lat, dragStateRef.current.imageId);
     };
 
-    /** Drag-End: Position via API persistieren */
+    /** Mouseup: Drag abschließen */
     const handleMouseUp = (e: maplibregl.MapMouseEvent) => {
-      if (!isDraggingRef.current || !dragStateRef.current) return;
+      const wasDragging = isDraggingRef.current;
+      const wasPending = isPendingRef.current;
+      const state = dragStateRef.current;
 
-      const { zeichenId, lagekarteId } = dragStateRef.current;
-      const { lng, lat } = e.lngLat;
+      if (wasDragging || wasPending) {
+        map.dragPan.enable();
+      }
 
-      // Drag-Zustand zurücksetzen
+      if (wasDragging && state) {
+        setFeatureState(state.zeichenId, { selected: true, dragging: false });
+        hideGhost();
+        map.getCanvas().style.cursor = 'grab';
+
+        // API-Call mit optimistischem Cache-Update (aktualisiert sofort die GeoJSON-Source via React)
+        const { lng, lat } = e.lngLat;
+        placeZeichen({
+          zeichenId: state.zeichenId,
+          dto: { lagekarteId: state.lagekarteId, lat, lng },
+        });
+      }
+
       isDraggingRef.current = false;
+      isPendingRef.current = false;
+      startPointRef.current = null;
       dragStateRef.current = null;
-      map.dragPan.enable();
-      map.getCanvas().style.cursor = '';
+    };
 
-      // Position via API persistieren
-      placeZeichen({
-        zeichenId,
-        dto: { lagekarteId, lat, lng },
-      });
+    /** Klick: Auswahl verwalten */
+    const handleMapClick = (e: maplibregl.MapMouseEvent) => {
+      if (isDraggingRef.current) return;
+
+      const features = map.queryRenderedFeatures(e.point, { layers: [TAKTISCHE_ZEICHEN_LAYER_ID] });
+
+      if (features.length > 0) {
+        const props = features[0].properties as ZeichenFeatureProperties;
+
+        if (props.zeichenId === selectedIdRef.current) {
+          selectZeichen(null);
+          map.getCanvas().style.cursor = 'pointer';
+        } else {
+          selectZeichen(props.zeichenId);
+          map.getCanvas().style.cursor = 'grab';
+        }
+      } else if (selectedIdRef.current) {
+        selectZeichen(null);
+      }
     };
 
     map.on('mouseenter', TAKTISCHE_ZEICHEN_LAYER_ID, handleMouseEnter);
     map.on('mouseleave', TAKTISCHE_ZEICHEN_LAYER_ID, handleMouseLeave);
-    map.on('mousedown', TAKTISCHE_ZEICHEN_LAYER_ID, handleMouseDown);
+    map.on('mousedown', TAKTISCHE_ZEICHEN_LAYER_ID, handleLayerMouseDown);
     map.on('mousemove', handleMouseMove);
     map.on('mouseup', handleMouseUp);
+    map.on('click', handleMapClick);
 
     return () => {
       map.off('mouseenter', TAKTISCHE_ZEICHEN_LAYER_ID, handleMouseEnter);
       map.off('mouseleave', TAKTISCHE_ZEICHEN_LAYER_ID, handleMouseLeave);
-      map.off('mousedown', TAKTISCHE_ZEICHEN_LAYER_ID, handleMouseDown);
+      map.off('mousedown', TAKTISCHE_ZEICHEN_LAYER_ID, handleLayerMouseDown);
       map.off('mousemove', handleMouseMove);
       map.off('mouseup', handleMouseUp);
+      map.off('click', handleMapClick);
 
-      // Sicherheits-Cleanup: dragPan reaktivieren falls noch deaktiviert
       if (isDraggingRef.current) {
         map.dragPan.enable();
         isDraggingRef.current = false;
+        isPendingRef.current = false;
         dragStateRef.current = null;
+        hideGhost();
       }
     };
-  }, [mapRef, canDrag, placeZeichen]);
+  }, [mapRef, canDrag, placeZeichen, selectZeichen, setFeatureState, showGhost, updateGhost, hideGhost]);
 
   useEffect(() => {
     if (!isMapLoaded) return;
-    return setupDragHandlers();
-  }, [isMapLoaded, setupDragHandlers]);
+    return setupHandlers();
+  }, [isMapLoaded, setupHandlers]);
 
-  return { isDragging: isDraggingRef.current };
+  const deselectZeichen = useCallback(() => selectZeichen(null), [selectZeichen]);
+
+  return { isDragging: isDraggingRef.current, selectedZeichenId, deselectZeichen };
 }

--- a/packages/frontend/src/features/lagekarte/stores/draw.store.ts
+++ b/packages/frontend/src/features/lagekarte/stores/draw.store.ts
@@ -7,6 +7,7 @@
 
 import { createStore } from '@tanstack/react-store';
 import type { DrawMode } from '../drawing/types';
+import type { ZeichenDefinition } from '@/features/taktische-zeichen/rendering/renderer';
 
 /** Feature-Gruppe für zusammengehörige Zeichnungsobjekte */
 export interface FeatureGroup {
@@ -49,6 +50,10 @@ export interface DrawStoreState {
   isZeichenSidebarVisible: boolean;
   /** Aktiver Tab der Zeichen-Sidebar */
   zeichenSidebarTab: ZeichenSidebarTab;
+  /** Wartet auf Platzierung: Zeichen-ID + Definition eines neu erstellten, aber noch nicht platzierten Zeichens */
+  pendingZeichenPlacement: { zeichenId: string; definition: ZeichenDefinition } | null;
+  /** ID des aktuell im Detail-Panel angezeigten Zeichens (null = Panel geschlossen) */
+  selectedZeichenId: string | null;
 }
 
 const initialState: DrawStoreState = {
@@ -63,6 +68,8 @@ const initialState: DrawStoreState = {
   isLocked: false,
   isZeichenSidebarVisible: false,
   zeichenSidebarTab: 'katalog',
+  pendingZeichenPlacement: null,
+  selectedZeichenId: null,
 };
 
 /**
@@ -207,6 +214,8 @@ export const toggleZeichenSidebar = () => {
   drawStore.setState((state) => ({
     ...state,
     isZeichenSidebarVisible: !state.isZeichenSidebarVisible,
+    // Beim Schließen: Wartende Platzierung abbrechen
+    ...(!state.isZeichenSidebarVisible ? {} : { pendingZeichenPlacement: null }),
   }));
 };
 
@@ -228,6 +237,49 @@ export const setZeichenSidebarTab = (tab: ZeichenSidebarTab) => {
   drawStore.setState((state) => ({
     ...state,
     zeichenSidebarTab: tab,
+  }));
+};
+
+/**
+ * Setzt ein Zeichen als wartend auf Platzierung (nächster Karten-Klick platziert es)
+ */
+export const setPendingZeichenPlacement = (zeichenId: string, definition: ZeichenDefinition) => {
+  drawStore.setState((state) => ({
+    ...state,
+    pendingZeichenPlacement: { zeichenId, definition },
+  }));
+};
+
+/**
+ * Löscht die wartende Zeichen-Platzierung
+ */
+export const clearPendingZeichenPlacement = () => {
+  drawStore.setState((state) => ({
+    ...state,
+    pendingZeichenPlacement: null,
+  }));
+};
+
+/**
+ * Öffnet das Zeichen-Detail-Panel für ein bestimmtes Zeichen.
+ * Schließt dabei die Zeichen-Sidebar und bricht wartende Platzierungen ab.
+ */
+export const openZeichenDetail = (zeichenId: string) => {
+  drawStore.setState((state) => ({
+    ...state,
+    selectedZeichenId: zeichenId,
+    isZeichenSidebarVisible: false,
+    pendingZeichenPlacement: null,
+  }));
+};
+
+/**
+ * Schließt das Zeichen-Detail-Panel
+ */
+export const closeZeichenDetail = () => {
+  drawStore.setState((state) => ({
+    ...state,
+    selectedZeichenId: null,
   }));
 };
 

--- a/packages/frontend/src/features/lagekarte/ui/molecules/GhostZeichenMarker.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/GhostZeichenMarker.molecule.tsx
@@ -1,0 +1,113 @@
+/**
+ * GhostZeichenMarker — Halbtransparenter Vorschau-Marker, der dem Cursor folgt.
+ *
+ * Wird im Platzierungsmodus angezeigt, damit der Nutzer sieht,
+ * wo das taktische Zeichen auf der Karte platziert wird.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Layer, Source } from 'react-map-gl/maplibre';
+import type { MapRef } from 'react-map-gl/maplibre';
+import type { FeatureCollection, Point } from 'geojson';
+import type { ZeichenDefinition } from '@/features/taktische-zeichen/rendering/renderer';
+import { getOrCreateImage } from '@/features/taktische-zeichen/rendering/zeichen-image-cache';
+
+const GHOST_SOURCE_ID = 'ghost-zeichen-source';
+const GHOST_LAYER_ID = 'ghost-zeichen-layer';
+
+interface GhostZeichenMarkerProps {
+  /** Referenz auf die MapLibre-GL-Instanz */
+  mapRef: React.RefObject<MapRef | null>;
+  /** Definition des zu platzierenden Zeichens */
+  definition: ZeichenDefinition;
+  /** Ob die Karte vollständig geladen ist */
+  isMapLoaded: boolean;
+}
+
+/**
+ * Rendert einen halbtransparenten Marker, der dem Cursor auf der Karte folgt.
+ * Registriert das Symbol-Image bei Bedarf in MapLibre.
+ */
+export function GhostZeichenMarker({ mapRef, definition, isMapLoaded }: GhostZeichenMarkerProps) {
+  const [cursorPosition, setCursorPosition] = useState<{ lng: number; lat: number } | null>(null);
+  const [imageId, setImageId] = useState<string | null>(null);
+  const imageRegisteredRef = useRef(false);
+
+  // Symbol-Image in MapLibre registrieren
+  useEffect(() => {
+    if (!isMapLoaded) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    imageRegisteredRef.current = false;
+
+    getOrCreateImage(definition).then(({ key, image }) => {
+      if (!map.hasImage(key)) {
+        map.addImage(key, image);
+      }
+      setImageId(key);
+      imageRegisteredRef.current = true;
+    });
+  }, [definition, isMapLoaded, mapRef]);
+
+  // Maus-Position auf der Karte verfolgen
+  const handleMouseMove = useCallback((e: maplibregl.MapMouseEvent) => {
+    setCursorPosition({ lng: e.lngLat.lng, lat: e.lngLat.lat });
+  }, []);
+
+  // Cursor ausblenden wenn Maus die Karte verlässt
+  const handleMouseLeave = useCallback(() => {
+    setCursorPosition(null);
+  }, []);
+
+  useEffect(() => {
+    if (!isMapLoaded) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    map.on('mousemove', handleMouseMove);
+    map.on('mouseout', handleMouseLeave);
+
+    return () => {
+      map.off('mousemove', handleMouseMove);
+      map.off('mouseout', handleMouseLeave);
+      setCursorPosition(null);
+    };
+  }, [isMapLoaded, mapRef, handleMouseMove, handleMouseLeave]);
+
+  if (!imageId || !cursorPosition) return null;
+
+  const geojson: FeatureCollection<Point> = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [cursorPosition.lng, cursorPosition.lat],
+        },
+        properties: {
+          imageId,
+        },
+      },
+    ],
+  };
+
+  return (
+    <Source id={GHOST_SOURCE_ID} type="geojson" data={geojson}>
+      <Layer
+        id={GHOST_LAYER_ID}
+        type="symbol"
+        layout={{
+          'icon-image': ['get', 'imageId'],
+          'icon-size': 0.5,
+          'icon-allow-overlap': true,
+          'icon-anchor': 'bottom',
+        }}
+        paint={{
+          'icon-opacity': 0.5,
+        }}
+      />
+    </Source>
+  );
+}

--- a/packages/frontend/src/features/lagekarte/ui/molecules/KartenZeichenSidebar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/KartenZeichenSidebar.molecule.tsx
@@ -20,7 +20,7 @@ import type { KatalogEintragData } from '@/features/taktische-zeichen/ui/molecul
 import type { ZeichenDefinition } from '@/features/taktische-zeichen/rendering/renderer';
 import { useZeichenKatalog, useCreateZeichen } from '@/features/taktische-zeichen';
 import type { ZeichenKatalogEintragResponseDto } from '@bluelight-hub/shared/client';
-import { drawStore, setZeichenSidebarTab, toggleZeichenSidebar } from '@/features/lagekarte/stores/draw.store';
+import { drawStore, setZeichenSidebarTab, toggleZeichenSidebar, setPendingZeichenPlacement, clearPendingZeichenPlacement } from '@/features/lagekarte/stores/draw.store';
 import { useStore } from '@tanstack/react-store';
 
 /** Konvertiert ein API-DTO in das lokale KatalogEintragData-Format */
@@ -55,6 +55,7 @@ interface KartenZeichenSidebarProps {
  */
 export function KartenZeichenSidebar({ einsatzId, isVisible }: KartenZeichenSidebarProps) {
   const activeTab = useStore(drawStore, (s) => s.zeichenSidebarTab);
+  const pendingPlacement = useStore(drawStore, (s) => s.pendingZeichenPlacement);
   const [selectedEintragId, setSelectedEintragId] = useState<string | undefined>(undefined);
 
   // Zeichen-Katalog vom Backend laden
@@ -66,37 +67,51 @@ export function KartenZeichenSidebar({ einsatzId, isVisible }: KartenZeichenSide
   // Katalog-DTOs in lokales Format konvertieren
   const katalogEintraege: KatalogEintragData[] = katalogDtos.map(dtoZuKatalogEintrag);
 
-  /** Aus Katalog: Zeichen dem Einsatz hinzufügen */
+  /** Aus Katalog: Zeichen dem Einsatz hinzufügen und Platzierungsmodus aktivieren */
   const handleKatalogSelect = useCallback(
     (eintrag: KatalogEintragData) => {
       setSelectedEintragId(eintrag.id);
-      createZeichen({
-        zeichenDefinition: {
-          grundzeichen: eintrag.zeichenDefinition.grundzeichen ?? 'kraftfahrzeug-gelaendegaengig',
-          organisation: eintrag.zeichenDefinition.organisation,
-          fachaufgabe: eintrag.zeichenDefinition.fachaufgabe,
-          einheit: eintrag.zeichenDefinition.einheit,
-          verwaltungsstufe: eintrag.zeichenDefinition.verwaltungsstufe,
+      createZeichen(
+        {
+          zeichenDefinition: {
+            grundzeichen: eintrag.zeichenDefinition.grundzeichen ?? 'kraftfahrzeug-gelaendegaengig',
+            organisation: eintrag.zeichenDefinition.organisation,
+            fachaufgabe: eintrag.zeichenDefinition.fachaufgabe,
+            einheit: eintrag.zeichenDefinition.einheit,
+            verwaltungsstufe: eintrag.zeichenDefinition.verwaltungsstufe,
+          },
+          katalogEintragId: eintrag.id,
         },
-        katalogEintragId: eintrag.id,
-      });
+        {
+          onSuccess: (created) => {
+            setPendingZeichenPlacement(created.id, eintrag.zeichenDefinition);
+          },
+        },
+      );
     },
     [createZeichen],
   );
 
-  /** Aus Baukasten: Eigenes Zeichen erstellen */
+  /** Aus Baukasten: Eigenes Zeichen erstellen und Platzierungsmodus aktivieren */
   const handleBaukastenErstellen = useCallback(
     (definition: ZeichenDefinition, label?: string) => {
-      createZeichen({
-        zeichenDefinition: {
-          grundzeichen: definition.grundzeichen ?? 'kraftfahrzeug-gelaendegaengig',
-          organisation: definition.organisation,
-          fachaufgabe: definition.fachaufgabe,
-          einheit: definition.einheit,
-          verwaltungsstufe: definition.verwaltungsstufe,
+      createZeichen(
+        {
+          zeichenDefinition: {
+            grundzeichen: definition.grundzeichen ?? 'kraftfahrzeug-gelaendegaengig',
+            organisation: definition.organisation,
+            fachaufgabe: definition.fachaufgabe,
+            einheit: definition.einheit,
+            verwaltungsstufe: definition.verwaltungsstufe,
+          },
+          ...(label && { label }),
         },
-        ...(label && { label }),
-      });
+        {
+          onSuccess: (created) => {
+            setPendingZeichenPlacement(created.id, definition);
+          },
+        },
+      );
     },
     [createZeichen],
   );
@@ -158,23 +173,23 @@ export function KartenZeichenSidebar({ einsatzId, isVisible }: KartenZeichenSide
       </div>
 
       {/* Tab-Inhalte */}
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="flex min-h-0 flex-1 flex-col">
         {/* Katalog-Tab */}
-        <div id="zeichen-tab-katalog" role="tabpanel" aria-labelledby="zeichen-tab-btn-katalog" hidden={activeTab !== 'katalog'}>
+        <div id="zeichen-tab-katalog" role="tabpanel" aria-labelledby="zeichen-tab-btn-katalog" hidden={activeTab !== 'katalog'} className="flex min-h-0 flex-1 flex-col">
           <ZeichenKatalog
             eintraege={katalogEintraege}
             isLoading={isKatalogLoading}
             error={katalogError ? 'Katalog konnte nicht geladen werden.' : undefined}
             onSelectEintrag={handleKatalogSelect}
             selectedEintragId={selectedEintragId}
+            isPendingPlacement={!!pendingPlacement}
+            onCancelPlacement={clearPendingZeichenPlacement}
           />
         </div>
 
         {/* Baukasten-Tab */}
-        <div id="zeichen-tab-baukasten" role="tabpanel" aria-labelledby="zeichen-tab-btn-baukasten" hidden={activeTab !== 'baukasten'}>
-          <div className="p-3">
-            <ZeichenBaukasten onErstelleZeichen={handleBaukastenErstellen} isCreating={isCreating} />
-          </div>
+        <div id="zeichen-tab-baukasten" role="tabpanel" aria-labelledby="zeichen-tab-btn-baukasten" hidden={activeTab !== 'baukasten'} className="flex min-h-0 flex-1 flex-col p-3">
+          <ZeichenBaukasten onErstelleZeichen={handleBaukastenErstellen} isCreating={isCreating} isPendingPlacement={!!pendingPlacement} onCancelPlacement={clearPendingZeichenPlacement} />
         </div>
       </div>
     </div>

--- a/packages/frontend/src/features/lagekarte/ui/molecules/MapDetailPanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/MapDetailPanel.molecule.tsx
@@ -1,13 +1,13 @@
 /**
- * MapDetailPanel - Generisches Side-Panel für Layer-Detail-Ansichten
+ * MapDetailPanel - Nicht-modales Side-Panel für Layer-Detail-Ansichten
  *
  * Zeigt Details eines Treffers mit Vor/Zurück-Navigation zwischen
  * mehreren Treffern am selben Klick-Punkt.
+ * Absolut positioniert, damit die Karte weiterhin bedienbar bleibt.
  */
 
 import { cn } from '@/shared/ui/cn';
-import { PiCaretLeft, PiCaretRight } from 'react-icons/pi';
-import { Dialog } from '@/shared/ui/molecules/dialog.molecule';
+import { PiCaretLeft, PiCaretRight, PiX } from 'react-icons/pi';
 import { getDetailProvider } from '../../detail-providers/registry';
 import type { LayerFeatureInfo } from '../../detail-providers/types';
 
@@ -29,50 +29,72 @@ export function MapDetailPanel({ results, panelIndex, isOpen, onClose, onNavigat
   const provider = info ? getDetailProvider(info.providerId) : null;
   const total = results.length;
 
-  if (!info || !provider) return null;
+  const title = info?.title ?? 'Details';
 
   return (
-    <Dialog.SlideIn isOpen={isOpen} onClose={onClose} title={info.title} size="md">
-      {/* Navigation zwischen Treffern */}
-      {total > 1 && (
-        <div className="mb-4 flex items-center justify-between border-b border-border-subtle pb-3">
-          <button
-            type="button"
-            onClick={() => onNavigate(panelIndex - 1)}
-            disabled={panelIndex === 0}
-            className={cn(
-              'flex items-center gap-1 rounded px-2 py-1 text-sm text-action-primary',
-              'disabled:cursor-not-allowed disabled:opacity-40',
-              'hover:bg-action-secondary focus-visible:shadow-focus-ring focus-visible:outline-none',
-            )}
-            aria-label="Vorheriger Treffer"
-          >
-            <PiCaretLeft className="h-4 w-4" aria-hidden="true" />
-            Zurück
-          </button>
-
-          <span className="text-sm font-medium text-text-secondary" aria-live="polite">
-            {panelIndex + 1} von {total}
-          </span>
-
-          <button
-            type="button"
-            onClick={() => onNavigate(panelIndex + 1)}
-            disabled={panelIndex === total - 1}
-            className={cn(
-              'flex items-center gap-1 rounded px-2 py-1 text-sm text-action-primary',
-              'disabled:cursor-not-allowed disabled:opacity-40',
-              'hover:bg-action-secondary focus-visible:shadow-focus-ring focus-visible:outline-none',
-            )}
-            aria-label="Nächster Treffer"
-          >
-            Weiter
-            <PiCaretRight className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
+    <div
+      className={cn(
+        'absolute top-0 right-0 z-20 flex h-full w-80 flex-col border-l border-border-subtle bg-surface-panel shadow-xl transition-transform duration-300 ease-out',
+        isOpen && info && provider ? 'translate-x-0' : 'translate-x-full',
       )}
+      aria-hidden={!isOpen || !info}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border-subtle px-4 py-3">
+        <h2 className="truncate text-sm font-semibold text-text-primary">{title}</h2>
+        <button
+          type="button"
+          aria-label="Detail-Panel schließen"
+          onClick={onClose}
+          className="rounded p-1 text-text-muted transition-colors hover:bg-action-secondary hover:text-text-primary focus-visible:shadow-focus-ring focus-visible:outline-none"
+        >
+          <PiX className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
 
-      {provider.renderPanel(info)}
-    </Dialog.SlideIn>
+      {/* Scrollbarer Inhalt */}
+      <div className="flex-1 overflow-y-auto p-3">
+        {/* Navigation zwischen Treffern */}
+        {total > 1 && (
+          <div className="mb-4 flex items-center justify-between border-b border-border-subtle pb-3">
+            <button
+              type="button"
+              onClick={() => onNavigate(panelIndex - 1)}
+              disabled={panelIndex === 0}
+              className={cn(
+                'flex items-center gap-1 rounded px-2 py-1 text-sm text-action-primary',
+                'disabled:cursor-not-allowed disabled:opacity-40',
+                'hover:bg-action-secondary focus-visible:shadow-focus-ring focus-visible:outline-none',
+              )}
+              aria-label="Vorheriger Treffer"
+            >
+              <PiCaretLeft className="h-4 w-4" aria-hidden="true" />
+              Zurück
+            </button>
+
+            <span className="text-sm font-medium text-text-secondary" aria-live="polite">
+              {panelIndex + 1} von {total}
+            </span>
+
+            <button
+              type="button"
+              onClick={() => onNavigate(panelIndex + 1)}
+              disabled={panelIndex === total - 1}
+              className={cn(
+                'flex items-center gap-1 rounded px-2 py-1 text-sm text-action-primary',
+                'disabled:cursor-not-allowed disabled:opacity-40',
+                'hover:bg-action-secondary focus-visible:shadow-focus-ring focus-visible:outline-none',
+              )}
+              aria-label="Nächster Treffer"
+            >
+              Weiter
+              <PiCaretRight className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+        )}
+
+        {info && provider && provider.renderPanel(info)}
+      </div>
+    </div>
   );
 }

--- a/packages/frontend/src/features/lagekarte/ui/molecules/TaktischeZeichenLayer.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/TaktischeZeichenLayer.molecule.tsx
@@ -73,7 +73,22 @@ export const TaktischeZeichenLayer: React.FC<TaktischeZeichenLayerProps> = ({ ma
 
   return (
     <>
-      <Source id={TAKTISCHE_ZEICHEN_SOURCE_ID} type="geojson" data={geojson}>
+      <Source id={TAKTISCHE_ZEICHEN_SOURCE_ID} type="geojson" data={geojson} promoteId="zeichenId">
+        {/* Auswahl-Indikator: Dezentes Highlight-Pad unter dem ausgewählten Symbol */}
+        <Layer
+          id="taktische-zeichen-selection-ring"
+          type="circle"
+          paint={{
+            'circle-radius': 20,
+            'circle-color': '#3b82f6',
+            'circle-opacity': ['case', ['boolean', ['feature-state', 'selected'], false], 0.12, 0],
+            'circle-stroke-color': '#3b82f6',
+            'circle-stroke-width': 1.5,
+            'circle-stroke-opacity': ['case', ['boolean', ['feature-state', 'selected'], false], 0.35, 0],
+            'circle-blur': 0.4,
+          }}
+        />
+
         {/* Symbol-Layer: rendert das SVG-Bild des taktischen Zeichens */}
         <Layer
           id={TAKTISCHE_ZEICHEN_LAYER_ID}
@@ -91,6 +106,7 @@ export const TaktischeZeichenLayer: React.FC<TaktischeZeichenLayerProps> = ({ ma
             'text-optional': true,
           }}
           paint={{
+            'icon-opacity': ['case', ['boolean', ['feature-state', 'dragging'], false], 0.8, 1],
             'text-color': '#1a1a1a',
             'text-halo-color': '#ffffff',
             'text-halo-width': 1.5,

--- a/packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailContent.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailContent.tsx
@@ -1,0 +1,198 @@
+/**
+ * ZeichenDetailContent - Inhalt des Zeichen-Detail-Panels
+ *
+ * 6 Sektionen: Vorschau, Label/Notiz (editierbar), Komposition, Position, Metadaten, Aktionen.
+ * Visueller Stil konsistent mit DwdPanelContent / NinaPanelContent.
+ */
+
+import { useEffect, useState } from 'react';
+import { PiClock, PiMapPin, PiNotePencil, PiPuzzlePiece, PiTrash } from 'react-icons/pi';
+import type { TaktischesZeichenResponseDto } from '@bluelight-hub/shared/client';
+import { ZeichenPreview } from '@/features/taktische-zeichen';
+import type { ZeichenDefinition } from '@/features/taktische-zeichen';
+import { Button } from '@/shared/ui/atoms/button.atom';
+
+/** Labels für die Kompositions-Felder */
+const KOMPOSITION_LABELS: { key: keyof TaktischesZeichenResponseDto['zeichenDefinition']; label: string }[] = [
+  { key: 'grundzeichen', label: 'Grundzeichen' },
+  { key: 'organisation', label: 'Organisation' },
+  { key: 'fachaufgabe', label: 'Fachaufgabe' },
+  { key: 'einheit', label: 'Einheit' },
+  { key: 'verwaltungsstufe', label: 'Verwaltungsstufe' },
+];
+
+function formatDateTime(iso: string): string {
+  return new Intl.DateTimeFormat('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(iso));
+}
+
+interface ZeichenDetailContentProps {
+  zeichen: TaktischesZeichenResponseDto;
+  onUpdateLabel: (label: string) => void;
+  onUpdateNotiz: (notiz: string) => void;
+  onRemove: () => void;
+  isRemoving: boolean;
+}
+
+export function ZeichenDetailContent({ zeichen, onUpdateLabel, onUpdateNotiz, onRemove, isRemoving }: ZeichenDetailContentProps) {
+  // Lokaler State für sofortige Input-Reaktion + Debounce
+  const [label, setLabel] = useState(zeichen.label ?? '');
+  const [notiz, setNotiz] = useState(zeichen.notiz ?? '');
+
+  // Sync wenn sich das Zeichen extern ändert (z.B. nach Mutation-Response)
+  useEffect(() => {
+    setLabel(zeichen.label ?? '');
+  }, [zeichen.label]);
+
+  useEffect(() => {
+    setNotiz(zeichen.notiz ?? '');
+  }, [zeichen.notiz]);
+
+  // Debounced Save für Label
+  useEffect(() => {
+    if (label === (zeichen.label ?? '')) return;
+    const timer = setTimeout(() => onUpdateLabel(label), 500);
+    return () => clearTimeout(timer);
+  }, [label, zeichen.label, onUpdateLabel]);
+
+  // Debounced Save für Notiz
+  useEffect(() => {
+    if (notiz === (zeichen.notiz ?? '')) return;
+    const timer = setTimeout(() => onUpdateNotiz(notiz), 500);
+    return () => clearTimeout(timer);
+  }, [notiz, zeichen.notiz, onUpdateNotiz]);
+
+  const definition: ZeichenDefinition = zeichen.zeichenDefinition;
+
+  return (
+    <div className="space-y-0">
+      {/* 1. Zeichen-Vorschau */}
+      <div className="flex flex-col items-center pb-4">
+        <ZeichenPreview definition={definition} size="lg" />
+        <h3 className="mt-2 text-base font-semibold text-text-primary">{zeichen.label || definition.grundzeichen}</h3>
+        <p className="mt-0.5 text-xs text-text-muted">{[definition.grundzeichen, definition.organisation, definition.fachaufgabe].filter(Boolean).join(' · ')}</p>
+      </div>
+
+      {/* 2. Label & Notiz (editierbar) */}
+      <section className="space-y-3.5 border-t border-border-subtle pt-3">
+        <div>
+          <div className="flex items-center gap-1.5">
+            <PiNotePencil className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+            <h4 className="text-[10px] font-semibold tracking-wider text-text-muted uppercase">Label & Notiz</h4>
+          </div>
+          <div className="mt-2 space-y-2">
+            <div>
+              <label htmlFor="zeichen-label" className="text-xs text-text-muted">
+                Label
+              </label>
+              <input
+                id="zeichen-label"
+                type="text"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="Bezeichnung eingeben..."
+                className="mt-0.5 w-full rounded-md border border-border-subtle bg-surface-raised px-2.5 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:border-action-primary focus:ring-1 focus:ring-action-primary focus:outline-none"
+              />
+            </div>
+            <div>
+              <label htmlFor="zeichen-notiz" className="text-xs text-text-muted">
+                Notiz
+              </label>
+              <textarea
+                id="zeichen-notiz"
+                value={notiz}
+                onChange={(e) => setNotiz(e.target.value)}
+                placeholder="Notiz hinzufügen..."
+                rows={3}
+                className="mt-0.5 w-full resize-y rounded-md border border-border-subtle bg-surface-raised px-2.5 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:border-action-primary focus:ring-1 focus:ring-action-primary focus:outline-none"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 3. Zeichen-Komposition */}
+      <section className="space-y-3.5 border-t border-border-subtle pt-3">
+        <div>
+          <div className="flex items-center gap-1.5">
+            <PiPuzzlePiece className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+            <h4 className="text-[10px] font-semibold tracking-wider text-text-muted uppercase">Zeichen-Komposition</h4>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {KOMPOSITION_LABELS.map(({ key, label: fieldLabel }) => {
+              const value = definition[key];
+              if (!value) return null;
+              return (
+                <span key={key} className="inline-flex items-center rounded-full border border-border-subtle bg-surface-raised px-2.5 py-0.5 text-body-xs text-text-secondary">
+                  <span className="mr-1 text-text-muted">{fieldLabel}:</span>
+                  {value}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* 4. Position */}
+      {zeichen.istPlatziert && zeichen.lat != null && zeichen.lng != null && (
+        <section className="space-y-3.5 border-t border-border-subtle pt-3">
+          <div>
+            <div className="flex items-center gap-1.5">
+              <PiMapPin className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+              <h4 className="text-[10px] font-semibold tracking-wider text-text-muted uppercase">Position</h4>
+            </div>
+            <div className="mt-1 grid grid-cols-2 gap-2 text-sm text-text-primary">
+              <div>
+                <span className="text-xs text-text-muted">Lat: </span>
+                {zeichen.lat.toFixed(5)}°
+              </div>
+              <div>
+                <span className="text-xs text-text-muted">Lng: </span>
+                {zeichen.lng.toFixed(5)}°
+              </div>
+            </div>
+            {zeichen.mgrs && (
+              <div className="mt-1 text-sm text-text-primary">
+                <span className="text-xs text-text-muted">MGRS: </span>
+                <span className="font-mono">{zeichen.mgrs}</span>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* 5. Metadaten */}
+      <section className="space-y-3.5 border-t border-border-subtle pt-3">
+        <div>
+          <div className="flex items-center gap-1.5">
+            <PiClock className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+            <h4 className="text-[10px] font-semibold tracking-wider text-text-muted uppercase">Metadaten</h4>
+          </div>
+          <div className="mt-1 text-xs leading-relaxed text-text-muted">
+            <p>
+              Erstellt von <span className="text-text-secondary">{zeichen.createdBy}</span> · {formatDateTime(zeichen.createdAt)}
+            </p>
+            {zeichen.updatedBy && (
+              <p>
+                Geändert von <span className="text-text-secondary">{zeichen.updatedBy}</span> · {formatDateTime(zeichen.updatedAt)}
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* 6. Aktionen */}
+      <section className="border-t border-border-subtle pt-3">
+        <Button intent="danger" size="sm" className="w-full" onClick={onRemove} loading={isRemoving} disabled={isRemoving}>
+          <PiTrash className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          Von Karte entfernen
+        </Button>
+      </section>
+    </div>
+  );
+}

--- a/packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailPanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailPanel.molecule.tsx
@@ -1,0 +1,59 @@
+/**
+ * ZeichenDetailPanel - Slide-In Panel für taktische Zeichen
+ *
+ * Wrapper um ZeichenDetailContent: Lädt Zeichen aus dem Query-Cache,
+ * stellt Mutations (Update, Remove) bereit, steuert Dialog.SlideIn.
+ */
+
+import { useCallback } from 'react';
+import type { TaktischesZeichenResponseDto } from '@bluelight-hub/shared/client';
+import { useUpdateZeichen, useRemoveZeichen } from '@/features/taktische-zeichen';
+import { Dialog } from '@/shared/ui/molecules/dialog.molecule';
+import { ZeichenDetailContent } from './ZeichenDetailContent';
+
+interface ZeichenDetailPanelProps {
+  /** Das anzuzeigende Zeichen (null = Panel geschlossen) */
+  zeichen: TaktischesZeichenResponseDto | undefined;
+  /** Einsatz-ID für Mutations */
+  einsatzId: string;
+  /** Ist das Panel geöffnet? */
+  isOpen: boolean;
+  /** Callback zum Schließen */
+  onClose: () => void;
+}
+
+export function ZeichenDetailPanel({ zeichen, einsatzId, isOpen, onClose }: ZeichenDetailPanelProps) {
+  const { mutate: updateZeichen } = useUpdateZeichen(einsatzId);
+  const { mutate: removeZeichen, isPending: isRemoving } = useRemoveZeichen(einsatzId);
+
+  const handleUpdateLabel = useCallback(
+    (label: string) => {
+      if (!zeichen) return;
+      updateZeichen({ zeichenId: zeichen.id, dto: { label: label || undefined } });
+    },
+    [zeichen, updateZeichen],
+  );
+
+  const handleUpdateNotiz = useCallback(
+    (notiz: string) => {
+      if (!zeichen) return;
+      updateZeichen({ zeichenId: zeichen.id, dto: { notiz: notiz || undefined } });
+    },
+    [zeichen, updateZeichen],
+  );
+
+  const handleRemove = useCallback(() => {
+    if (!zeichen) return;
+    removeZeichen(zeichen.id, { onSuccess: onClose });
+  }, [zeichen, removeZeichen, onClose]);
+
+  if (!zeichen) return null;
+
+  const title = zeichen.label || zeichen.zeichenDefinition.grundzeichen;
+
+  return (
+    <Dialog.SlideIn isOpen={isOpen} onClose={onClose} title={title} size="md">
+      <ZeichenDetailContent zeichen={zeichen} onUpdateLabel={handleUpdateLabel} onUpdateNotiz={handleUpdateNotiz} onRemove={handleRemove} isRemoving={isRemoving} />
+    </Dialog.SlideIn>
+  );
+}

--- a/packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailPanel.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailPanel.molecule.tsx
@@ -1,18 +1,21 @@
 /**
- * ZeichenDetailPanel - Slide-In Panel für taktische Zeichen
+ * ZeichenDetailPanel - Nicht-modales Slide-In Panel für taktische Zeichen
  *
  * Wrapper um ZeichenDetailContent: Lädt Zeichen aus dem Query-Cache,
- * stellt Mutations (Update, Remove) bereit, steuert Dialog.SlideIn.
+ * stellt Mutations (Update, Remove) bereit.
+ * Nutzt absolute Positionierung statt Dialog.SlideIn, damit die Karte
+ * weiterhin bedienbar bleibt.
  */
 
 import { useCallback } from 'react';
+import { PiX } from 'react-icons/pi';
 import type { TaktischesZeichenResponseDto } from '@bluelight-hub/shared/client';
 import { useUpdateZeichen, useRemoveZeichen } from '@/features/taktische-zeichen';
-import { Dialog } from '@/shared/ui/molecules/dialog.molecule';
+import { cn } from '@/shared/ui/cn';
 import { ZeichenDetailContent } from './ZeichenDetailContent';
 
 interface ZeichenDetailPanelProps {
-  /** Das anzuzeigende Zeichen (null = Panel geschlossen) */
+  /** Das anzuzeigende Zeichen (undefined = Panel geschlossen) */
   zeichen: TaktischesZeichenResponseDto | undefined;
   /** Einsatz-ID für Mutations */
   einsatzId: string;
@@ -47,13 +50,33 @@ export function ZeichenDetailPanel({ zeichen, einsatzId, isOpen, onClose }: Zeic
     removeZeichen(zeichen.id, { onSuccess: onClose });
   }, [zeichen, removeZeichen, onClose]);
 
-  if (!zeichen) return null;
-
-  const title = zeichen.label || zeichen.zeichenDefinition.grundzeichen;
+  const title = zeichen?.label || zeichen?.zeichenDefinition.grundzeichen || 'Zeichen';
 
   return (
-    <Dialog.SlideIn isOpen={isOpen} onClose={onClose} title={title} size="md">
-      <ZeichenDetailContent zeichen={zeichen} onUpdateLabel={handleUpdateLabel} onUpdateNotiz={handleUpdateNotiz} onRemove={handleRemove} isRemoving={isRemoving} />
-    </Dialog.SlideIn>
+    <div
+      className={cn(
+        'absolute top-0 right-0 z-20 flex h-full w-80 flex-col border-l border-border-subtle bg-surface-panel shadow-xl transition-transform duration-300 ease-out',
+        isOpen && zeichen ? 'translate-x-0' : 'translate-x-full',
+      )}
+      aria-hidden={!isOpen || !zeichen}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border-subtle px-4 py-3">
+        <h2 className="truncate text-sm font-semibold text-text-primary">{title}</h2>
+        <button
+          type="button"
+          aria-label="Detail-Panel schließen"
+          onClick={onClose}
+          className="rounded p-1 text-text-muted transition-colors hover:bg-action-secondary hover:text-text-primary focus-visible:shadow-focus-ring focus-visible:outline-none"
+        >
+          <PiX className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Scrollbarer Inhalt */}
+      <div className="flex-1 overflow-y-auto p-3">
+        {zeichen && <ZeichenDetailContent zeichen={zeichen} onUpdateLabel={handleUpdateLabel} onUpdateNotiz={handleUpdateNotiz} onRemove={handleRemove} isRemoving={isRemoving} />}
+      </div>
+    </div>
   );
 }

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -423,7 +423,14 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   };
 
   return (
-    <div className={cn('relative w-full overflow-hidden rounded-lg', mode === 'standard' && 'h-full', (mode === 'fullscreen' || mode === 'presentation') && 'h-screen')}>
+    <div
+      className={cn(
+        'relative w-full overflow-hidden rounded-lg',
+        mode === 'standard' && 'h-full',
+        (mode === 'fullscreen' || mode === 'presentation') && 'h-screen',
+        (isPanelOpen || selectedZeichenId || isZeichenSidebarVisible) && 'has-right-panel',
+      )}
+    >
       {mode !== 'standard' && <FullscreenCloseButton />}
 
       {isLoading && (

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -109,13 +109,23 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   // Platzierung von taktischen Zeichen per Karten-Klick
   const { mutate: placeZeichen } = usePlaceZeichen(einsatzId);
 
+  // Zeichen-Selektion → Detail-Panel steuern
+  const handleZeichenSelect = useCallback((zeichenId: string | null) => {
+    if (zeichenId) {
+      openZeichenDetail(zeichenId);
+    } else {
+      closeZeichenDetail();
+    }
+  }, []);
+
   // Drag & Drop für taktische Zeichen (nur wenn Zeichnen erlaubt und nicht gesperrt)
-  useZeichenDrag({
+  const { deselectZeichen } = useZeichenDrag({
     mapRef,
     isMapLoaded,
     zeichen: einsatzZeichen,
     einsatzId,
     canDrag: canDraw && !isLocked,
+    onSelect: handleZeichenSelect,
   });
 
   // Style-Panel State (vor useDrawControl, damit activeStyleRef verfügbar ist)
@@ -478,7 +488,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
         {ninaGeoJson && <NinaGeoJsonLayer data={ninaGeoJson} ninaOverlays={ninaOverlays} />}
 
         {/* Taktische Zeichen Layer (DV 102) */}
-        <TaktischeZeichenLayer mapRef={mapRef} isMapLoaded={isMapLoaded} zeichen={einsatzZeichen} onZeichenClick={(z) => openZeichenDetail(z.id)} />
+        <TaktischeZeichenLayer mapRef={mapRef} isMapLoaded={isMapLoaded} zeichen={einsatzZeichen} />
 
         {/* Ghost-Marker: Halbtransparente Vorschau beim Platzieren */}
         {pendingZeichenPlacement && <GhostZeichenMarker mapRef={mapRef} isMapLoaded={isMapLoaded} definition={pendingZeichenPlacement.definition} />}
@@ -547,7 +557,15 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
       <MapDetailPanel results={results} panelIndex={panelIndex} isOpen={isPanelOpen} onClose={closePanel} onNavigate={navigatePanel} />
 
       {/* Zeichen-Detail-Panel (Slide-In von rechts) */}
-      <ZeichenDetailPanel zeichen={selectedZeichen} einsatzId={einsatzId} isOpen={selectedZeichenId !== null} onClose={closeZeichenDetail} />
+      <ZeichenDetailPanel
+        zeichen={selectedZeichen}
+        einsatzId={einsatzId}
+        isOpen={selectedZeichenId !== null}
+        onClose={() => {
+          closeZeichenDetail();
+          deselectZeichen();
+        }}
+      />
 
       {/* Karten-Zeichen-Sidebar (nur im Nicht-Präsentationsmodus) */}
       {mode !== 'presentation' && <KartenZeichenSidebar einsatzId={einsatzId} isVisible={isZeichenSidebarVisible} />}

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -391,7 +391,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   };
 
   return (
-    <div className={cn('relative w-full overflow-hidden rounded-lg', mode === 'standard' && 'h-[600px] md:h-[calc(100vh-180px)]', (mode === 'fullscreen' || mode === 'presentation') && 'h-screen')}>
+    <div className={cn('relative w-full overflow-hidden rounded-lg', mode === 'standard' && 'h-full', (mode === 'fullscreen' || mode === 'presentation') && 'h-screen')}>
       {mode !== 'standard' && <FullscreenCloseButton />}
 
       {isLoading && (

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -12,7 +12,7 @@ import { useOsmMarkierung } from '@/features/lagekarte/hooks/use-osm-markierung'
 import { useGamsZonen } from '@/features/lagekarte/hooks/use-gams-zonen';
 import { useSnapControl } from '@/features/lagekarte/hooks/use-snap-control';
 import { useSymbolMarker } from '@/features/lagekarte/hooks/use-symbol-marker';
-import { drawStore, toggleSnapEnabled, toggleSymbolPanel, toggleTemplatePanel } from '@/features/lagekarte/stores/draw.store';
+import { drawStore, toggleSnapEnabled, toggleSymbolPanel, toggleTemplatePanel, clearPendingZeichenPlacement, openZeichenDetail, closeZeichenDetail } from '@/features/lagekarte/stores/draw.store';
 import { DEFAULT_DRAWING_STYLE } from '@/features/lagekarte/drawing/types';
 import type { DrawingStyle, HatchConfig } from '@/features/lagekarte/drawing/types';
 import type { ShapeTemplate } from '@/features/lagekarte/drawing/templates/template-registry';
@@ -43,8 +43,10 @@ import { GamsZonenPanel } from '../../molecules/GamsZonenPanel.molecule';
 import { FullscreenCloseButton } from '../FullscreenCloseButton/FullscreenCloseButton';
 import { NinaGeoJsonLayer } from '../../molecules/NinaGeoJsonLayer.molecule';
 import { TaktischeZeichenLayer } from '../../molecules/TaktischeZeichenLayer.molecule';
+import { GhostZeichenMarker } from '../../molecules/GhostZeichenMarker.molecule';
 import { KartenZeichenSidebar } from '../../molecules/KartenZeichenSidebar.molecule';
-import { useEinsatzZeichen } from '@/features/taktische-zeichen';
+import { ZeichenDetailPanel } from '../../molecules/ZeichenDetailPanel.molecule';
+import { useEinsatzZeichen, usePlaceZeichen } from '@/features/taktische-zeichen';
 import { useZeichenDrag } from '@/features/lagekarte/hooks/use-zeichen-drag';
 import '@/features/lagekarte/detail-providers';
 import './lagekarte-view.css';
@@ -95,9 +97,17 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   const isTemplatePanelVisible = useStore(drawStore, (s) => s.isTemplatePanelVisible);
   const isLocked = useStore(drawStore, (s) => s.isLocked);
   const isZeichenSidebarVisible = useStore(drawStore, (s) => s.isZeichenSidebarVisible);
+  const pendingZeichenPlacement = useStore(drawStore, (s) => s.pendingZeichenPlacement);
+  const selectedZeichenId = useStore(drawStore, (s) => s.selectedZeichenId);
 
   // Map-Ladezustand
   const isMapLoaded = !isLoading;
+
+  // Zeichen für Detail-Panel aus Cache ableiten
+  const selectedZeichen = selectedZeichenId ? einsatzZeichen.find((z) => z.id === selectedZeichenId) : undefined;
+
+  // Platzierung von taktischen Zeichen per Karten-Klick
+  const { mutate: placeZeichen } = usePlaceZeichen(einsatzId);
 
   // Drag & Drop für taktische Zeichen (nur wenn Zeichnen erlaubt und nicht gesperrt)
   useZeichenDrag({
@@ -365,6 +375,17 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
    */
   const handleCombinedClick = useCallback(
     (event: MapLayerMouseEvent) => {
+      // 0. Taktisches Zeichen platzieren (Klick nach Sidebar-Erstellung)
+      if (pendingZeichenPlacement && lagekarteData?.id) {
+        const { lng, lat } = event.lngLat;
+        placeZeichen({
+          zeichenId: pendingZeichenPlacement.zeichenId,
+          dto: { lagekarteId: lagekarteData.id, lat, lng },
+        });
+        clearPendingZeichenPlacement();
+        return;
+      }
+
       // 1. Im Zeichenmodus: Draw hat Vorrang (MapboxDraw verarbeitet den Klick)
       if (drawMode !== 'idle' && drawMode !== 'select' && drawMode !== 'osm_mark') {
         return;
@@ -379,12 +400,13 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
       // 3. Idle/Select: Bestehender Detail-Provider-Flow
       handleMapClick(event);
     },
-    [drawMode, handleOsmClick, handleMapClick],
+    [drawMode, handleOsmClick, handleMapClick, pendingZeichenPlacement, lagekarteData?.id, placeZeichen],
   );
 
   /** Cursor je nach Modus bestimmen */
   const getCursor = () => {
     if (isDetailLoading) return 'wait';
+    if (pendingZeichenPlacement) return 'crosshair';
     if (drawMode === 'osm_mark') return 'crosshair';
     if (drawMode !== 'idle' && drawMode !== 'select') return 'crosshair';
     return undefined;
@@ -456,7 +478,10 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
         {ninaGeoJson && <NinaGeoJsonLayer data={ninaGeoJson} ninaOverlays={ninaOverlays} />}
 
         {/* Taktische Zeichen Layer (DV 102) */}
-        <TaktischeZeichenLayer mapRef={mapRef} isMapLoaded={isMapLoaded} zeichen={einsatzZeichen} />
+        <TaktischeZeichenLayer mapRef={mapRef} isMapLoaded={isMapLoaded} zeichen={einsatzZeichen} onZeichenClick={(z) => openZeichenDetail(z.id)} />
+
+        {/* Ghost-Marker: Halbtransparente Vorschau beim Platzieren */}
+        {pendingZeichenPlacement && <GhostZeichenMarker mapRef={mapRef} isMapLoaded={isMapLoaded} definition={pendingZeichenPlacement.definition} />}
 
         {/* Detail-Popup am Klick-Punkt */}
         {results.length > 0 && coordinate && !isPanelOpen && <MapDetailPopup results={results} coordinate={coordinate} onShowDetails={openPanel} onClose={clearSelection} />}
@@ -520,6 +545,9 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
 
       {/* Detail-Panel (Slide-In von rechts) */}
       <MapDetailPanel results={results} panelIndex={panelIndex} isOpen={isPanelOpen} onClose={closePanel} onNavigate={navigatePanel} />
+
+      {/* Zeichen-Detail-Panel (Slide-In von rechts) */}
+      <ZeichenDetailPanel zeichen={selectedZeichen} einsatzId={einsatzId} isOpen={selectedZeichenId !== null} onClose={closeZeichenDetail} />
 
       {/* Karten-Zeichen-Sidebar (nur im Nicht-Präsentationsmodus) */}
       {mode !== 'presentation' && <KartenZeichenSidebar einsatzId={einsatzId} isVisible={isZeichenSidebarVisible} />}

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/__tests__/LagekarteView.spec.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/__tests__/LagekarteView.spec.tsx
@@ -158,6 +158,8 @@ vi.mock('@/features/lagekarte/stores/draw.store', () => ({
       isLocked: false,
       isZeichenSidebarVisible: false,
       zeichenSidebarTab: 'katalog',
+      pendingZeichenPlacement: null,
+      selectedZeichenId: null,
     },
     subscribe: vi.fn((cb) => {
       cb();
@@ -178,6 +180,9 @@ vi.mock('@/features/lagekarte/stores/draw.store', () => ({
   setDrawMode: vi.fn(),
   setSelectedFeatures: vi.fn(),
   setDirectSelect: vi.fn(),
+  clearPendingZeichenPlacement: vi.fn(),
+  openZeichenDetail: vi.fn(),
+  closeZeichenDetail: vi.fn(),
 }));
 
 vi.mock('@tanstack/react-store', () => ({
@@ -199,17 +204,23 @@ vi.mock('@tanstack/react-store', () => ({
       isLocked: false,
       isZeichenSidebarVisible: false,
       zeichenSidebarTab: 'katalog',
+      pendingZeichenPlacement: null,
+      selectedZeichenId: null,
     };
     return selector(state);
   }),
 }));
 
-vi.mock('@/features/taktische-zeichen/api/use-einsatz-zeichen', () => ({
+vi.mock('@/features/taktische-zeichen', () => ({
   useEinsatzZeichen: () => ({ data: [], isLoading: false, isError: false }),
+  usePlaceZeichen: () => ({ mutate: vi.fn() }),
+  useUpdateZeichen: () => ({ mutate: vi.fn() }),
+  useRemoveZeichen: () => ({ mutate: vi.fn(), isPending: false }),
+  ZeichenPreview: () => <div data-testid="zeichen-preview" />,
 }));
 
 vi.mock('@/features/lagekarte/hooks/use-zeichen-drag', () => ({
-  useZeichenDrag: vi.fn(),
+  useZeichenDrag: vi.fn(() => ({ isDragging: false, selectedZeichenId: null, deselectZeichen: vi.fn() })),
 }));
 
 vi.mock('@/features/lagekarte/drawing/types', () => ({
@@ -285,6 +296,14 @@ vi.mock('@/features/lagekarte/ui/molecules/TaktischeZeichenLayer.molecule', () =
 
 vi.mock('@/features/lagekarte/ui/molecules/KartenZeichenSidebar.molecule', () => ({
   KartenZeichenSidebar: () => <div data-testid="karten-zeichen-sidebar" />,
+}));
+
+vi.mock('@/features/lagekarte/ui/molecules/ZeichenDetailPanel.molecule', () => ({
+  ZeichenDetailPanel: () => <div data-testid="zeichen-detail-panel" />,
+}));
+
+vi.mock('@/features/lagekarte/ui/molecules/GhostZeichenMarker.molecule', () => ({
+  GhostZeichenMarker: () => <div data-testid="ghost-zeichen-marker" />,
 }));
 
 vi.mock('@/features/lagekarte/ui/organisms/FullscreenCloseButton/FullscreenCloseButton', () => ({

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/lagekarte-view.css
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/lagekarte-view.css
@@ -8,11 +8,11 @@
 
 /* Controls nach links schieben wenn ein Side-Panel offen ist */
 .maplibregl-ctrl-top-right {
-  transition: right 300ms ease-out;
+  transition: transform 300ms ease-out;
 }
 
 .has-right-panel .maplibregl-ctrl-top-right {
-  right: 20.5rem; /* w-80 (20rem) + etwas Abstand */
+  transform: translateX(-20.5rem); /* w-80 (20rem) + etwas Abstand */
 }
 
 /* MapboxDraw Default-Controls ausblenden — eigene Toolbar wird verwendet */

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/lagekarte-view.css
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/lagekarte-view.css
@@ -6,6 +6,15 @@
   z-index: 0 !important;
 }
 
+/* Controls nach links schieben wenn ein Side-Panel offen ist */
+.maplibregl-ctrl-top-right {
+  transition: right 300ms ease-out;
+}
+
+.has-right-panel .maplibregl-ctrl-top-right {
+  right: 20.5rem; /* w-80 (20rem) + etwas Abstand */
+}
+
 /* MapboxDraw Default-Controls ausblenden — eigene Toolbar wird verwendet */
 .mapboxgl-ctrl-group:has(.mapbox-gl-draw_ctrl-draw-btn) {
   display: none;

--- a/packages/frontend/src/features/taktische-zeichen/api/use-place-zeichen.ts
+++ b/packages/frontend/src/features/taktische-zeichen/api/use-place-zeichen.ts
@@ -3,6 +3,7 @@
  *
  * Setzt oder aktualisiert die Kartenposition (lat/lng) eines Zeichens
  * und verknüpft es mit einer Lagekarte.
+ * Optimistisches Update: Position wird sofort im Cache aktualisiert.
  */
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -16,22 +17,6 @@ interface PlaceZeichenParams {
   dto: PlatziereZeichenDto;
 }
 
-/**
- * Hook zum Platzieren oder Verschieben eines taktischen Zeichens auf der Karte.
- *
- * Wird sowohl für die Erstplatzierung als auch für das Verschieben (Drag & Drop)
- * auf der Lagekarte verwendet.
- *
- * @param einsatzId - Die Einsatz-ID
- * @returns TanStack Mutation Result
- *
- * @example
- * ```tsx
- * const { mutate } = usePlaceZeichen(einsatzId);
- *
- * mutate({ zeichenId: 'abc123', dto: { lagekarteId: 'lk1', lat: 51.5, lng: 9.3 } });
- * ```
- */
 export const usePlaceZeichen = (einsatzId: string) => {
   const queryClient = useQueryClient();
 
@@ -39,14 +24,36 @@ export const usePlaceZeichen = (einsatzId: string) => {
     mutationFn: async ({ zeichenId, dto }: PlaceZeichenParams): Promise<TaktischesZeichenResponseDto> => {
       return await apiPlaceZeichen(einsatzId, zeichenId, dto);
     },
-    onSuccess: () => {
+    onMutate: async ({ zeichenId, dto }) => {
+      // Laufende Queries abbrechen, damit sie das optimistische Update nicht überschreiben
+      await queryClient.cancelQueries({
+        queryKey: TAKTISCHE_ZEICHEN_QUERY_KEYS.zeichen(einsatzId),
+      });
+
+      // Vorherigen Cache-Wert sichern (für Rollback bei Fehler)
+      const previousZeichen = queryClient.getQueryData<TaktischesZeichenResponseDto[]>(TAKTISCHE_ZEICHEN_QUERY_KEYS.zeichen(einsatzId));
+
+      // Optimistisches Update: Position sofort aktualisieren
+      if (previousZeichen) {
+        queryClient.setQueryData<TaktischesZeichenResponseDto[]>(TAKTISCHE_ZEICHEN_QUERY_KEYS.zeichen(einsatzId), (old) =>
+          old?.map((z) => (z.id === zeichenId ? { ...z, lat: dto.lat, lng: dto.lng, lagekarteId: dto.lagekarteId, istPlatziert: true } : z)),
+        );
+      }
+
+      return { previousZeichen };
+    },
+    onError: (error, _variables, context) => {
+      // Rollback bei Fehler
+      if (context?.previousZeichen) {
+        queryClient.setQueryData(TAKTISCHE_ZEICHEN_QUERY_KEYS.zeichen(einsatzId), context.previousZeichen);
+      }
+      logger.error('Fehler beim Platzieren des taktischen Zeichens', error);
+    },
+    onSettled: () => {
+      // Nach Erfolg oder Fehler: Cache revalidieren
       queryClient.invalidateQueries({
         queryKey: TAKTISCHE_ZEICHEN_QUERY_KEYS.zeichen(einsatzId),
       });
-      logger.info('Taktisches Zeichen erfolgreich platziert');
-    },
-    onError: (error) => {
-      logger.error('Fehler beim Platzieren des taktischen Zeichens', error);
     },
   });
 };

--- a/packages/frontend/src/features/taktische-zeichen/ui/atoms/FachaufgabePicker.tsx
+++ b/packages/frontend/src/features/taktische-zeichen/ui/atoms/FachaufgabePicker.tsx
@@ -38,7 +38,7 @@ export function FachaufgabePicker({ grundzeichen: gz, organisation, value, onCha
       </button>
 
       {/* Fachaufgaben-Grid */}
-      <div className="grid max-h-52 grid-cols-3 gap-1 overflow-y-auto">
+      <div className="grid grid-cols-3 gap-1">
         {fachaufgaben.map((fa) => {
           const definition: ZeichenDefinition = {
             grundzeichen: gz,

--- a/packages/frontend/src/features/taktische-zeichen/ui/atoms/GrundzeichenPicker.tsx
+++ b/packages/frontend/src/features/taktische-zeichen/ui/atoms/GrundzeichenPicker.tsx
@@ -49,7 +49,7 @@ export function GrundzeichenPicker({ value, onChange }: GrundzeichenPickerProps)
   });
 
   return (
-    <div className="grid max-h-64 grid-cols-4 gap-1.5 overflow-y-auto">
+    <div className="grid grid-cols-4 gap-1.5">
       {sortiertGrundzeichen.map((gz) => {
         const definition: ZeichenDefinition = { grundzeichen: gz.id as GrundzeichenId };
         const isSelected = value === gz.id;

--- a/packages/frontend/src/features/taktische-zeichen/ui/organisms/ZeichenBaukasten.tsx
+++ b/packages/frontend/src/features/taktische-zeichen/ui/organisms/ZeichenBaukasten.tsx
@@ -3,11 +3,12 @@
  *
  * Schritte: Grundzeichen → Organisation → Fachaufgabe → Einheit.
  * Live-Vorschau des entstehenden Zeichens.
- * "Erstellen"-Button am Ende delegiert an den Aufrufer.
+ * Nach Erstellung: Prominenter Platzierungsmodus mit Abbruch-/Neustart-Option.
  */
 
 import { useState } from 'react';
 import type { EinheitId, FachaufgabeId, GrundzeichenId, OrganisationId } from 'taktische-zeichen-core';
+import { PiCursorClick, PiArrowCounterClockwise, PiX } from 'react-icons/pi';
 import { cn } from '@/shared/ui/cn';
 import { ZeichenPreview } from '../../rendering/ZeichenPreview';
 import type { ZeichenDefinition } from '../../rendering/renderer';
@@ -25,11 +26,15 @@ export interface ZeichenBaukastenProps {
   onErstelleZeichen: (definition: ZeichenDefinition, label?: string) => void;
   /** Ladezustand des Erstell-Vorgangs */
   isCreating?: boolean;
+  /** Zeichen wartet auf Platzierung auf der Karte */
+  isPendingPlacement?: boolean;
+  /** Platzierung abbrechen */
+  onCancelPlacement?: () => void;
 }
 
 const DEFAULT_GRUNDZEICHEN: GrundzeichenId = 'kraftfahrzeug-gelaendegaengig';
 
-export function ZeichenBaukasten({ onErstelleZeichen, isCreating }: ZeichenBaukastenProps) {
+export function ZeichenBaukasten({ onErstelleZeichen, isCreating, isPendingPlacement, onCancelPlacement }: ZeichenBaukastenProps) {
   const [aktiverSchritt, setAktiverSchritt] = useState<number>(0);
   const [grundzeichen, setGrundzeichen] = useState<GrundzeichenId>(DEFAULT_GRUNDZEICHEN);
   const [organisation, setOrganisation] = useState<OrganisationId | undefined>(undefined);
@@ -46,7 +51,6 @@ export function ZeichenBaukasten({ onErstelleZeichen, isCreating }: ZeichenBauka
 
   const handleGrundzeichenChange = (id: GrundzeichenId) => {
     setGrundzeichen(id);
-    // Fachaufgabe und Einheit zurücksetzen bei Grundzeichen-Wechsel
     setFachaufgabe(undefined);
     setEinheit(undefined);
   };
@@ -67,14 +71,72 @@ export function ZeichenBaukasten({ onErstelleZeichen, isCreating }: ZeichenBauka
     onErstelleZeichen(aktuellDefinition, label.trim() || undefined);
   };
 
+  const resetBaukasten = () => {
+    setAktiverSchritt(0);
+    setGrundzeichen(DEFAULT_GRUNDZEICHEN);
+    setOrganisation(undefined);
+    setFachaufgabe(undefined);
+    setEinheit(undefined);
+    setLabel('');
+  };
+
+  const handleNeuBeginnen = () => {
+    onCancelPlacement?.();
+    resetBaukasten();
+  };
+
   const istLetzterSchritt = aktiverSchritt === SCHRITTE.length - 1;
 
+  // Platzierungsmodus: Zeichen wurde erstellt, wartet auf Karten-Klick
+  if (isPendingPlacement) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-6 px-2">
+        {/* Erfolgs-Vorschau */}
+        <div className="relative">
+          <div className="absolute -inset-3 animate-pulse rounded-full bg-action-primary/10" />
+          <div className="relative rounded-xl border border-action-primary/20 bg-gradient-to-b from-action-primary/5 to-transparent p-5">
+            <ZeichenPreview definition={aktuellDefinition} size="lg" />
+          </div>
+        </div>
+
+        {/* Platzierungs-Hinweis */}
+        <div className="flex flex-col items-center gap-2 text-center">
+          <div className="flex items-center gap-2 text-action-primary">
+            <PiCursorClick className="h-5 w-5 animate-bounce" />
+            <span className="text-sm font-semibold">Auf Karte klicken</span>
+          </div>
+          <p className="text-xs leading-relaxed text-text-muted">Klicke auf die gewünschte Position,{'\u00A0'}um das Zeichen zu platzieren.</p>
+        </div>
+
+        {/* Aktionen */}
+        <div className="flex w-full flex-col gap-2">
+          <button
+            type="button"
+            onClick={handleNeuBeginnen}
+            className="flex items-center justify-center gap-2 rounded-lg bg-action-primary px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-action-primary-hover"
+          >
+            <PiArrowCounterClockwise className="h-4 w-4" />
+            Neues Zeichen erstellen
+          </button>
+          <button
+            type="button"
+            onClick={onCancelPlacement}
+            className="hover:bg-surface-hover flex items-center justify-center gap-2 rounded-lg border border-border-subtle px-4 py-2 text-sm text-text-muted transition-colors hover:text-text-primary"
+          >
+            <PiX className="h-4 w-4" />
+            Platzierung abbrechen
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-full flex-col gap-4">
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
       {/* Live-Vorschau oben */}
       <div className="flex flex-col items-center gap-2 rounded-lg border border-border-subtle bg-surface-panel p-4">
         <span className="text-xs font-medium text-text-secondary">Vorschau</span>
-        <ZeichenPreview definition={aktuellDefinition} size="lg" />
+        <ZeichenPreview definition={aktuellDefinition} size="md" />
       </div>
 
       {/* Schritt-Indikatoren */}

--- a/packages/frontend/src/features/taktische-zeichen/ui/organisms/ZeichenKatalog.tsx
+++ b/packages/frontend/src/features/taktische-zeichen/ui/organisms/ZeichenKatalog.tsx
@@ -3,10 +3,13 @@
  *
  * Panel mit Suchfeld und Kategorie-Tabs.
  * Zeigt gefilterte KatalogEintrag-Komponenten.
+ * Nach Auswahl: Platzierungsmodus mit Abbruch-Option.
  */
 
 import { useState, useMemo } from 'react';
+import { PiCursorClick, PiListBullets, PiX } from 'react-icons/pi';
 import { cn } from '@/shared/ui/cn';
+import { ZeichenPreview } from '../../rendering/ZeichenPreview';
 import { KatalogEintrag, type KatalogEintragData } from '../molecules/KatalogEintrag';
 
 export const ZEICHEN_KATEGORIEN = ['FUEHRUNG', 'EINHEITEN', 'FAHRZEUGE', 'GEFAHREN', 'VERSORGUNG', 'INFRASTRUKTUR'] as const;
@@ -32,9 +35,13 @@ export interface ZeichenKatalogProps {
   onSelectEintrag: (eintrag: KatalogEintragData) => void;
   /** Aktuell ausgewählter Eintrag */
   selectedEintragId?: string;
+  /** Zeichen wartet auf Platzierung auf der Karte */
+  isPendingPlacement?: boolean;
+  /** Platzierung abbrechen */
+  onCancelPlacement?: () => void;
 }
 
-export function ZeichenKatalog({ eintraege, isLoading, error, onSelectEintrag, selectedEintragId }: ZeichenKatalogProps) {
+export function ZeichenKatalog({ eintraege, isLoading, error, onSelectEintrag, selectedEintragId, isPendingPlacement, onCancelPlacement }: ZeichenKatalogProps) {
   const [suche, setSuche] = useState('');
   const [aktiveKategorie, setAktiveKategorie] = useState<ZeichenKategorie | 'ALLE'>('ALLE');
 
@@ -55,8 +62,55 @@ export function ZeichenKatalog({ eintraege, isLoading, error, onSelectEintrag, s
     return ergebnis;
   }, [eintraege, aktiveKategorie, suche]);
 
+  const selectedEintrag = selectedEintragId ? eintraege.find((e) => e.id === selectedEintragId) : undefined;
+
+  // Platzierungsmodus: Zeichen ausgewählt, wartet auf Karten-Klick
+  if (isPendingPlacement && selectedEintrag) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-6 px-4">
+        {/* Ausgewähltes Zeichen */}
+        <div className="relative">
+          <div className="absolute -inset-3 animate-pulse rounded-full bg-action-primary/10" />
+          <div className="relative rounded-xl border border-action-primary/20 bg-gradient-to-b from-action-primary/5 to-transparent p-5">
+            <ZeichenPreview definition={selectedEintrag.zeichenDefinition} size="lg" />
+          </div>
+        </div>
+
+        {/* Name & Platzierungs-Hinweis */}
+        <div className="flex flex-col items-center gap-2 text-center">
+          <span className="text-sm font-medium text-text-primary">{selectedEintrag.name}</span>
+          <div className="flex items-center gap-2 text-action-primary">
+            <PiCursorClick className="h-5 w-5 animate-bounce" />
+            <span className="text-sm font-semibold">Auf Karte klicken</span>
+          </div>
+          <p className="text-xs leading-relaxed text-text-muted">Klicke auf die gewünschte Position,{'\u00A0'}um das Zeichen zu platzieren.</p>
+        </div>
+
+        {/* Aktionen */}
+        <div className="flex w-full flex-col gap-2">
+          <button
+            type="button"
+            onClick={onCancelPlacement}
+            className="flex items-center justify-center gap-2 rounded-lg bg-action-primary px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-action-primary-hover"
+          >
+            <PiListBullets className="h-4 w-4" />
+            Anderes Zeichen wählen
+          </button>
+          <button
+            type="button"
+            onClick={onCancelPlacement}
+            className="hover:bg-surface-hover flex items-center justify-center gap-2 rounded-lg border border-border-subtle px-4 py-2 text-sm text-text-muted transition-colors hover:text-text-primary"
+          >
+            <PiX className="h-4 w-4" />
+            Platzierung abbrechen
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex min-h-0 flex-1 flex-col">
       {/* Suchfeld */}
       <div className="border-b border-border-subtle px-3 py-2">
         <input

--- a/packages/frontend/src/features/workspace/ui/WorkspaceShell.tsx
+++ b/packages/frontend/src/features/workspace/ui/WorkspaceShell.tsx
@@ -142,134 +142,138 @@ export function WorkspaceShell({
         <Container maxWidth="full">
           <div className="flex gap-3 xl:gap-4">
             <aside className="hidden w-52 flex-shrink-0 py-2 lg:block xl:w-56">
-              <div className="sticky top-24 h-[calc(100vh-8rem)] space-y-2 overflow-y-auto rounded-panel border border-border-subtle bg-surface-panel p-2 shadow-panel">
-                {sidebarHeader}
-                {onCommandTriggerClick ? (
-                  <div className="px-0.5">
-                    <CommandTrigger onClick={onCommandTriggerClick} label={commandTriggerLabel} />
-                  </div>
-                ) : null}
+              <div className="sticky top-24 flex h-[calc(100vh-8rem)] flex-col rounded-panel border border-border-subtle bg-surface-panel p-2 shadow-panel">
+                <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
+                  {sidebarHeader}
+                  {onCommandTriggerClick ? (
+                    <div className="px-0.5">
+                      <CommandTrigger onClick={onCommandTriggerClick} label={commandTriggerLabel} />
+                    </div>
+                  ) : null}
 
-                <nav aria-label="Modulseiten" className="-mt-1 space-y-0.5 pb-3">
-                  <h2 className="mb-3 px-2.5 text-body-xs font-semibold tracking-[0.16em] text-text-secondary uppercase">Navigation</h2>
-                  {navigationGroups.map((module) => (
-                    <div key={module.id} className="space-y-1 pb-2 last:pb-0">
-                      {isDisabled(module.visibility) ? (
-                        <div aria-disabled="true" className="flex items-center gap-2 rounded-control px-2.5 py-2 text-text-muted" title={module.visibility.reason}>
-                          <module.icon className="h-4 w-4 flex-shrink-0 text-text-muted" aria-hidden="true" />
-                          <h3 className="text-body-sm font-medium">{module.label}</h3>
-                          {getShortcutBadge(module) ? (
-                            <span
+                  <nav aria-label="Modulseiten" className="-mt-1 space-y-0.5 pb-3">
+                    <h2 className="mb-3 px-2.5 text-body-xs font-semibold tracking-[0.16em] text-text-secondary uppercase">Navigation</h2>
+                    {navigationGroups.map((module) => (
+                      <div key={module.id} className="space-y-1 pb-2 last:pb-0">
+                        {isDisabled(module.visibility) ? (
+                          <div aria-disabled="true" className="flex items-center gap-2 rounded-control px-2.5 py-2 text-text-muted" title={module.visibility.reason}>
+                            <module.icon className="h-4 w-4 flex-shrink-0 text-text-muted" aria-hidden="true" />
+                            <h3 className="text-body-sm font-medium">{module.label}</h3>
+                            {getShortcutBadge(module) ? (
+                              <span
+                                aria-hidden="true"
+                                className="ml-auto rounded-pill border border-border-subtle bg-surface-raised px-1.5 py-0.5 font-mono text-[11px] leading-none text-text-secondary shadow-sm"
+                              >
+                                {getShortcutBadge(module)}
+                              </span>
+                            ) : null}
+                          </div>
+                        ) : (
+                          <DynamicLink
+                            to={module.routeTarget}
+                            params={routeParams}
+                            aria-label={module.label}
+                            aria-keyshortcuts={module.shortcut ? [...module.shortcut.modifiers, module.shortcut.key].join('+') : undefined}
+                            className={cn(
+                              'group flex cursor-pointer items-center gap-2 rounded-control px-2.5 py-2 transition-colors focus:outline-none focus-visible:shadow-focus-ring',
+                              module.id === currentModule.id ? 'bg-action-secondary text-text-primary' : 'text-text-secondary hover:bg-action-secondary',
+                            )}
+                            search={(prev) => prev}
+                            aria-description={getBadgeText(module)}
+                            title={
+                              module.shortcut
+                                ? `Tastenkürzel: ${module.shortcut.modifiers.join('+').toLowerCase() === 'alt' ? `Alt+${module.shortcut.key}` : [...module.shortcut.modifiers, module.shortcut.key].join('+')}`
+                                : undefined
+                            }
+                          >
+                            <module.icon
+                              className={cn('h-4 w-4 flex-shrink-0 transition-colors', module.id === currentModule.id ? 'text-text-primary' : 'text-text-muted group-hover:text-text-secondary')}
                               aria-hidden="true"
-                              className="ml-auto rounded-pill border border-border-subtle bg-surface-raised px-1.5 py-0.5 font-mono text-[11px] leading-none text-text-secondary shadow-sm"
-                            >
-                              {getShortcutBadge(module)}
-                            </span>
-                          ) : null}
-                        </div>
-                      ) : (
-                        <DynamicLink
-                          to={module.routeTarget}
-                          params={routeParams}
-                          aria-label={module.label}
-                          aria-keyshortcuts={module.shortcut ? [...module.shortcut.modifiers, module.shortcut.key].join('+') : undefined}
-                          className={cn(
-                            'group flex cursor-pointer items-center gap-2 rounded-control px-2.5 py-2 transition-colors focus:outline-none focus-visible:shadow-focus-ring',
-                            module.id === currentModule.id ? 'bg-action-secondary text-text-primary' : 'text-text-secondary hover:bg-action-secondary',
-                          )}
-                          search={(prev) => prev}
-                          aria-description={getBadgeText(module)}
-                          title={
-                            module.shortcut
-                              ? `Tastenkürzel: ${module.shortcut.modifiers.join('+').toLowerCase() === 'alt' ? `Alt+${module.shortcut.key}` : [...module.shortcut.modifiers, module.shortcut.key].join('+')}`
-                              : undefined
-                          }
-                        >
-                          <module.icon
-                            className={cn('h-4 w-4 flex-shrink-0 transition-colors', module.id === currentModule.id ? 'text-text-primary' : 'text-text-muted group-hover:text-text-secondary')}
-                            aria-hidden="true"
-                          />
-                          <h3 className="text-body-sm font-medium">{module.label}</h3>
-                          {getShortcutBadge(module) ? (
-                            <span
-                              aria-hidden="true"
-                              className="ml-auto rounded-pill border border-border-subtle bg-surface-raised px-1.5 py-0.5 font-mono text-[11px] leading-none text-text-secondary shadow-sm"
-                            >
-                              {getShortcutBadge(module)}
-                            </span>
-                          ) : null}
-                        </DynamicLink>
-                      )}
+                            />
+                            <h3 className="text-body-sm font-medium">{module.label}</h3>
+                            {getShortcutBadge(module) ? (
+                              <span
+                                aria-hidden="true"
+                                className="ml-auto rounded-pill border border-border-subtle bg-surface-raised px-1.5 py-0.5 font-mono text-[11px] leading-none text-text-secondary shadow-sm"
+                              >
+                                {getShortcutBadge(module)}
+                              </span>
+                            ) : null}
+                          </DynamicLink>
+                        )}
 
-                      {module.badgeHint ? (
-                        <div className="ml-2.5 flex items-center gap-2 px-2.5 py-1 text-body-xs text-text-secondary">
-                          <span className="font-medium">{module.badgeHint.label}</span>
-                          {module.badgeHint.value !== undefined ? (
-                            <span className="rounded-pill bg-action-secondary px-1.5 py-0.5 text-body-xs font-semibold text-text-primary">{module.badgeHint.value}</span>
-                          ) : null}
-                        </div>
-                      ) : null}
+                        {module.badgeHint ? (
+                          <div className="ml-2.5 flex items-center gap-2 px-2.5 py-1 text-body-xs text-text-secondary">
+                            <span className="font-medium">{module.badgeHint.label}</span>
+                            {module.badgeHint.value !== undefined ? (
+                              <span className="rounded-pill bg-action-secondary px-1.5 py-0.5 text-body-xs font-semibold text-text-primary">{module.badgeHint.value}</span>
+                            ) : null}
+                          </div>
+                        ) : null}
 
-                      {module.id !== currentModule.id || isDisabled(module.visibility)
-                        ? null
-                        : module.visibleSubPages.map((page) => {
-                            const isActive = page.href === resolvedActivePageHref;
-                            const pageIsDisabled = isDisabled(page.visibility);
+                        {module.id !== currentModule.id || isDisabled(module.visibility)
+                          ? null
+                          : module.visibleSubPages.map((page) => {
+                              const isActive = page.href === resolvedActivePageHref;
+                              const pageIsDisabled = isDisabled(page.visibility);
 
-                            if (pageIsDisabled) {
-                              return (
-                                <div key={page.id} aria-disabled="true" className="ml-2.5 rounded-control px-2.5 py-2 text-text-muted" title={page.visibility.reason}>
-                                  <div className="flex items-start gap-3">
-                                    <page.icon className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />
-                                    <div className="min-w-0 flex-1">
-                                      <div className="flex items-center gap-2">
-                                        <span className="text-body-sm font-medium">{page.label}</span>
-                                        {page.badge ? <span className="rounded-pill bg-action-secondary px-1.5 py-0.5 text-body-xs font-semibold text-text-secondary">{page.badge}</span> : null}
+                              if (pageIsDisabled) {
+                                return (
+                                  <div key={page.id} aria-disabled="true" className="ml-2.5 rounded-control px-2.5 py-2 text-text-muted" title={page.visibility.reason}>
+                                    <div className="flex items-start gap-3">
+                                      <page.icon className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />
+                                      <div className="min-w-0 flex-1">
+                                        <div className="flex items-center gap-2">
+                                          <span className="text-body-sm font-medium">{page.label}</span>
+                                          {page.badge ? <span className="rounded-pill bg-action-secondary px-1.5 py-0.5 text-body-xs font-semibold text-text-secondary">{page.badge}</span> : null}
+                                        </div>
+                                        {page.description ? <p className="mt-0.5 text-body-xs">{page.description}</p> : null}
+                                        {page.visibility.reason ? <p className="mt-1 text-body-xs">{page.visibility.reason}</p> : null}
                                       </div>
-                                      {page.description ? <p className="mt-0.5 text-body-xs">{page.description}</p> : null}
-                                      {page.visibility.reason ? <p className="mt-1 text-body-xs">{page.visibility.reason}</p> : null}
                                     </div>
                                   </div>
-                                </div>
-                              );
-                            }
+                                );
+                              }
 
-                            return (
-                              <DynamicLink
-                                key={page.id}
-                                to={page.href}
-                                params={routeParams}
-                                search={(prev) => prev}
-                                aria-current={isActive ? 'page' : undefined}
-                                className={cn(
-                                  'group ml-2.5 flex cursor-pointer items-start gap-3 rounded-control px-2.5 py-2 transition-colors',
-                                  isActive ? 'bg-action-secondary text-text-primary' : 'text-text-secondary hover:bg-action-secondary',
-                                )}
-                              >
-                                <page.icon className={cn('mt-0.5 h-5 w-5 shrink-0 transition-colors', isActive ? 'text-text-primary' : 'text-text-muted group-hover:text-text-secondary')} />
-                                <div className="min-w-0 flex-1">
-                                  <div className="flex items-center gap-2">
-                                    <span className="text-body-sm font-medium">{page.label}</span>
-                                    {page.badge ? <span className="rounded-pill bg-action-primary px-1.5 py-0.5 text-body-xs font-semibold text-text-inverse">{page.badge}</span> : null}
+                              return (
+                                <DynamicLink
+                                  key={page.id}
+                                  to={page.href}
+                                  params={routeParams}
+                                  search={(prev) => prev}
+                                  aria-current={isActive ? 'page' : undefined}
+                                  className={cn(
+                                    'group ml-2.5 flex cursor-pointer items-start gap-3 rounded-control px-2.5 py-2 transition-colors',
+                                    isActive ? 'bg-action-secondary text-text-primary' : 'text-text-secondary hover:bg-action-secondary',
+                                  )}
+                                >
+                                  <page.icon className={cn('mt-0.5 h-5 w-5 shrink-0 transition-colors', isActive ? 'text-text-primary' : 'text-text-muted group-hover:text-text-secondary')} />
+                                  <div className="min-w-0 flex-1">
+                                    <div className="flex items-center gap-2">
+                                      <span className="text-body-sm font-medium">{page.label}</span>
+                                      {page.badge ? <span className="rounded-pill bg-action-primary px-1.5 py-0.5 text-body-xs font-semibold text-text-inverse">{page.badge}</span> : null}
+                                    </div>
+                                    {page.description ? <p className="mt-0.5 text-body-xs text-text-secondary">{page.description}</p> : null}
                                   </div>
-                                  {page.description ? <p className="mt-0.5 text-body-xs text-text-secondary">{page.description}</p> : null}
-                                </div>
-                              </DynamicLink>
-                            );
-                          })}
-                    </div>
-                  ))}
-                </nav>
+                                </DynamicLink>
+                              );
+                            })}
+                      </div>
+                    ))}
+                  </nav>
+                </div>
 
-                {quickActionsSlot ? (
-                  <section aria-label="Schnellaktionen" className="space-y-2 border-t border-border-subtle pt-3">
-                    <h2 className="px-2.5 text-body-xs font-semibold tracking-[0.16em] text-text-secondary uppercase">Schnellaktionen</h2>
-                    {quickActionsSlot}
-                  </section>
-                ) : null}
+                <div className="flex-shrink-0">
+                  {quickActionsSlot ? (
+                    <section aria-label="Schnellaktionen" className="space-y-1 border-t border-border-subtle pt-2">
+                      <h2 className="px-2.5 text-body-xs font-semibold tracking-[0.16em] text-text-secondary uppercase">Schnellaktionen</h2>
+                      {quickActionsSlot}
+                    </section>
+                  ) : null}
 
-                <StatusRail items={statusItems} />
-                {sidebarFooter}
+                  <StatusRail items={statusItems} />
+                  {sidebarFooter}
+                </div>
               </div>
             </aside>
 

--- a/packages/frontend/src/routes/app/einsatz/$einsatzId/übersicht/karte.tsx
+++ b/packages/frontend/src/routes/app/einsatz/$einsatzId/übersicht/karte.tsx
@@ -20,5 +20,9 @@ function RouteComponent() {
   const { einsatzId } = Route.useParams();
   const { mode } = Route.useSearch();
 
-  return <LagekarteView einsatzId={einsatzId} mode={mode} />;
+  return (
+    <div className={mode === 'standard' ? 'h-[calc(100dvh-14rem)] lg:h-[calc(100dvh-6rem)]' : undefined}>
+      <LagekarteView einsatzId={einsatzId} mode={mode} />
+    </div>
+  );
 }

--- a/packages/frontend/src/shared/ui/templates/SingleEinsatzLayout.tsx
+++ b/packages/frontend/src/shared/ui/templates/SingleEinsatzLayout.tsx
@@ -481,8 +481,8 @@ export function SingleEinsatzLayout({ className }: SingleEinsatzLayoutProps) {
         onOpenModuleOverview={() => setShowModuleOverview(true)}
         sidebarHeader={<EinsatzSwitcher />}
         quickActionsSlot={
-          <div className="border-t border-border-subtle pt-4">
-            <Button appearance="ghost" size="sm" className="mb-2 w-full justify-start" onClick={() => setShowBeitrittDialog(true)}>
+          <div className="space-y-1">
+            <Button appearance="ghost" size="sm" className="w-full justify-start" onClick={() => setShowBeitrittDialog(true)}>
               <PiRadio className="mr-2 h-4 w-4" />
               {currentEinsatzPersonId ? (
                 <span className="truncate">{teilnahmeData?.data?.personFunkrufname || `${teilnahmeData?.data?.personVorname} ${teilnahmeData?.data?.personNachname}`}</span>
@@ -491,12 +491,12 @@ export function SingleEinsatzLayout({ className }: SingleEinsatzLayoutProps) {
               )}
             </Button>
             {isFuehrungskraft && (
-              <Button appearance="ghost" size="sm" className="mb-2 w-full justify-start" onClick={() => setShowExterneEinladenDialog(true)} aria-haspopup="dialog">
+              <Button appearance="ghost" size="sm" className="w-full justify-start" onClick={() => setShowExterneEinladenDialog(true)} aria-haspopup="dialog">
                 <PiUserPlus className="mr-2 h-4 w-4" />
                 Externe einladen
               </Button>
             )}
-            <Button appearance="ghost" size="sm" className="mb-2 w-full justify-start" onClick={() => setShowAudioDialog(true)} aria-haspopup="dialog">
+            <Button appearance="ghost" size="sm" className="w-full justify-start" onClick={() => setShowAudioDialog(true)} aria-haspopup="dialog">
               <PiSpeakerHigh className="mr-2 h-4 w-4" />
               Audio-Einstellungen
             </Button>


### PR DESCRIPTION
## Summary

- Vertikale Platzausnutzung der Lagekarte optimiert (Karte höher)
- Schnellaktionen in der Sidebar immer sichtbar (fixiert am unteren Rand)
- Neues Zeichen-Detail-Panel: Klick auf taktische Zeichen öffnet nicht-modales Side-Panel mit Vorschau, editierbarem Label/Notiz, Komposition, Position, Metadaten und Lösch-Aktion

## Changes

### Frontend — Lagekarte
- `draw.store.ts`: `selectedZeichenId` State + `openZeichenDetail`/`closeZeichenDetail` Actions
- `ZeichenDetailContent.tsx`: 6 Sektionen (Vorschau, Label/Notiz, Komposition, Position, Metadaten, Aktionen)
- `ZeichenDetailPanel.molecule.tsx`: Nicht-modales Side-Panel mit Update/Remove Mutations
- `MapDetailPanel.molecule.tsx`: Von Dialog.SlideIn auf nicht-modales Panel umgebaut (konsistent)
- `use-zeichen-drag.ts`: `onSelect`-Callback für Detail-Panel-Integration
- `LagekarteView.tsx`: Panel eingebunden, Map-Controls verschieben sich bei offenem Panel
- `lagekarte-view.css`: Synchrone Transform-Animation für Controls
- `GhostZeichenMarker.molecule.tsx`: Halbtransparente Vorschau beim Platzieren
- Katalog/Baukasten-UI-Verbesserungen

### Frontend — Workspace
- `WorkspaceShell.tsx`: Sidebar-Flexbox — Navigation scrollt, Schnellaktionen fixiert
- `SingleEinsatzLayout.tsx`: Quick-Actions-Spacing reduziert

## Test plan

- [ ] Lagekarte öffnen → Zeichen platzieren → Klick auf Zeichen → Detail-Panel öffnet sich
- [ ] Label/Notiz im Panel bearbeiten → Auto-Save nach 500ms
- [ ] "Von Karte entfernen" → Zeichen verschwindet, Panel schließt sich
- [ ] DWD/NINA-Warnungen klicken → Panel öffnet sich nicht-modal
- [ ] +/- Buttons wandern synchron mit Panel-Animation
- [ ] Schnellaktionen in Sidebar bleiben bei langem Navigationsmenü sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)