### PR TITLE
🐛(frontend): Fix Baukasten feedback and label for Zeichen

### DIFF
--- a/packages/frontend/src/features/lagekarte/stores/draw.store.ts
+++ b/packages/frontend/src/features/lagekarte/stores/draw.store.ts
@@ -51,7 +51,7 @@ export interface DrawStoreState {
   /** Aktiver Tab der Zeichen-Sidebar */
   zeichenSidebarTab: ZeichenSidebarTab;
   /** Wartet auf Platzierung: Definition für ein neues Zeichen, optional existierende Zeichen-ID für unplatzierte Zeichen */
-  pendingZeichenPlacement: { definition: ZeichenDefinition; existingZeichenId?: string } | null;
+  pendingZeichenPlacement: { definition: ZeichenDefinition; existingZeichenId?: string; label?: string } | null;
   /** ID des aktuell im Detail-Panel angezeigten Zeichens (null = Panel geschlossen) */
   selectedZeichenId: string | null;
 }
@@ -244,10 +244,10 @@ export const setZeichenSidebarTab = (tab: ZeichenSidebarTab) => {
  * Setzt ein Zeichen als wartend auf Platzierung (nächster Karten-Klick platziert es).
  * Für neue Zeichen: nur definition. Für bestehende unplatzierte Zeichen: zusätzlich existingZeichenId.
  */
-export const setPendingZeichenPlacement = (definition: ZeichenDefinition, existingZeichenId?: string) => {
+export const setPendingZeichenPlacement = (definition: ZeichenDefinition, existingZeichenId?: string, label?: string) => {
   drawStore.setState((state) => ({
     ...state,
-    pendingZeichenPlacement: { definition, existingZeichenId },
+    pendingZeichenPlacement: { definition, existingZeichenId, label },
   }));
 };
 

--- a/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/DrawToolbar.molecule.tsx
@@ -39,6 +39,8 @@ export interface DrawToolbarProps {
   activeMode: DrawMode;
   /** Modus wechseln */
   onModeChange: (mode: DrawMode) => void;
+  /** Anzahl unplatzierter taktischer Zeichen (für Badge-Anzeige) */
+  unplatzierteZeichenCount?: number;
 }
 
 /** Konfiguration für einen Zeichenmodus-Button */
@@ -77,7 +79,7 @@ export const TOOLBAR_ITEMS: ToolbarItem[] = [
 /** Gemeinsame Button-Styles */
 const buttonBase = 'flex items-center justify-center p-2 transition-colors duration-100 focus-visible:shadow-focus-ring focus-visible:outline-none';
 
-export function DrawToolbar({ activeMode, onModeChange }: DrawToolbarProps) {
+export function DrawToolbar({ activeMode, onModeChange, unplatzierteZeichenCount = 0 }: DrawToolbarProps) {
   const isExpanded = useStore(drawStore, (s) => s.isDrawToolbarVisible);
   const isSymbolPanelVisible = useStore(drawStore, (s) => s.isSymbolPanelVisible);
   const isTemplatePanelVisible = useStore(drawStore, (s) => s.isTemplatePanelVisible);
@@ -108,9 +110,14 @@ export function DrawToolbar({ activeMode, onModeChange }: DrawToolbarProps) {
           aria-pressed={isZeichenSidebarVisible}
           title="Taktische Zeichen"
           onClick={toggleZeichenSidebar}
-          className={cn(buttonBase, isZeichenSidebarVisible ? 'bg-action-secondary text-action-primary' : 'text-text-muted hover:bg-action-secondary hover:text-text-primary')}
+          className={cn(buttonBase, 'relative', isZeichenSidebarVisible ? 'bg-action-secondary text-action-primary' : 'text-text-muted hover:bg-action-secondary hover:text-text-primary')}
         >
           <PiShieldStar className="h-5 w-5" aria-hidden="true" />
+          {unplatzierteZeichenCount > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-status-warning-surface text-[10px] font-bold text-status-warning-text ring-1 ring-status-warning-border">
+              {unplatzierteZeichenCount}
+            </span>
+          )}
         </button>
 
         <button

--- a/packages/frontend/src/features/lagekarte/ui/molecules/KartenZeichenSidebar.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/KartenZeichenSidebar.molecule.tsx
@@ -12,7 +12,7 @@
 
 import type * as React from 'react';
 import { useCallback, useMemo, useState } from 'react';
-import { PiList, PiMapPin, PiTrash, PiWrench, PiX } from 'react-icons/pi';
+import { PiList, PiMapPin, PiTrash, PiWarning, PiWrench, PiX } from 'react-icons/pi';
 import { cn } from '@/shared/ui/cn';
 import { ZeichenKatalog } from '@/features/taktische-zeichen/ui/organisms/ZeichenKatalog';
 import { ZeichenBaukasten } from '@/features/taktische-zeichen/ui/organisms/ZeichenBaukasten';
@@ -81,8 +81,8 @@ export function KartenZeichenSidebar({ einsatzId, isVisible }: KartenZeichenSide
   }, []);
 
   /** Aus Baukasten: Platzierungsmodus aktivieren (Zeichen wird erst beim Karten-Klick erstellt) */
-  const handleBaukastenErstellen = useCallback((definition: ZeichenDefinition) => {
-    setPendingZeichenPlacement(definition);
+  const handleBaukastenErstellen = useCallback((definition: ZeichenDefinition, label?: string) => {
+    setPendingZeichenPlacement(definition, undefined, label);
   }, []);
 
   /** Bestehendes unplatziertes Zeichen zur Platzierung auswählen */
@@ -169,9 +169,12 @@ export function KartenZeichenSidebar({ einsatzId, isVisible }: KartenZeichenSide
 
       {/* Unplatzierte Zeichen */}
       {unplatzierteZeichen.length > 0 && (
-        <div className="border-t border-border-subtle">
-          <div className="px-4 py-2 text-xs font-semibold tracking-wider text-text-muted uppercase">Nicht platziert ({unplatzierteZeichen.length})</div>
-          <ul className="max-h-48 divide-y divide-border-subtle overflow-y-auto">
+        <div className="border-t border-status-warning-border bg-status-warning-surface">
+          <div className="flex items-center gap-1.5 px-4 py-2">
+            <PiWarning className="h-3.5 w-3.5 shrink-0 text-status-warning-text" aria-hidden="true" />
+            <span className="text-xs font-semibold tracking-wider text-status-warning-text uppercase">Nicht platziert ({unplatzierteZeichen.length})</span>
+          </div>
+          <ul className="max-h-48 divide-y divide-status-warning-border overflow-y-auto">
             {unplatzierteZeichen.map((z) => (
               <li key={z.id} className="flex items-center gap-2 px-4 py-2">
                 <ZeichenPreview definition={z.zeichenDefinition as unknown as ZeichenDefinition} size="sm" />
@@ -183,7 +186,7 @@ export function KartenZeichenSidebar({ einsatzId, isVisible }: KartenZeichenSide
                   type="button"
                   aria-label="Zeichen platzieren"
                   onClick={() => handlePlatziereUnplatziert(z)}
-                  className="rounded p-1 text-text-muted transition-colors hover:bg-action-secondary hover:text-action-primary focus-visible:shadow-focus-ring focus-visible:outline-none"
+                  className="rounded p-1 text-text-muted transition-colors hover:bg-action-secondary hover:text-status-warning-text focus-visible:shadow-focus-ring focus-visible:outline-none"
                 >
                   <PiMapPin className="h-3.5 w-3.5" aria-hidden="true" />
                 </button>

--- a/packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailContent.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/ZeichenDetailContent.tsx
@@ -66,12 +66,13 @@ export function ZeichenDetailContent({ zeichen, einsatzId, onUpdateLabel, onUpda
     setNotiz(zeichen.notiz ?? '');
   }, [zeichen.notiz]);
 
-  // Debounced Save für Label
+  // Debounced Save für Label (nicht bei verknüpften Zeichen — Label wird dort extern verwaltet)
   useEffect(() => {
+    if (zeichen.referenzTyp) return;
     if (label === (zeichen.label ?? '')) return;
     const timer = setTimeout(() => onUpdateLabel(label), 500);
     return () => clearTimeout(timer);
-  }, [label, zeichen.label, onUpdateLabel]);
+  }, [label, zeichen.label, zeichen.referenzTyp, onUpdateLabel]);
 
   // Debounced Save für Notiz
   useEffect(() => {
@@ -121,7 +122,8 @@ export function ZeichenDetailContent({ zeichen, einsatzId, onUpdateLabel, onUpda
                 value={label}
                 onChange={(e) => setLabel(e.target.value)}
                 placeholder="Bezeichnung eingeben..."
-                className="mt-0.5 w-full rounded-md border border-border-subtle bg-surface-raised px-2.5 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:border-action-primary focus:ring-1 focus:ring-action-primary focus:outline-none"
+                disabled={!!zeichen.referenzTyp}
+                className="mt-0.5 w-full rounded-md border border-border-subtle bg-surface-raised px-2.5 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:border-action-primary focus:ring-1 focus:ring-action-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
               />
             </div>
             <div>

--- a/packages/frontend/src/features/lagekarte/ui/molecules/__tests__/DrawToolbar.molecule.spec.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/__tests__/DrawToolbar.molecule.spec.tsx
@@ -126,4 +126,17 @@ describe('DrawToolbar', () => {
     expect(lockBtn).toBeInTheDocument();
     expect(lockBtn).toHaveAttribute('aria-pressed', 'false');
   });
+
+  it('sollte Badge mit Anzahl unplatzierter Zeichen anzeigen', () => {
+    render(<DrawToolbar activeMode="idle" onModeChange={vi.fn()} unplatzierteZeichenCount={3} />);
+
+    const badge = screen.getByText('3');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('sollte kein Badge anzeigen wenn keine unplatzierten Zeichen', () => {
+    render(<DrawToolbar activeMode="idle" onModeChange={vi.fn()} unplatzierteZeichenCount={0} />);
+
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
 });

--- a/packages/frontend/src/features/lagekarte/ui/molecules/__tests__/KartenZeichenSidebar.molecule.spec.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/__tests__/KartenZeichenSidebar.molecule.spec.tsx
@@ -160,10 +160,7 @@ describe('KartenZeichenSidebar', () => {
 
       await user.click(screen.getByTestId('baukasten-erstellen-btn'));
 
-      expect(mockSetPendingZeichenPlacement).toHaveBeenCalledWith({
-        grundzeichen: 'fahrzeug',
-        organisation: 'fw',
-      });
+      expect(mockSetPendingZeichenPlacement).toHaveBeenCalledWith({ grundzeichen: 'fahrzeug', organisation: 'fw' }, undefined, undefined);
     });
   });
 

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/LagekarteView.tsx
@@ -48,6 +48,7 @@ import { KartenZeichenSidebar } from '../../molecules/KartenZeichenSidebar.molec
 import { ZeichenDetailPanel } from '../../molecules/ZeichenDetailPanel.molecule';
 import { useEinsatzZeichen, useCreateZeichen, usePlaceZeichen } from '@/features/taktische-zeichen';
 import { useZeichenDrag } from '@/features/lagekarte/hooks/use-zeichen-drag';
+import { toast } from 'sonner';
 import '@/features/lagekarte/detail-providers';
 import './lagekarte-view.css';
 
@@ -387,6 +388,10 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
   const handleCombinedClick = useCallback(
     (event: MapLayerMouseEvent) => {
       // 0. Taktisches Zeichen platzieren (Klick nach Sidebar-Auswahl)
+      if (pendingZeichenPlacement && !lagekarteData?.id) {
+        toast.error('Lagekarte noch nicht geladen — bitte einen Moment warten');
+        return;
+      }
       if (pendingZeichenPlacement && lagekarteData?.id) {
         const { lng, lat } = event.lngLat;
 
@@ -397,7 +402,15 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
               zeichenId: pendingZeichenPlacement.existingZeichenId,
               dto: { lagekarteId: lagekarteData.id, lat, lng },
             },
-            { onSuccess: () => clearPendingZeichenPlacement() },
+            {
+              onSuccess: () => {
+                clearPendingZeichenPlacement();
+                toast.success('Zeichen platziert');
+              },
+              onError: () => {
+                toast.error('Fehler beim Platzieren des Zeichens');
+              },
+            },
           );
         } else {
           // Neues Zeichen erstellen + direkt platzieren (atomar)
@@ -411,11 +424,20 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
                 einheit: def.einheit,
                 verwaltungsstufe: def.verwaltungsstufe,
               },
+              label: pendingZeichenPlacement.label,
               lagekarteId: lagekarteData.id,
               lat,
               lng,
             },
-            { onSuccess: () => clearPendingZeichenPlacement() },
+            {
+              onSuccess: () => {
+                clearPendingZeichenPlacement();
+                toast.success('Zeichen platziert');
+              },
+              onError: () => {
+                toast.error('Fehler beim Platzieren des Zeichens');
+              },
+            },
           );
         }
         return;
@@ -546,7 +568,7 @@ export const LagekarteView: React.FC<LagekarteViewProps> = ({ einsatzId, mode = 
       {/* Draw-Toolbar (immer sichtbar für Lock-Button, ShortcutBar nur wenn nicht gesperrt) */}
       {canDraw && (
         <>
-          <DrawToolbar activeMode={drawMode} onModeChange={setMode} />
+          <DrawToolbar activeMode={drawMode} onModeChange={setMode} unplatzierteZeichenCount={einsatzZeichen.filter((z) => !z.istPlatziert).length} />
           {!isLocked && (
             <DrawShortcutBar
               activeMode={drawMode}

--- a/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/__tests__/LagekarteView.spec.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/organisms/LagekarteView/__tests__/LagekarteView.spec.tsx
@@ -325,6 +325,15 @@ vi.mock('@/features/lagekarte/ui/organisms/FullscreenCloseButton/FullscreenClose
 
 vi.mock('@/features/lagekarte/detail-providers', () => ({}));
 
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: any[]) => mockToastSuccess(...args),
+    error: (...args: any[]) => mockToastError(...args),
+  },
+}));
+
 vi.mock('../lagekarte-view.css', () => ({}));
 
 vi.mock('@/shared/lib/logger', () => ({
@@ -530,13 +539,56 @@ describe('LagekarteView', () => {
             einheit: undefined,
             verwaltungsstufe: undefined,
           },
+          label: undefined,
           lagekarteId: 'lagekarte-42',
           lat: 50.3,
           lng: 10.5,
         },
-        expect.objectContaining({ onSuccess: expect.any(Function) }),
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
       );
       expect(mockPlaceZeichen).not.toHaveBeenCalled();
+    });
+
+    it('sollte Label im createZeichen-DTO durchreichen', () => {
+      const definition = { grundzeichen: 'stelle', organisation: 'thw', fachaufgabe: undefined, einheit: undefined, verwaltungsstufe: undefined };
+
+      mockDrawStoreOverrides = {
+        pendingZeichenPlacement: { definition, label: 'ELW-1' },
+      };
+      mockLagekarteData.mockReturnValue({ data: { id: 'lagekarte-42', state: null } });
+
+      render(<LagekarteView einsatzId="einsatz-1" />);
+      capturedMapOnClick!(mockMapEvent);
+
+      expect(mockCreateZeichen).toHaveBeenCalledWith(expect.objectContaining({ label: 'ELW-1' }), expect.any(Object));
+    });
+
+    it('sollte toast.success zeigen bei erfolgreicher Erstellung', () => {
+      const definition = { grundzeichen: 'stelle' };
+      mockDrawStoreOverrides = { pendingZeichenPlacement: { definition } };
+      mockLagekarteData.mockReturnValue({ data: { id: 'lagekarte-42', state: null } });
+
+      render(<LagekarteView einsatzId="einsatz-1" />);
+      capturedMapOnClick!(mockMapEvent);
+
+      const callArgs = mockCreateZeichen.mock.calls[0][1];
+      callArgs.onSuccess();
+
+      expect(mockToastSuccess).toHaveBeenCalledWith('Zeichen platziert');
+    });
+
+    it('sollte toast.error zeigen bei fehlgeschlagener Erstellung', () => {
+      const definition = { grundzeichen: 'stelle' };
+      mockDrawStoreOverrides = { pendingZeichenPlacement: { definition } };
+      mockLagekarteData.mockReturnValue({ data: { id: 'lagekarte-42', state: null } });
+
+      render(<LagekarteView einsatzId="einsatz-1" />);
+      capturedMapOnClick!(mockMapEvent);
+
+      const callArgs = mockCreateZeichen.mock.calls[0][1];
+      callArgs.onError();
+
+      expect(mockToastError).toHaveBeenCalledWith('Fehler beim Platzieren des Zeichens');
     });
 
     it('sollte bestehendes Zeichen platzieren wenn pendingZeichenPlacement mit existingZeichenId', () => {
@@ -558,12 +610,30 @@ describe('LagekarteView', () => {
           zeichenId: 'z-existing-1',
           dto: { lagekarteId: 'lagekarte-42', lat: 50.3, lng: 10.5 },
         },
-        expect.objectContaining({ onSuccess: expect.any(Function) }),
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
       );
       expect(mockCreateZeichen).not.toHaveBeenCalled();
     });
 
-    it('sollte NICHT platzieren wenn keine lagekarteData vorhanden', () => {
+    it('sollte toast.success zeigen bei erfolgreicher Platzierung eines bestehenden Zeichens', () => {
+      mockDrawStoreOverrides = {
+        pendingZeichenPlacement: {
+          definition: { grundzeichen: 'fahrzeug' },
+          existingZeichenId: 'z-existing-1',
+        },
+      };
+      mockLagekarteData.mockReturnValue({ data: { id: 'lagekarte-42', state: null } });
+
+      render(<LagekarteView einsatzId="einsatz-1" />);
+      capturedMapOnClick!(mockMapEvent);
+
+      const callArgs = mockPlaceZeichen.mock.calls[0][1];
+      callArgs.onSuccess();
+
+      expect(mockToastSuccess).toHaveBeenCalledWith('Zeichen platziert');
+    });
+
+    it('sollte toast.error zeigen wenn Lagekarte noch nicht geladen', () => {
       mockDrawStoreOverrides = {
         pendingZeichenPlacement: {
           definition: { grundzeichen: 'stelle' },
@@ -577,6 +647,7 @@ describe('LagekarteView', () => {
 
       expect(mockCreateZeichen).not.toHaveBeenCalled();
       expect(mockPlaceZeichen).not.toHaveBeenCalled();
+      expect(mockToastError).toHaveBeenCalledWith('Lagekarte noch nicht geladen — bitte einen Moment warten');
     });
   });
 });


### PR DESCRIPTION
- Thread label from ZeichenBaukasten through drawStore to createZeichen API call
- Add toast.success/toast.error after zeichen placement on map
- Add error toast when lagekarte not yet loaded during placement
- Style unplatzierte Zeichen section with warning design tokens
- Add unplaced count badge to DrawToolbar zeichen button
- Disable label input in ZeichenDetailContent for referenced zeichen
- Guard debounced label save for referenzTyp zeichen

Closes #665

🤖 Generated with Claude Code

## Zusammenfassung

<!-- Kurze Beschreibung der Änderungen -->

## Änderungen

<!-- Liste der wichtigsten Änderungen -->

-

## Typ der Änderung

- [ ] 🐛 Bugfix
- [ ] ✨ Neues Feature
- [ ] ♻️ Refactoring
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests
- [ ] 💥 Breaking Change

## Testing

<!-- Wie wurden die Änderungen getestet? -->

- [ ] Unit Tests hinzugefügt/aktualisiert
- [ ] Manuell getestet
- [ ] E2E Tests (falls relevant)

---

## Checklisten

### Domain Events (falls zutreffend)

> **Wichtig:** Neue Domain Events müssen an mehreren Stellen registriert werden!

- [ ] Event-Klasse erstellt unter `domain/events/` oder `domain/<context>/events/`
- [ ] Event-Name in `EVENT_NAMES` definiert (`domain/events/event-names.ts`)
- [ ] Event im `EventDeserializer` registriert (`infrastructure/outbox/event-deserializer.ts`)
- [ ] Event-Namen Convention eingehalten (lowercase, dot-separated, z.B. `einsatz.created`)
- [ ] Import-Statement für Event-Klasse im Deserializer hinzugefügt

### API Änderungen (falls zutreffend)

- [ ] `pnpm run generate-api` ausgeführt nach Backend-Änderungen
- [ ] `@ApiWrappedResponse` / `@ApiWrappedCreatedResponse` Decorators verwendet (nicht `@ApiOkResponse`)

### Code Quality

- [ ] `pnpm lint` läuft ohne Fehler
- [ ] `pnpm --filter @bluelight-hub/backend test` läuft ohne Fehler
- [ ] Keine `import type` für Injectable Classes (NestJS DI)

---

## Verknüpfte Issues

<!-- z.B. Closes #123, Fixes #456 -->
