### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: rubenvitt
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
## Zusammenfassung

Adds a GitHub FUNDING.yml configuration file to enable GitHub Sponsors funding model for the project, with the maintainer's GitHub username configured.

## Änderungen

- Added `.github/FUNDING.yml` with GitHub Sponsors enabled for user `rubenvitt`
- Included template placeholders for other funding platforms (Patreon, Open Collective, Ko-fi, etc.) for future use

## Typ der Änderung

- [ ] 🐛 Bugfix
- [ ] ✨ Neues Feature
- [x] ♻️ Refactoring
- [x] 📝 Dokumentation
- [ ] 🧪 Tests
- [ ] 💥 Breaking Change

## Testing

N/A - Configuration file only

---

## Checklisten

### Code Quality

- [x] `pnpm lint` läuft ohne Fehler
- [x] Keine funktionalen Änderungen erforderlich

https://claude.ai/code/session_0129ncYoUx8fNburqS6W1Te6