### PR TITLE
✨(frontend): Fahrzeuge-Seite UI/UX grundlegend überarbeiten

### DIFF
--- a/docs/superpowers/specs/2026-04-14-fahrzeuge-seite-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-14-fahrzeuge-seite-redesign-design.md
@@ -1,0 +1,229 @@
+# Fahrzeuge-Seite: UI/UX Redesign
+
+**Issue:** #679
+**Datum:** 2026-04-14
+**Status:** Approved
+
+## Zusammenfassung
+
+Die Fahrzeuge-Verwaltungsseite (`/kräfte/fahrzeuge`) wird von einer redundanten 3-Ebenen-Darstellung (Statistik-Karten + EinsatzResourceWidget + gruppierte Liste) zu einem kompakten Karten-Grid mit Statustableau-Feeling und editierbarem Detail-Panel umgebaut.
+
+## Entscheidungen
+
+| Frage | Entscheidung | Begründung |
+|-------|-------------|------------|
+| Layout-Pattern | Karten-Grid (Hybrid C) | Statustableau-Feeling, kompakteste Übersicht, FMS-Farbe als Border scanbar |
+| Detail-Panel | Editierbar (B) | Weniger Klicks, alle Dropdowns direkt im Panel |
+| FMS auf Karte | Direkt änderbar | Schnelle Status-Änderung ohne Panel ist Kern-Workflow |
+| Filter/Gruppierung | Tabs (Alle/Im Einsatz/Bereit/Weitere) | Ersetzt feste Sektionen, "Alle" als Default |
+| Statistik-Header | 4 kompakte Karten behalten | Schneller Überblick, kein Redundanz mehr ohne Widget |
+| EinsatzResourceWidget | Nur aus dieser Seite entfernt | An anderen Stellen (Einsatz-Überblick) bleibt es |
+| FahrzeugCard (Dashboard) | Unverändert | Dashboard-Mode-aware, anderer Zweck |
+| View-Toggle Grid/Liste | Nicht implementiert | YAGNI, kann als separates Enhancement nachkommen |
+| Kennzeichen | Nicht prominent | Unwichtig laut User, nur im Detail-Panel sichtbar |
+| Besatzung auf Karte | Nur Anzahl | Detail-Ansicht mit Namen im Panel |
+
+## Seitenaufbau
+
+```
+┌─────────────────────────────────────────────────┐
+│ Header: "Fahrzeuge"          [+ Fahrzeug hinzufügen] │
+├─────────────────────────────────────────────────┤
+│ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐           │
+│ │  12  │ │   5  │ │  18  │ │ 1.5  │           │
+│ │Gesamt│ │Einsatz│ │Pers. │ │Ø Bes.│           │
+│ └──────┘ └──────┘ └──────┘ └──────┘           │
+├─────────────────────────────────────────────────┤
+│ [Alle (12)] [Im Einsatz (5)] [Bereit (4)] [Weitere (3)] │
+├─────────────────────────────────────────────────┤
+│ ┌───────────────┐ ┌───────────────┐             │
+│ │▌Florian 1/44  │ │▌Florian 1/46  │             │
+│ │ FMS 3  3 Pers.│ │ FMS 4  6 Pers.│             │
+│ │ Zugtrupp      │ │ 1. Gruppe     │             │
+│ └───────────────┘ └───────────────┘             │
+│ ┌───────────────┐ ┌───────────────┐             │
+│ │▌Florian 1/83  │ │▌Florian 1/10  │             │
+│ │ FMS 2  2 Pers.│ │ FMS 6  0 Pers.│             │
+│ │ -             │ │ -             │             │
+│ └───────────────┘ └───────────────┘             │
+└─────────────────────────────────────────────────┘
+```
+
+Bei Klick auf eine Karte öffnet sich das Detail-Panel:
+
+```
+                              ┌──────────────────┐
+                              │ Florian 1/44   X │
+                              ├──────────────────┤
+                              │   ┌──────────┐   │
+                              │   │  TZ-Bild │   │
+                              │   └──────────┘   │
+                              │  DA-BH 123       │
+                              │  HLF 20          │
+                              │  [Zeichen bearb.]│
+                              ├──────────────────┤
+                              │ FMS-STATUS       │
+                              │ [3 - Einsatz ▼]  │
+                              │                  │
+                              │ EINHEIT          │
+                              │ [Zugtrupp    ▼]  │
+                              ├──────────────────┤
+                              │ BESATZUNG (3)    │
+                              │ Max Mustermann GF│
+                              │ Anna Schmidt  MA │
+                              │ Peter Weber   AT │
+                              └──────────────────┘
+```
+
+## Neue Komponenten
+
+### 1. `FahrzeugGridCard` (Molecule)
+
+**Pfad:** `packages/frontend/src/features/kraefte/ui/molecules/FahrzeugGridCard.tsx`
+
+Kompakte Karte für das Fahrzeug-Grid.
+
+**Props:**
+```typescript
+interface FahrzeugGridCardProps {
+  fahrzeug: EinsatzFahrzeugDto;
+  zeichen?: TaktischesZeichenResponseDto | null;
+  einheitName?: string | null;
+  onSelect: (fahrzeugId: string) => void;
+  onStatusChange: (fahrzeugId: string, newStatus: FmsStatus) => void;
+}
+```
+
+**Darstellung:**
+- `rounded-panel border border-border-subtle bg-surface-panel shadow-panel`
+- Farbiger `border-left` (3px) nach FMS-Status via `getStatusBgClasses()`
+- `hover:border-border-strong` + `cursor-pointer`
+- Zeile 1: TZ-Preview (sm) oder PiTruck-Icon, Funkrufname (font-semibold), FmsStatusBadge (rechts)
+- Zeile 2: Besatzungsanzahl (Badge), Einheit-Badge (wenn zugewiesen)
+- Klick auf FMS-Badge: `stopPropagation()` + öffnet `FmsStatusDropdown` als Popover
+- Klick auf Karte (außerhalb FMS): ruft `onSelect(fahrzeug.id)`
+
+### 2. `FahrzeugDetailPanel` (Organism)
+
+**Pfad:** `packages/frontend/src/features/kraefte/ui/organisms/FahrzeugDetailPanel.tsx`
+
+SlideIn-Panel mit allen editierbaren Feldern.
+
+**Props:**
+```typescript
+interface FahrzeugDetailPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  einsatzId: string;
+  fahrzeug: EinsatzFahrzeugDto;
+  zeichen?: TaktischesZeichenResponseDto | null;
+  einheiten: Array<{ id: string; name: string; typ: string }>;
+  onStatusChange: (fahrzeugId: string, newStatus: FmsStatus) => void;
+  onEinheitAssign: (fahrzeugId: string, einheitId: string | null) => void;
+  onManageZeichen: (fahrzeugId: string) => void;
+}
+```
+
+**Aufbau:**
+- Nutzt `Dialog.SlideIn` mit `size="md"` und `position="right"`
+- **Header:** Funkrufname + Close-Button
+- **TZ-Sektion:** `ZeichenPreview` (lg) + Kennzeichen + Fahrzeugtyp + "Zeichen bearbeiten"-Button
+- **Editierbare Felder:** `FmsStatusDropdown` + `EinheitZuweisungsDropdown` (beide bestehende Komponenten)
+- **Besatzung:** Liste aller zugewiesenen Personen mit Namen (read-only)
+
+### 3. `FahrzeugFilterTabs` (Molecule)
+
+**Pfad:** `packages/frontend/src/features/kraefte/ui/molecules/FahrzeugFilterTabs.tsx`
+
+Filter-Tabs mit Zähler.
+
+**Props:**
+```typescript
+type FahrzeugFilter = 'alle' | 'einsatz' | 'bereit' | 'andere';
+
+interface FahrzeugFilterTabsProps {
+  activeFilter: FahrzeugFilter;
+  onFilterChange: (filter: FahrzeugFilter) => void;
+  counts: Record<FahrzeugFilter, number>;
+}
+```
+
+**Darstellung:**
+- Horizontal, Pill-Style (aktiv: `bg-surface-panel shadow`, inaktiv: `text-text-secondary hover:bg-action-secondary-hover`)
+- Jeder Tab zeigt Label + Zähler in Klammern
+- Filterlogik:
+  - `alle`: Kein Filter
+  - `einsatz`: FMS 3-4
+  - `bereit`: FMS 2
+  - `andere`: FMS 0-1, 5-9
+
+## Geänderte Dateien
+
+### Route-Datei (Hauptrefaktor)
+
+**Pfad:** `packages/frontend/src/routes/app/einsatz/$einsatzId/kräfte/fahrzeuge.tsx`
+
+Wird zum reinen Orchestrator (wie `TaktischeEinheitenPage`):
+- State: `selectedFahrzeugId`, `activeFilter`, `showFahrzeugDialog`, `zeichenPanelFahrzeugId`, `assigningFahrzeugIds`
+- Queries: `useEinsatzFahrzeuge`, `useEinsatzEinheiten`, `useEinsatzZeichen`
+- Mutations: `useUpdateFmsStatus`, `useAssignFahrzeugZuEinheit`
+- Memos: `zeichenByFahrzeug`, `einheitenMap`, `filteredFahrzeuge`, `filterCounts`
+- Layout: Header → Stats → FilterTabs → Grid → DetailPanel → Dialoge
+
+**Entfernt:**
+- `EinsatzResourceWidget`-Import und -Nutzung
+- Gruppierte Sektionen (Im Einsatz / Bereit / Andere)
+- Inline-Fahrzeug-Rows mit dupliziertem Markup
+
+## Wiederverwendete Komponenten (unverändert)
+
+- `FmsStatusBadge` — Badge-Anzeige auf der Karte
+- `FmsStatusDropdown` — Inline-Dropdown auf Karte + im Panel
+- `EinheitZuweisungsDropdown` — Im Detail-Panel
+- `ZeichenPreview` — Auf Karte (sm) und im Panel (lg)
+- `FahrzeugHinzufuegenDialog` — Wird weiterhin vom Header-Button geöffnet
+- `FahrzeugZeichenPanel` — Wird vom Detail-Panel aus geöffnet
+- `Dialog.SlideIn` — Basis für das Detail-Panel
+- `Button`, `LoadingState`, `ErrorState` — Shared UI
+
+## Grid-Layout
+
+```css
+/* Responsive Grid */
+grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4
+```
+
+- Mobile: 1 Spalte
+- Tablet: 2 Spalten
+- Desktop: 3 Spalten
+
+## Interaktions-Flüsse
+
+### FMS-Status schnell ändern (auf Karte)
+1. User klickt FMS-Badge auf Karte
+2. `stopPropagation()` verhindert Karten-Klick
+3. FmsStatusDropdown erscheint als Popover
+4. User wählt neuen Status
+5. `useUpdateFmsStatus.mutate()` mit Optimistic Update
+6. Badge-Farbe und Border-Left aktualisieren sich sofort
+
+### Detail-Panel öffnen
+1. User klickt Karte (außerhalb FMS-Badge)
+2. `selectedFahrzeugId` wird gesetzt
+3. `FahrzeugDetailPanel` öffnet als SlideIn von rechts
+4. Panel zeigt alle Infos + editierbare Dropdowns
+
+### Zeichen bearbeiten (aus Panel)
+1. User klickt "Zeichen bearbeiten" im Detail-Panel
+2. Detail-Panel schließt sich (nur ein Panel gleichzeitig offen)
+3. `FahrzeugZeichenPanel` öffnet sich
+4. Nach Schließen des Zeichen-Panels: zurück zum Grid (kein Auto-Reopen des Detail-Panels)
+
+## Abgrenzung
+
+- Kein View-Toggle Grid/Liste (YAGNI)
+- Keine Backend-Änderungen
+- `FahrzeugCard` (Dashboard) bleibt unverändert
+- `EinsatzResourceWidget` bleibt an anderen Stellen
+- Fahrzeug-Erfassung (Dialog) ist nicht Teil des Redesigns
+- Besatzungsverwaltung bleibt read-only auf dieser Seite

--- a/packages/frontend/src/features/einsatz/constants/__tests__/fms-status.constants.spec.ts
+++ b/packages/frontend/src/features/einsatz/constants/__tests__/fms-status.constants.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests für FMS-Status Konstanten und Helper-Funktionen.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  FMS_STATUS_LABELS,
+  FMS_STATUS_COLORS,
+  FMS_STATUS_OPTIONS,
+  FMS_BORDER_LEFT_COLORS,
+  getStatusClasses,
+  getStatusBgClasses,
+  getStatusBorderLeftClass,
+  isFmsStatus,
+  isImEinsatzStatus,
+  isEinsatzbereitStatus,
+} from '../fms-status.constants';
+
+describe('FMS-Status Konstanten', () => {
+  it('enthält Labels für alle Status 0-9', () => {
+    for (let i = 0; i <= 9; i++) {
+      expect(FMS_STATUS_LABELS[i]).toBeDefined();
+      expect(FMS_STATUS_LABELS[i].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('nutzt BOS-Standard-Labels', () => {
+    expect(FMS_STATUS_LABELS[0]).toBe('Notruf');
+    expect(FMS_STATUS_LABELS[1]).toBe('Einsatzbereit über Funk');
+    expect(FMS_STATUS_LABELS[6]).toBe('Außer Dienst');
+    expect(FMS_STATUS_LABELS[9]).toBe('Außerhalb Funkbereich');
+  });
+
+  it('FMS_STATUS_OPTIONS enthält alle Status 0-9', () => {
+    expect(FMS_STATUS_OPTIONS).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+});
+
+describe('getStatusClasses', () => {
+  it('gibt die korrekte Farb-Klasse für bekannten Status zurück', () => {
+    expect(getStatusClasses(1)).toBe(FMS_STATUS_COLORS[1]);
+    expect(getStatusClasses(6)).toBe(FMS_STATUS_COLORS[6]);
+  });
+
+  it('gibt Fallback-Klasse für unbekannten Status zurück', () => {
+    expect(getStatusClasses(99)).toBe('bg-gray-500/15 text-gray-600 dark:bg-gray-500/25 dark:text-gray-400');
+  });
+});
+
+describe('getStatusBgClasses', () => {
+  it('extrahiert nur bg- und dark:bg- Klassen', () => {
+    const result = getStatusBgClasses(1);
+    expect(result).toContain('bg-green-500/15');
+    expect(result).toContain('dark:bg-green-500/25');
+    expect(result).not.toContain('text-');
+  });
+
+  it('gibt Fallback für unbekannten Status zurück', () => {
+    const result = getStatusBgClasses(99);
+    expect(result).toContain('bg-gray-500/15');
+  });
+});
+
+describe('getStatusBorderLeftClass', () => {
+  it('gibt Border-Farbe für bekannten Status zurück', () => {
+    expect(getStatusBorderLeftClass(0)).toBe('border-l-red-600');
+    expect(getStatusBorderLeftClass(1)).toBe('border-l-green-500');
+    expect(getStatusBorderLeftClass(5)).toBe('border-l-blue-500');
+    expect(getStatusBorderLeftClass(8)).toBe('border-l-violet-500');
+  });
+
+  it('gibt Fallback-Border für unbekannten Status zurück', () => {
+    expect(getStatusBorderLeftClass(42)).toBe('border-l-text-primary');
+  });
+
+  it('FMS_BORDER_LEFT_COLORS deckt alle Status 0-9 ab', () => {
+    for (let i = 0; i <= 9; i++) {
+      expect(FMS_BORDER_LEFT_COLORS[i]).toBeDefined();
+    }
+  });
+});
+
+describe('isFmsStatus', () => {
+  it('akzeptiert gültige Status 0-9', () => {
+    for (let i = 0; i <= 9; i++) {
+      expect(isFmsStatus(i)).toBe(true);
+    }
+  });
+
+  it('lehnt Werte außerhalb 0-9 ab', () => {
+    expect(isFmsStatus(-1)).toBe(false);
+    expect(isFmsStatus(10)).toBe(false);
+    expect(isFmsStatus(3.5)).toBe(false);
+  });
+
+  it('lehnt Nicht-Zahlen ab', () => {
+    expect(isFmsStatus('3')).toBe(false);
+    expect(isFmsStatus(null)).toBe(false);
+    expect(isFmsStatus(undefined)).toBe(false);
+    expect(isFmsStatus({})).toBe(false);
+  });
+});
+
+describe('isImEinsatzStatus', () => {
+  it('erkennt Im-Einsatz-Status (3-4)', () => {
+    expect(isImEinsatzStatus(3)).toBe(true);
+    expect(isImEinsatzStatus(4)).toBe(true);
+  });
+
+  it('lehnt andere Status ab', () => {
+    expect(isImEinsatzStatus(0)).toBe(false);
+    expect(isImEinsatzStatus(2)).toBe(false);
+    expect(isImEinsatzStatus(5)).toBe(false);
+    expect(isImEinsatzStatus(9)).toBe(false);
+  });
+});
+
+describe('isEinsatzbereitStatus', () => {
+  it('erkennt Einsatzbereit-Status (1-2)', () => {
+    expect(isEinsatzbereitStatus(1)).toBe(true);
+    expect(isEinsatzbereitStatus(2)).toBe(true);
+  });
+
+  it('lehnt andere Status ab', () => {
+    expect(isEinsatzbereitStatus(0)).toBe(false);
+    expect(isEinsatzbereitStatus(3)).toBe(false);
+    expect(isEinsatzbereitStatus(6)).toBe(false);
+  });
+});

--- a/packages/frontend/src/features/einsatz/constants/fms-status.constants.ts
+++ b/packages/frontend/src/features/einsatz/constants/fms-status.constants.ts
@@ -1,9 +1,12 @@
 /**
- * FMS-Status Labels für UI-Anzeige.
- * Story 4.3 Spezifikation + Status 0 für Story 6.1b.
+ * FMS-Status Labels für UI-Anzeige (BOS-Kontext).
+ *
+ * Grün (1,2) = verfügbar, Warm-Töne (3,4,7) = im Einsatz aktiv,
+ * Rot (0,6) = nicht verfügbar/Notfall, Blau (5) = Kommunikation,
+ * Violett (8) = Transport, Grau (9) = technisch/neutral.
  */
 export const FMS_STATUS_LABELS: Record<number, string> = {
-  0: 'Nicht einsatzbereit',
+  0: 'Notruf',
   1: 'Frei über Funk',
   2: 'Einsatzbereit auf Wache',
   3: 'Einsatz übernommen',
@@ -11,33 +14,43 @@ export const FMS_STATUS_LABELS: Record<number, string> = {
   5: 'Sprechwunsch',
   6: 'Nicht einsatzbereit',
   7: 'Patient aufgenommen',
-  8: 'Am Zielort',
-  9: 'Handfunkgerät',
+  8: 'Am Transportziel',
+  9: 'Quittung',
 };
 
 /**
- * FMS-Status Farben gemäß Story 4.3 + Status 0 für Story 6.1b.
- * Nutzt Ring-1 Design Tokens für konsistente Light-/Dark-Mode-Farben.
+ * FMS-Status Farben — praxisnahe BOS-Farbzuordnung.
+ *
+ * Nutzt Tailwind v4 Standard-Palette mit /opacity-Syntax
+ * für konsistente Light-/Dark-Mode-Darstellung.
+ *
+ * Farblogik:
+ * - Grüntöne = verfügbar (FMS 1, 2)
+ * - Warm-Töne (Gelb/Orange) = im Einsatz aktiv (FMS 3, 4, 7)
+ * - Rot = nicht verfügbar oder Notfall (FMS 0, 6)
+ * - Blau = Kommunikation (FMS 5)
+ * - Violett = Transport (FMS 8)
+ * - Grau = neutral/technisch (FMS 9)
  */
 export const FMS_STATUS_COLORS: Record<number, string> = {
-  0: 'bg-status-danger-surface text-status-danger-text',
-  1: 'bg-surface-raised text-text-primary',
-  2: 'bg-status-success-surface text-status-success-text',
-  3: 'bg-status-info-surface text-status-info-text',
-  4: 'bg-action-secondary text-action-primary',
-  5: 'bg-status-warning-surface text-status-warning-text',
-  6: 'bg-status-danger-surface text-status-danger-text',
-  7: 'bg-status-info-surface text-status-info-text',
-  8: 'bg-status-success-surface text-status-success-text',
-  9: 'bg-action-secondary text-action-primary',
+  0: 'bg-red-600/15 text-red-700 dark:bg-red-600/25 dark:text-red-400',
+  1: 'bg-green-500/15 text-green-700 dark:bg-green-500/25 dark:text-green-400',
+  2: 'bg-green-400/15 text-green-600 dark:bg-green-400/25 dark:text-green-300',
+  3: 'bg-amber-500/15 text-amber-700 dark:bg-amber-500/25 dark:text-amber-400',
+  4: 'bg-orange-500/15 text-orange-700 dark:bg-orange-500/25 dark:text-orange-400',
+  5: 'bg-blue-500/15 text-blue-700 dark:bg-blue-500/25 dark:text-blue-400',
+  6: 'bg-red-500/15 text-red-600 dark:bg-red-500/25 dark:text-red-400',
+  7: 'bg-yellow-500/15 text-yellow-700 dark:bg-yellow-500/25 dark:text-yellow-400',
+  8: 'bg-violet-500/15 text-violet-700 dark:bg-violet-500/25 dark:text-violet-400',
+  9: 'bg-gray-500/15 text-gray-600 dark:bg-gray-500/25 dark:text-gray-400',
 };
 
 /**
  * Gibt Tailwind-Klassen für einen FMS-Status zurück.
- * Fallback: grau für unbekannte Status (mit Dark Mode Support).
+ * Fallback: grau für unbekannte Status.
  */
 export const getStatusClasses = (status: number): string => {
-  return FMS_STATUS_COLORS[status] ?? 'bg-surface-raised text-text-primary';
+  return FMS_STATUS_COLORS[status] ?? 'bg-gray-500/15 text-gray-600 dark:bg-gray-500/25 dark:text-gray-400';
 };
 
 /**
@@ -45,9 +58,9 @@ export const getStatusClasses = (status: number): string => {
  * Für Status-Dots ohne Text.
  */
 export const getStatusBgClasses = (status: number): string => {
-  const colorClasses = FMS_STATUS_COLORS[status] ?? 'bg-surface-raised text-text-primary';
+  const colorClasses = FMS_STATUS_COLORS[status] ?? 'bg-gray-500/15 dark:bg-gray-500/25';
   const bgClasses = colorClasses.split(/\s+/).filter((cls) => cls.startsWith('bg-') || cls.startsWith('dark:bg-'));
-  return bgClasses.join(' ') || 'bg-surface-raised';
+  return bgClasses.join(' ') || 'bg-gray-500/15';
 };
 
 /**
@@ -78,3 +91,37 @@ export const isFmsStatus = (value: unknown): value is FmsStatus => {
  * Alle verfügbaren FMS-Status Codes (0-9).
  */
 export const FMS_STATUS_OPTIONS: readonly FmsStatus[] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+
+/**
+ * Prüft ob ein FMS-Status "Im Einsatz" bedeutet (FMS 3-4).
+ */
+export const isImEinsatzStatus = (fmsStatus: number): boolean => fmsStatus >= 3 && fmsStatus <= 4;
+
+/**
+ * Prüft ob ein FMS-Status "Einsatzbereit" bedeutet (FMS 1-2).
+ */
+export const isEinsatzbereitStatus = (fmsStatus: number): boolean => fmsStatus >= 1 && fmsStatus <= 2;
+
+/**
+ * Border-Left-Farben nach FMS-Status für Karten-Darstellung.
+ * Passt zur BOS-Farbzuordnung in FMS_STATUS_COLORS.
+ */
+export const FMS_BORDER_LEFT_COLORS: Record<number, string> = {
+  0: 'border-l-red-600',
+  1: 'border-l-green-500',
+  2: 'border-l-green-400',
+  3: 'border-l-amber-500',
+  4: 'border-l-orange-500',
+  5: 'border-l-blue-500',
+  6: 'border-l-red-500',
+  7: 'border-l-yellow-500',
+  8: 'border-l-violet-500',
+  9: 'border-l-gray-500',
+};
+
+/**
+ * Gibt die Border-Left-Klasse für einen FMS-Status zurück.
+ */
+export const getStatusBorderLeftClass = (status: number): string => {
+  return FMS_BORDER_LEFT_COLORS[status] ?? 'border-l-text-primary';
+};

--- a/packages/frontend/src/features/einsatz/constants/fms-status.constants.ts
+++ b/packages/frontend/src/features/einsatz/constants/fms-status.constants.ts
@@ -7,15 +7,15 @@
  */
 export const FMS_STATUS_LABELS: Record<number, string> = {
   0: 'Notruf',
-  1: 'Frei über Funk',
+  1: 'Einsatzbereit über Funk',
   2: 'Einsatzbereit auf Wache',
-  3: 'Einsatz übernommen',
+  3: 'Einsatzauftrag übernommen',
   4: 'Am Einsatzort',
   5: 'Sprechwunsch',
-  6: 'Nicht einsatzbereit',
+  6: 'Außer Dienst',
   7: 'Patient aufgenommen',
-  8: 'Am Transportziel',
-  9: 'Quittung',
+  8: 'Transportziel erreicht',
+  9: 'Außerhalb Funkbereich',
 };
 
 /**

--- a/packages/frontend/src/features/einsatz/index.ts
+++ b/packages/frontend/src/features/einsatz/index.ts
@@ -72,6 +72,7 @@ export {
   FMS_STATUS_LABELS,
   FMS_STATUS_COLORS,
   FMS_STATUS_OPTIONS,
+  FMS_BORDER_LEFT_COLORS,
   getStatusClasses,
   getStatusBgClasses,
   getStatusBorderLeftClass,

--- a/packages/frontend/src/features/einsatz/index.ts
+++ b/packages/frontend/src/features/einsatz/index.ts
@@ -68,7 +68,18 @@ export * from './schemas';
 // ============================================
 // Constants (Story 3-3 FMS-Status)
 // ============================================
-export { FMS_STATUS_LABELS, FMS_STATUS_COLORS, FMS_STATUS_OPTIONS, getStatusClasses, getStatusBgClasses, isFmsStatus, type FmsStatus } from './constants/fms-status.constants';
+export {
+  FMS_STATUS_LABELS,
+  FMS_STATUS_COLORS,
+  FMS_STATUS_OPTIONS,
+  getStatusClasses,
+  getStatusBgClasses,
+  getStatusBorderLeftClass,
+  isFmsStatus,
+  isImEinsatzStatus,
+  isEinsatzbereitStatus,
+  type FmsStatus,
+} from './constants/fms-status.constants';
 
 // ============================================
 // Utils (Story 4-2 QR-Code)

--- a/packages/frontend/src/features/kraefte/ui/molecules/FahrzeugFilterTabs.tsx
+++ b/packages/frontend/src/features/kraefte/ui/molecules/FahrzeugFilterTabs.tsx
@@ -1,0 +1,49 @@
+/**
+ * Filter-Tabs für die Fahrzeuge-Seite.
+ *
+ * Zeigt Tabs mit Zähler zum Filtern nach FMS-Status-Gruppen.
+ * Default: "Alle" zeigt alle Fahrzeuge.
+ */
+
+import { cn } from '@/shared/ui/cn';
+
+export type FahrzeugFilter = 'alle' | 'einsatz' | 'bereit' | 'andere';
+
+interface FahrzeugFilterTabsProps {
+  /** Aktuell aktiver Filter */
+  activeFilter: FahrzeugFilter;
+  /** Callback bei Filterwechsel */
+  onFilterChange: (filter: FahrzeugFilter) => void;
+  /** Anzahl Fahrzeuge pro Filter-Gruppe */
+  counts: Record<FahrzeugFilter, number>;
+}
+
+const FILTER_OPTIONS: Array<{ value: FahrzeugFilter; label: string }> = [
+  { value: 'alle', label: 'Alle' },
+  { value: 'einsatz', label: 'Im Einsatz' },
+  { value: 'bereit', label: 'Einsatzbereit' },
+  { value: 'andere', label: 'Weitere' },
+];
+
+export function FahrzeugFilterTabs({ activeFilter, onFilterChange, counts }: FahrzeugFilterTabsProps) {
+  return (
+    <div className="flex space-x-1 rounded-panel bg-action-secondary p-1" role="tablist" aria-label="Fahrzeuge filtern">
+      {FILTER_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          role="tab"
+          aria-selected={activeFilter === option.value}
+          onClick={() => onFilterChange(option.value)}
+          className={cn(
+            'rounded-control px-3 py-1.5 text-sm leading-5 font-medium transition-colors',
+            'focus-visible:shadow-focus-ring focus-visible:outline-none',
+            activeFilter === option.value ? 'bg-surface-panel text-text-primary shadow' : 'text-text-secondary hover:bg-action-secondary-hover hover:text-text-primary',
+          )}
+        >
+          {option.label} ({counts[option.value]})
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/features/kraefte/ui/molecules/FahrzeugGridCard.tsx
+++ b/packages/frontend/src/features/kraefte/ui/molecules/FahrzeugGridCard.tsx
@@ -1,0 +1,166 @@
+/**
+ * Kompakte Karte für das Fahrzeug-Grid (Statustableau-Stil).
+ *
+ * Zeigt Funkrufname, FMS-Status (direkt änderbar), Besatzungsanzahl
+ * und Einheit-Zuweisung. Klick auf die Karte öffnet das Detail-Panel.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+import { cn } from '@/shared/ui/cn';
+import { FmsStatusBadge } from '@/features/einsatz/ui/atoms/FmsStatusBadge.atom';
+import { isFmsStatus, getStatusBorderLeftClass, getStatusClasses, FMS_STATUS_OPTIONS, type FmsStatus } from '@/features/einsatz/constants/fms-status.constants';
+import { ZeichenPreview } from '@/features/taktische-zeichen/rendering/ZeichenPreview';
+import type { ZeichenDefinition } from '@/features/taktische-zeichen/rendering/renderer';
+import type { EinsatzFahrzeugDto } from '@/shared';
+import type { TaktischesZeichenResponseDto } from '@bluelight-hub/shared/client';
+import { PiTruck, PiUsers, PiTreeStructure } from 'react-icons/pi';
+
+interface FahrzeugGridCardProps {
+  /** Fahrzeug-Daten */
+  fahrzeug: EinsatzFahrzeugDto;
+  /** Verknüpftes taktisches Zeichen */
+  zeichen?: TaktischesZeichenResponseDto | null;
+  /** Name der zugewiesenen Einheit */
+  einheitName?: string | null;
+  /** Callback bei Klick auf die Karte (öffnet Detail-Panel) */
+  onSelect: (fahrzeugId: string) => void;
+  /** Callback bei FMS-Status-Änderung */
+  onStatusChange: (fahrzeugId: string, newStatus: FmsStatus) => void;
+}
+
+export function FahrzeugGridCard({ fahrzeug, zeichen, einheitName, onSelect, onStatusChange }: FahrzeugGridCardProps) {
+  const [showStatusDropdown, setShowStatusDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const validFmsStatus: FmsStatus = isFmsStatus(fahrzeug.fmsStatus) ? fahrzeug.fmsStatus : 0;
+  const besatzungCount = fahrzeug.besatzung?.length ?? 0;
+  const borderColor = getStatusBorderLeftClass(validFmsStatus);
+
+  const handleCardClick = useCallback(() => {
+    if (!showStatusDropdown) {
+      onSelect(fahrzeug.id);
+    }
+  }, [onSelect, fahrzeug.id, showStatusDropdown]);
+
+  const handleCardKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if ((e.key === 'Enter' || e.key === ' ') && !showStatusDropdown) {
+        e.preventDefault();
+        onSelect(fahrzeug.id);
+      }
+    },
+    [onSelect, fahrzeug.id, showStatusDropdown],
+  );
+
+  const handleStatusBadgeClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowStatusDropdown((prev) => !prev);
+  }, []);
+
+  const handleStatusChange = useCallback(
+    (newStatus: FmsStatus) => {
+      onStatusChange(fahrzeug.id, newStatus);
+      setShowStatusDropdown(false);
+    },
+    [onStatusChange, fahrzeug.id],
+  );
+
+  const handleCloseDropdown = useCallback(() => {
+    setShowStatusDropdown(false);
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        'rounded-panel border border-l-[3px] border-border-subtle bg-surface-panel p-3 shadow-panel',
+        'cursor-pointer transition-colors hover:border-border-strong hover:shadow-md',
+        borderColor,
+      )}
+      onClick={handleCardClick}
+      onKeyDown={handleCardKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={`Fahrzeug ${fahrzeug.funkrufname}, FMS ${validFmsStatus}`}
+    >
+      {/* Zeile 1: TZ/Icon + Funkrufname + FMS-Badge */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          {zeichen ? <ZeichenPreview definition={zeichen.zeichenDefinition as unknown as ZeichenDefinition} size="sm" /> : <PiTruck className="h-5 w-5 flex-shrink-0 text-text-muted" />}
+          <h3 className="truncate text-sm font-semibold text-text-primary">{fahrzeug.funkrufname}</h3>
+        </div>
+
+        {/* FMS-Badge (klickbar für Status-Änderung) */}
+        <div className="relative flex-shrink-0" ref={dropdownRef}>
+          <button
+            type="button"
+            onClick={handleStatusBadgeClick}
+            className="rounded-full focus-visible:shadow-focus-ring focus-visible:outline-none"
+            aria-label={`FMS-Status ändern, aktuell FMS ${validFmsStatus}`}
+            aria-haspopup="listbox"
+            aria-expanded={showStatusDropdown}
+          >
+            <FmsStatusBadge status={validFmsStatus} className="cursor-pointer hover:opacity-80" />
+          </button>
+
+          {showStatusDropdown && (
+            <>
+              <div className="fixed inset-0 z-10" onClick={handleCloseDropdown} onKeyDown={(e) => e.key === 'Escape' && handleCloseDropdown()} role="presentation" />
+              <div className="absolute right-0 z-20 mt-1 w-44 rounded-panel border border-border-subtle bg-surface-panel py-1 shadow-panel" onClick={(e) => e.stopPropagation()}>
+                {FMS_STATUS_OPTIONS.map((status) => (
+                  <button
+                    key={status}
+                    type="button"
+                    onClick={() => handleStatusChange(status)}
+                    className={cn(
+                      'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors hover:brightness-90 active:brightness-80',
+                      getStatusClasses(status),
+                      status === validFmsStatus ? 'font-medium' : 'font-normal',
+                    )}
+                  >
+                    <FmsStatusBadge status={status} />
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Zeile 2: Besatzung + Einheit */}
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+        {besatzungCount > 0 && (
+          <span className="inline-flex items-center gap-1">
+            <PiUsers className="h-3.5 w-3.5" />
+            {besatzungCount} {besatzungCount === 1 ? 'Person' : 'Pers.'}
+          </span>
+        )}
+
+        {einheitName && (
+          <span className="inline-flex items-center gap-1 rounded-pill bg-status-info-surface px-1.5 py-0.5 text-xs font-medium text-status-info-text">
+            <PiTreeStructure className="h-3 w-3" />
+            {einheitName}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Skeleton-Variante für Loading-State */
+export function FahrzeugGridCardSkeleton() {
+  return (
+    <div className="animate-pulse rounded-panel border border-l-[3px] border-border-subtle border-l-surface-raised bg-surface-panel p-3 shadow-panel">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <div className="h-5 w-5 rounded bg-surface-raised" />
+          <div className="h-4 w-24 rounded bg-surface-raised" />
+        </div>
+        <div className="h-5 w-14 rounded-full bg-surface-raised" />
+      </div>
+      <div className="mt-2 flex gap-2">
+        <div className="h-3 w-16 rounded bg-surface-raised" />
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/features/kraefte/ui/organisms/FahrzeugDetailPanel.tsx
+++ b/packages/frontend/src/features/kraefte/ui/organisms/FahrzeugDetailPanel.tsx
@@ -1,0 +1,102 @@
+/**
+ * Detail-Panel für ein Fahrzeug (SlideIn von rechts).
+ *
+ * Zeigt alle Fahrzeug-Informationen und ermöglicht direkte
+ * Bearbeitung von FMS-Status und Einheit-Zuweisung.
+ */
+
+import { Dialog } from '@/shared/ui/molecules/dialog.molecule';
+import { Button } from '@/shared/ui/atoms/button.atom';
+import { FmsStatusDropdown } from '@/features/einsatz/ui/molecules/FmsStatusDropdown.molecule';
+import { isFmsStatus, type FmsStatus } from '@/features/einsatz/constants/fms-status.constants';
+import { EinheitZuweisungsDropdown } from '@/features/kraefte/ui/molecules/EinheitZuweisungsDropdown';
+import { ZeichenPreview } from '@/features/taktische-zeichen/rendering/ZeichenPreview';
+import type { ZeichenDefinition } from '@/features/taktische-zeichen/rendering/renderer';
+import type { EinsatzFahrzeugDto } from '@/shared';
+import type { TaktischesZeichenResponseDto } from '@bluelight-hub/shared/client';
+import { PiMapPin, PiTruck, PiUser } from 'react-icons/pi';
+
+interface FahrzeugDetailPanelProps {
+  /** Panel geöffnet? */
+  isOpen: boolean;
+  /** Callback zum Schließen */
+  onClose: () => void;
+  /** Fahrzeug-Daten */
+  fahrzeug: EinsatzFahrzeugDto;
+  /** Verknüpftes taktisches Zeichen */
+  zeichen?: TaktischesZeichenResponseDto | null;
+  /** Verfügbare Einheiten für das Dropdown */
+  einheiten: Array<{ id: string; name: string; typ: string }>;
+  /** Callback bei FMS-Status-Änderung */
+  onStatusChange: (fahrzeugId: string, newStatus: FmsStatus) => void;
+  /** Callback bei Einheit-Zuweisung */
+  onEinheitAssign: (fahrzeugId: string, einheitId: string | null) => void;
+  /** Callback für "Zeichen bearbeiten" */
+  onManageZeichen: (fahrzeugId: string) => void;
+  /** Lädt die Einheit-Zuweisung gerade? */
+  isAssigning?: boolean;
+}
+
+export function FahrzeugDetailPanel({ isOpen, onClose, fahrzeug, zeichen, einheiten, onStatusChange, onEinheitAssign, onManageZeichen, isAssigning = false }: FahrzeugDetailPanelProps) {
+  const validFmsStatus: FmsStatus = isFmsStatus(fahrzeug.fmsStatus) ? fahrzeug.fmsStatus : 0;
+  const besatzung = fahrzeug.besatzung ?? [];
+
+  return (
+    <Dialog.SlideIn isOpen={isOpen} onClose={onClose} title={fahrzeug.funkrufname} size="sm" position="right">
+      <div className="space-y-6">
+        {/* Taktisches Zeichen Sektion */}
+        <div className="rounded-panel bg-surface-raised p-4 text-center">
+          {zeichen ? <ZeichenPreview definition={zeichen.zeichenDefinition as unknown as ZeichenDefinition} size="lg" /> : <PiTruck className="mx-auto h-16 w-16 text-text-muted opacity-50" />}
+          <div className="mt-2 space-y-0.5">
+            {fahrzeug.kennzeichen && <p className="text-sm text-text-secondary">{fahrzeug.kennzeichen}</p>}
+            {fahrzeug.fahrzeugtyp && <p className="text-xs text-text-muted">{typeof fahrzeug.fahrzeugtyp === 'object' && 'name' in fahrzeug.fahrzeugtyp ? String(fahrzeug.fahrzeugtyp.name) : ''}</p>}
+          </div>
+          <Button
+            intent="secondary"
+            appearance="outline"
+            size="sm"
+            className="mt-3"
+            onClick={() => {
+              onManageZeichen(fahrzeug.id);
+              onClose();
+            }}
+          >
+            <PiMapPin className="mr-1.5 h-3.5 w-3.5" />
+            {zeichen ? 'Zeichen bearbeiten' : 'Zeichen zuweisen'}
+          </Button>
+        </div>
+
+        {/* FMS-Status */}
+        <div>
+          <label className="mb-1.5 block text-xs font-medium tracking-wide text-text-muted uppercase">FMS-Status</label>
+          <FmsStatusDropdown value={validFmsStatus} onChange={(newStatus) => onStatusChange(fahrzeug.id, newStatus)} />
+        </div>
+
+        {/* Einheit-Zuweisung */}
+        <div>
+          <label className="mb-1.5 block text-xs font-medium tracking-wide text-text-muted uppercase">Einheit</label>
+          <EinheitZuweisungsDropdown currentEinheitId={fahrzeug.einheitId} einheiten={einheiten} onAssign={(einheitId) => onEinheitAssign(fahrzeug.id, einheitId)} isLoading={isAssigning} />
+        </div>
+
+        {/* Besatzung */}
+        <div>
+          <label className="mb-1.5 block text-xs font-medium tracking-wide text-text-muted uppercase">Besatzung ({besatzung.length})</label>
+          {besatzung.length > 0 ? (
+            <div className="space-y-1.5">
+              {besatzung.map((person) => (
+                <div key={person.id} className="flex items-center gap-2 rounded-panel bg-surface-raised px-3 py-2 text-sm text-text-secondary">
+                  <PiUser className="h-4 w-4 flex-shrink-0 text-text-muted" />
+                  <span>
+                    {person.vorname} {person.nachname}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-text-muted">Keine Besatzung zugewiesen</p>
+          )}
+        </div>
+      </div>
+    </Dialog.SlideIn>
+  );
+}

--- a/packages/frontend/src/features/kraefte/ui/organisms/FahrzeugZeichenPanel.tsx
+++ b/packages/frontend/src/features/kraefte/ui/organisms/FahrzeugZeichenPanel.tsx
@@ -62,12 +62,15 @@ export function FahrzeugZeichenPanel({ isOpen, onClose, einsatzId, fahrzeugId, f
     (definition: ZeichenDefinition, label: string) => {
       if (zeichen) {
         // Bestehendes Zeichen aktualisieren
-        updateZeichen({
-          dto: {
-            zeichenDefinition: definition as unknown as ZeichenDefinitionRequestDto,
-            label: label || undefined,
+        updateZeichen(
+          {
+            dto: {
+              zeichenDefinition: definition as unknown as ZeichenDefinitionRequestDto,
+              label: label || undefined,
+            },
           },
-        });
+          { onSuccess: onClose },
+        );
       } else {
         // Neues Zeichen erstellen mit Fahrzeug-Verknüpfung
         createZeichenMutation(
@@ -80,12 +83,13 @@ export function FahrzeugZeichenPanel({ isOpen, onClose, einsatzId, fahrzeugId, f
           {
             onSuccess: () => {
               queryClient.invalidateQueries({ queryKey: KRAEFTE_QUERY_KEYS.fahrzeugZeichen(einsatzId, fahrzeugId) });
+              onClose();
             },
           },
         );
       }
     },
-    [zeichen, updateZeichen, createZeichenMutation, fahrzeugId, queryClient, einsatzId],
+    [zeichen, updateZeichen, createZeichenMutation, fahrzeugId, queryClient, einsatzId, onClose],
   );
 
   return (

--- a/packages/frontend/src/features/kraefte/ui/organisms/__tests__/FahrzeugZeichenPanel.spec.tsx
+++ b/packages/frontend/src/features/kraefte/ui/organisms/__tests__/FahrzeugZeichenPanel.spec.tsx
@@ -4,8 +4,8 @@
  * Prüft Rendering-Zustände: Loading, Empty State, Zeichen vorhanden, nicht platziert.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FahrzeugZeichenPanel } from '../FahrzeugZeichenPanel';
 
@@ -13,11 +13,13 @@ import { FahrzeugZeichenPanel } from '../FahrzeugZeichenPanel';
 // Mocks
 // ============================================
 
-const { mockZeichenState } = vi.hoisted(() => ({
+const { mockZeichenState, mockUpdateMutate, mockCreateMutate } = vi.hoisted(() => ({
   mockZeichenState: {
     data: undefined as any,
     isLoading: false,
   },
+  mockUpdateMutate: vi.fn(),
+  mockCreateMutate: vi.fn(),
 }));
 
 vi.mock('@/features/kraefte/api/use-fahrzeug-zeichen', () => ({
@@ -25,11 +27,11 @@ vi.mock('@/features/kraefte/api/use-fahrzeug-zeichen', () => ({
 }));
 
 vi.mock('@/features/kraefte/api/use-update-fahrzeug-zeichen', () => ({
-  useUpdateFahrzeugZeichen: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateFahrzeugZeichen: () => ({ mutate: mockUpdateMutate, isPending: false }),
 }));
 
 vi.mock('@/features/taktische-zeichen/api/use-create-zeichen', () => ({
-  useCreateZeichen: () => ({ mutate: vi.fn(), isPending: false }),
+  useCreateZeichen: () => ({ mutate: mockCreateMutate, isPending: false }),
 }));
 
 vi.mock('@/features/taktische-zeichen/rendering/ZeichenPreview', () => ({
@@ -37,7 +39,14 @@ vi.mock('@/features/taktische-zeichen/rendering/ZeichenPreview', () => ({
 }));
 
 vi.mock('@/features/taktische-zeichen/ui/molecules/ZeichenEditor', () => ({
-  ZeichenEditor: ({ initialLabel }: any) => <div data-testid="zeichen-editor">Editor: {initialLabel}</div>,
+  ZeichenEditor: ({ initialLabel, onSave }: any) => (
+    <div data-testid="zeichen-editor">
+      Editor: {initialLabel}
+      <button data-testid="save-trigger" onClick={() => onSave({ grundzeichen: 'kraftfahrzeug-landgebunden' }, 'Label')}>
+        save
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@/shared/ui/atoms/LoadingState', () => ({
@@ -77,6 +86,11 @@ function renderPanel(overrides = {}) {
 }
 
 describe('FahrzeugZeichenPanel', () => {
+  beforeEach(() => {
+    mockUpdateMutate.mockReset();
+    mockCreateMutate.mockReset();
+  });
+
   it('rendert nicht wenn isOpen=false', () => {
     mockZeichenState.data = undefined;
     mockZeichenState.isLoading = false;
@@ -146,5 +160,39 @@ describe('FahrzeugZeichenPanel', () => {
 
     renderPanel();
     expect(screen.getByTestId('zeichen-editor')).toHaveTextContent('Editor: KTW 1');
+  });
+
+  it('schließt Panel nach erfolgreichem Erstellen eines Zeichens', () => {
+    mockZeichenState.data = undefined;
+    mockZeichenState.isLoading = false;
+    const onClose = vi.fn();
+
+    renderPanel({ onClose });
+    fireEvent.click(screen.getByTestId('save-trigger'));
+
+    expect(mockCreateMutate).toHaveBeenCalledTimes(1);
+    const onSuccess = mockCreateMutate.mock.calls[0][1].onSuccess;
+    onSuccess();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('schließt Panel nach erfolgreichem Aktualisieren eines Zeichens', () => {
+    mockZeichenState.data = {
+      id: 'z-1',
+      label: 'Existierend',
+      lat: 50.1,
+      lng: 10.5,
+      zeichenDefinition: { grundzeichen: 'kraftfahrzeug-landgebunden' },
+    };
+    mockZeichenState.isLoading = false;
+    const onClose = vi.fn();
+
+    renderPanel({ onClose });
+    fireEvent.click(screen.getByTestId('save-trigger'));
+
+    expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+    const onSuccess = mockUpdateMutate.mock.calls[0][1].onSuccess;
+    onSuccess();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/frontend/src/routes/app/einsatz/$einsatzId/kräfte/fahrzeuge.tsx
+++ b/packages/frontend/src/routes/app/einsatz/$einsatzId/kräfte/fahrzeuge.tsx
@@ -1,8 +1,8 @@
 /**
- * Fahrzeuge-Verwaltung Route (Story 4-3)
+ * Fahrzeuge-Verwaltung Route
  *
- * Zeigt alle Fahrzeuge eines Einsatzes mit FMS-Status und Besatzung.
- * Ermöglicht Hinzufügen neuer Fahrzeuge und FMS-Status-Verwaltung.
+ * Zeigt alle Fahrzeuge eines Einsatzes als Karten-Grid (Statustableau-Stil).
+ * Klick auf FMS-Badge ändert Status direkt, Klick auf Karte öffnet Detail-Panel.
  */
 
 import { createFileRoute, useParams } from '@tanstack/react-router';
@@ -10,19 +10,18 @@ import { EinsatzRolleGate } from '@/features/einsatz/ui/molecules/EinsatzRolleGa
 import { useEinsatzFahrzeuge, useUpdateFmsStatus } from '@/features/einsatz/api';
 import { useEinsatzEinheiten, useAssignFahrzeugZuEinheit } from '@/features/kraefte/api';
 import { useEinsatzZeichen } from '@/features/taktische-zeichen';
-import { EinheitZuweisungsDropdown } from '@/features/kraefte/ui/molecules/EinheitZuweisungsDropdown';
 import { FahrzeugHinzufuegenDialog } from '@/features/einsatz/ui/organisms/FahrzeugHinzufuegenDialog.organism';
 import { FahrzeugZeichenPanel } from '@/features/kraefte/ui/organisms/FahrzeugZeichenPanel';
-import { EinsatzResourceWidget } from '@/features/einsatz/ui/molecules/EinsatzResourceWidget';
-import { ZeichenPreview } from '@/features/taktische-zeichen/rendering/ZeichenPreview';
-import type { ZeichenDefinition } from '@/features/taktische-zeichen/rendering/renderer';
+import { FahrzeugDetailPanel } from '@/features/kraefte/ui/organisms/FahrzeugDetailPanel';
+import { FahrzeugGridCard, FahrzeugGridCardSkeleton } from '@/features/kraefte/ui/molecules/FahrzeugGridCard';
+import { FahrzeugFilterTabs, type FahrzeugFilter } from '@/features/kraefte/ui/molecules/FahrzeugFilterTabs';
 import type { TaktischesZeichenResponseDto } from '@bluelight-hub/shared/client';
 import { Button } from '@/shared/ui/atoms/button.atom';
 import { LoadingState } from '@/shared/ui/atoms/LoadingState';
 import { ErrorState } from '@/shared/ui/atoms/ErrorState';
-import type { FmsStatus } from '@/features/einsatz';
+import { isImEinsatzStatus, isEinsatzbereitStatus, type FmsStatus } from '@/features/einsatz';
 import { useState, useCallback, useMemo } from 'react';
-import { PiMapPin, PiTruck, PiUsers, PiUser, PiGauge } from 'react-icons/pi';
+import { PiTruck, PiUsers, PiUser, PiGauge } from 'react-icons/pi';
 
 export const Route = createFileRoute('/app/einsatz/$einsatzId/kräfte/fahrzeuge')({
   component: RouteComponent,
@@ -39,23 +38,23 @@ function RouteComponent() {
 }
 
 function FahrzeugeContent({ einsatzId }: { einsatzId: string }) {
-  // State für Dialog
+  // === Dialog/Panel States ===
   const [showFahrzeugDialog, setShowFahrzeugDialog] = useState(false);
-  const handleOpenFahrzeugDialog = useCallback(() => setShowFahrzeugDialog(true), []);
-  const handleCloseFahrzeugDialog = useCallback(() => setShowFahrzeugDialog(false), []);
-
-  // State für Zeichen-Panel
+  const [selectedFahrzeugId, setSelectedFahrzeugId] = useState<string | null>(null);
   const [zeichenPanelFahrzeugId, setZeichenPanelFahrzeugId] = useState<string | null>(null);
-  const handleOpenZeichen = useCallback((fahrzeugId: string) => setZeichenPanelFahrzeugId(fahrzeugId), []);
-  const handleCloseZeichen = useCallback(() => setZeichenPanelFahrzeugId(null), []);
-
-  // State für Einheit-Zuweisungs-Race-Condition-Guard
+  const [activeFilter, setActiveFilter] = useState<FahrzeugFilter>('alle');
   const [assigningFahrzeugIds, setAssigningFahrzeugIds] = useState<Set<string>>(new Set());
 
-  // Daten laden
+  // === Daten laden ===
   const { data: fahrzeuge = [], isLoading, error } = useEinsatzFahrzeuge(einsatzId);
   const { data: einheiten = [] } = useEinsatzEinheiten(einsatzId);
   const { data: alleZeichen = [] } = useEinsatzZeichen(einsatzId);
+
+  // === Mutations ===
+  const updateFmsStatus = useUpdateFmsStatus(einsatzId);
+  const assignToEinheit = useAssignFahrzeugZuEinheit(einsatzId);
+
+  // === Abgeleitete Daten ===
 
   /** Taktische Zeichen nach Fahrzeug-ID indexiert */
   const zeichenByFahrzeug = useMemo(() => {
@@ -68,14 +67,72 @@ function FahrzeugeContent({ einsatzId }: { einsatzId: string }) {
     return map;
   }, [alleZeichen]);
 
-  /** Fahrzeug-Daten für das aktuell geöffnete Zeichen-Panel */
-  const zeichenPanelFahrzeug = fahrzeuge.find((f) => f.id === zeichenPanelFahrzeugId);
+  /** Einheiten-Map für schnellen Namens-Lookup */
+  const einheitenMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const e of einheiten) {
+      map.set(e.id, e.name);
+    }
+    return map;
+  }, [einheiten]);
 
-  // Mutations
-  const updateFmsStatus = useUpdateFmsStatus(einsatzId);
-  const assignToEinheit = useAssignFahrzeugZuEinheit(einsatzId);
+  /** Einheiten-Optionen für Dropdowns */
+  const einheitenOptions = useMemo(() => einheiten.map((e) => ({ id: e.id, name: e.name, typ: e.typ })), [einheiten]);
 
-  // Handler für FMS-Status Änderungen
+  /** Filter-Zähler */
+  const filterCounts = useMemo(
+    () => ({
+      alle: fahrzeuge.length,
+      einsatz: fahrzeuge.filter((f) => isImEinsatzStatus(f.fmsStatus)).length,
+      bereit: fahrzeuge.filter((f) => isEinsatzbereitStatus(f.fmsStatus)).length,
+      andere: fahrzeuge.filter((f) => !isImEinsatzStatus(f.fmsStatus) && !isEinsatzbereitStatus(f.fmsStatus)).length,
+    }),
+    [fahrzeuge],
+  );
+
+  /** Gefilterte Fahrzeuge */
+  const filteredFahrzeuge = useMemo(() => {
+    switch (activeFilter) {
+      case 'einsatz':
+        return fahrzeuge.filter((f) => isImEinsatzStatus(f.fmsStatus));
+      case 'bereit':
+        return fahrzeuge.filter((f) => isEinsatzbereitStatus(f.fmsStatus));
+      case 'andere':
+        return fahrzeuge.filter((f) => !isImEinsatzStatus(f.fmsStatus) && !isEinsatzbereitStatus(f.fmsStatus));
+      default:
+        return fahrzeuge;
+    }
+  }, [fahrzeuge, activeFilter]);
+
+  /** Statistiken */
+  const stats = useMemo(() => {
+    const total = fahrzeuge.length;
+    const active = fahrzeuge.filter((f) => isImEinsatzStatus(f.fmsStatus)).length;
+    const totalBesatzung = fahrzeuge.reduce((sum, f) => sum + (f.besatzung?.length || 0), 0);
+    const avgBesatzung = total > 0 ? (totalBesatzung / total).toFixed(1) : '0';
+    return { total, active, totalBesatzung, avgBesatzung };
+  }, [fahrzeuge]);
+
+  /** Ausgewähltes Fahrzeug für das Detail-Panel */
+  const selectedFahrzeug = selectedFahrzeugId ? fahrzeuge.find((f) => f.id === selectedFahrzeugId) : null;
+
+  /** Fahrzeug für das Zeichen-Panel */
+  const zeichenPanelFahrzeug = zeichenPanelFahrzeugId ? fahrzeuge.find((f) => f.id === zeichenPanelFahrzeugId) : null;
+
+  // === Handler ===
+
+  const handleOpenFahrzeugDialog = useCallback(() => setShowFahrzeugDialog(true), []);
+  const handleCloseFahrzeugDialog = useCallback(() => setShowFahrzeugDialog(false), []);
+
+  const handleSelectFahrzeug = useCallback((fahrzeugId: string) => setSelectedFahrzeugId(fahrzeugId), []);
+  const handleCloseDetail = useCallback(() => setSelectedFahrzeugId(null), []);
+
+  const handleOpenZeichen = useCallback((fahrzeugId: string) => {
+    setSelectedFahrzeugId(null);
+    setZeichenPanelFahrzeugId(fahrzeugId);
+  }, []);
+  const handleCloseZeichen = useCallback(() => setZeichenPanelFahrzeugId(null), []);
+
   const handleStatusChange = useCallback(
     (fahrzeugId: string, newStatus: FmsStatus) => {
       updateFmsStatus.mutate({ fahrzeugId, fmsStatus: newStatus });
@@ -83,30 +140,28 @@ function FahrzeugeContent({ einsatzId }: { einsatzId: string }) {
     [updateFmsStatus],
   );
 
-  // Handler für Einheit-Zuweisung (Race-Condition-Guard mit funktionalem setState)
   const handleEinheitAssign = useCallback(
     (fahrzeugId: string, einheitId: string | null) => {
-      setAssigningFahrzeugIds((prev) => {
-        if (prev.has(fahrzeugId)) return prev;
-        const next = new Set(prev).add(fahrzeugId);
-        const onSettled = () => {
-          setAssigningFahrzeugIds((p) => {
-            const n = new Set(p);
-            n.delete(fahrzeugId);
-            return n;
-          });
-        };
-        assignToEinheit.mutate({ fahrzeugId, einheitId }, { onSettled });
-        return next;
-      });
+      if (assigningFahrzeugIds.has(fahrzeugId)) return;
+      setAssigningFahrzeugIds((prev) => new Set(prev).add(fahrzeugId));
+      assignToEinheit.mutate(
+        { fahrzeugId, einheitId },
+        {
+          onSettled: () => {
+            setAssigningFahrzeugIds((p) => {
+              const n = new Set(p);
+              n.delete(fahrzeugId);
+              return n;
+            });
+          },
+        },
+      );
     },
-    [assignToEinheit],
+    [assignToEinheit, assigningFahrzeugIds],
   );
 
-  /** Einheiten-Daten für das Dropdown aufbereiten */
-  const einheitenOptions = einheiten.map((e) => ({ id: e.id, name: e.name, typ: e.typ }));
+  // === Loading & Error ===
 
-  // Loading State
   if (isLoading) {
     return (
       <div className="flex h-96 items-center justify-center">
@@ -115,21 +170,9 @@ function FahrzeugeContent({ einsatzId }: { einsatzId: string }) {
     );
   }
 
-  // Error State
   if (error) {
     return <ErrorState title="Fehler beim Laden" description="Die Fahrzeugdaten konnten nicht geladen werden." />;
   }
-
-  // Statistiken berechnen
-  const totalFahrzeuge = fahrzeuge.length;
-  const activeFahrzeuge = fahrzeuge.filter((f) => f.fmsStatus >= 3 && f.fmsStatus <= 4).length;
-  const totalBesatzung = fahrzeuge.reduce((sum, f) => sum + (f.besatzung?.length || 0), 0);
-  const durchschnittBesatzung = totalFahrzeuge > 0 ? (totalBesatzung / totalFahrzeuge).toFixed(1) : '0';
-
-  // Fahrzeuge nach Status gruppieren
-  const fahrzeugeImEinsatz = fahrzeuge.filter((f) => f.fmsStatus >= 3 && f.fmsStatus <= 4);
-  const fahrzeugeBereit = fahrzeuge.filter((f) => f.fmsStatus === 2);
-  const fahrzeugeAndere = fahrzeuge.filter((f) => f.fmsStatus < 2 || f.fmsStatus > 4);
 
   return (
     <div className="space-y-4">
@@ -137,7 +180,7 @@ function FahrzeugeContent({ einsatzId }: { einsatzId: string }) {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-text-primary">Fahrzeuge</h1>
-          <p className="mt-1 text-sm text-text-muted">Verwalten Sie die eingesetzten Fahrzeuge und deren Status</p>
+          <p className="mt-1 text-sm text-text-secondary">Verwalten Sie die eingesetzten Fahrzeuge und deren Status</p>
         </div>
         <Button intent="primary" onClick={handleOpenFahrzeugDialog}>
           <PiTruck className="mr-2 h-4 w-4" />
@@ -147,203 +190,98 @@ function FahrzeugeContent({ einsatzId }: { einsatzId: string }) {
 
       {/* Statistiken */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-        <div className="rounded-lg bg-surface-panel p-4 shadow-sm">
+        <div className="rounded-panel bg-surface-panel p-4 shadow-sm">
           <div className="flex items-center gap-3">
             <div className="rounded-lg bg-status-info-surface p-3">
               <PiTruck className="h-6 w-6 text-status-info-text" />
             </div>
             <div>
-              <p className="text-2xl font-semibold text-text-primary">{totalFahrzeuge}</p>
+              <p className="text-2xl font-semibold text-text-primary">{stats.total}</p>
               <p className="text-sm text-text-muted">Gesamt</p>
             </div>
           </div>
         </div>
 
-        <div className="rounded-lg bg-surface-panel p-4 shadow-sm">
+        <div className="rounded-panel bg-surface-panel p-4 shadow-sm">
           <div className="flex items-center gap-3">
             <div className="rounded-panel bg-status-success-surface p-3">
               <PiGauge className="h-6 w-6 text-status-success-text" />
             </div>
             <div>
-              <p className="text-2xl font-semibold text-text-primary">{activeFahrzeuge}</p>
+              <p className="text-2xl font-semibold text-text-primary">{stats.active}</p>
               <p className="text-sm text-text-muted">Im Einsatz</p>
             </div>
           </div>
         </div>
 
-        <div className="rounded-lg bg-surface-panel p-4 shadow-sm">
+        <div className="rounded-panel bg-surface-panel p-4 shadow-sm">
           <div className="flex items-center gap-3">
             <div className="rounded-panel bg-status-info-surface p-3">
               <PiUsers className="h-6 w-6 text-status-info-text" />
             </div>
             <div>
-              <p className="text-2xl font-semibold text-text-primary">{totalBesatzung}</p>
+              <p className="text-2xl font-semibold text-text-primary">{stats.totalBesatzung}</p>
               <p className="text-sm text-text-muted">Personen</p>
             </div>
           </div>
         </div>
 
-        <div className="rounded-lg bg-surface-panel p-4 shadow-sm">
+        <div className="rounded-panel bg-surface-panel p-4 shadow-sm">
           <div className="flex items-center gap-3">
             <div className="rounded-panel bg-status-warning-surface p-3">
               <PiUser className="h-6 w-6 text-status-warning-text" />
             </div>
             <div>
-              <p className="text-2xl font-semibold text-text-primary">{durchschnittBesatzung}</p>
+              <p className="text-2xl font-semibold text-text-primary">{stats.avgBesatzung}</p>
               <p className="text-sm text-text-muted">Ø Besatzung</p>
             </div>
           </div>
         </div>
       </div>
 
-      {/* Fahrzeug-Widget (Story 3-3 Pattern) */}
-      <EinsatzResourceWidget
-        fahrzeuge={fahrzeuge}
-        onStatusChange={handleStatusChange}
-        onAddResource={handleOpenFahrzeugDialog}
-        zeichenByFahrzeug={zeichenByFahrzeug}
-        onManageZeichen={handleOpenZeichen}
-      />
+      {/* Filter-Tabs */}
+      <FahrzeugFilterTabs activeFilter={activeFilter} onFilterChange={setActiveFilter} counts={filterCounts} />
 
-      {/* Detaillierte Fahrzeug-Liste nach Status gruppiert */}
-      {totalFahrzeuge > 0 && (
-        <div className="space-y-4">
-          {/* Im Einsatz (FMS 3-4) */}
-          {fahrzeugeImEinsatz.length > 0 && (
-            <div className="rounded-panel bg-surface-panel shadow-sm">
-              <div className="border-b border-status-success-border bg-status-success-surface px-4 py-3">
-                <h3 className="text-sm font-semibold text-status-success-text">Im Einsatz ({fahrzeugeImEinsatz.length})</h3>
-              </div>
-              <div className="divide-y divide-border-subtle">
-                {fahrzeugeImEinsatz.map((fahrzeug) => {
-                  const zeichen = zeichenByFahrzeug.get(fahrzeug.id);
-                  return (
-                    <div key={fahrzeug.id} className="px-4 py-4">
-                      <div className="flex items-start justify-between">
-                        <div className="flex-1">
-                          <div className="flex items-center gap-3">
-                            {zeichen ? <ZeichenPreview definition={zeichen.zeichenDefinition as unknown as ZeichenDefinition} size="sm" /> : <PiTruck className="h-5 w-5 text-text-muted" />}
-                            <div>
-                              <p className="font-medium text-text-primary">{fahrzeug.funkrufname}</p>
-                              {fahrzeug.kennzeichen && <p className="text-sm text-text-muted">{fahrzeug.kennzeichen}</p>}
-                            </div>
-                            <Button
-                              intent="secondary"
-                              appearance="ghost"
-                              size="icon"
-                              onClick={() => handleOpenZeichen(fahrzeug.id)}
-                              title="Taktisches Zeichen"
-                              aria-label="Taktisches Zeichen verwalten"
-                            >
-                              <PiMapPin className="h-4 w-4" />
-                            </Button>
-                          </div>
-                          {fahrzeug.besatzung && fahrzeug.besatzung.length > 0 && (
-                            <div className="mt-2 ml-8">
-                              <p className="mb-1 text-xs font-medium text-text-secondary">Besatzung ({fahrzeug.besatzung.length}):</p>
-                              <div className="flex flex-wrap gap-2">
-                                {fahrzeug.besatzung.map((person) => (
-                                  <span key={person.id} className="inline-flex items-center gap-1.5 rounded-control bg-surface-raised px-2.5 py-1 text-xs text-text-secondary">
-                                    <PiUser className="h-3 w-3" />
-                                    {person.vorname} {person.nachname}
-                                  </span>
-                                ))}
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                        <div className="w-48 flex-shrink-0">
-                          <EinheitZuweisungsDropdown
-                            currentEinheitId={fahrzeug.einheitId}
-                            einheiten={einheitenOptions}
-                            onAssign={(einheitId) => handleEinheitAssign(fahrzeug.id, einheitId)}
-                            isLoading={assigningFahrzeugIds.has(fahrzeug.id)}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* Bereit (FMS 2) */}
-          {fahrzeugeBereit.length > 0 && (
-            <div className="rounded-panel bg-surface-panel shadow-sm">
-              <div className="border-b border-status-info-border bg-status-info-surface px-4 py-3">
-                <h3 className="text-sm font-semibold text-status-info-text">Einsatzbereit ({fahrzeugeBereit.length})</h3>
-              </div>
-              <div className="divide-y divide-border-subtle">
-                {fahrzeugeBereit.map((fahrzeug) => {
-                  const zeichen = zeichenByFahrzeug.get(fahrzeug.id);
-                  return (
-                    <div key={fahrzeug.id} className="px-4 py-4">
-                      <div className="flex items-start justify-between">
-                        <div className="flex items-center gap-3">
-                          {zeichen ? <ZeichenPreview definition={zeichen.zeichenDefinition as unknown as ZeichenDefinition} size="sm" /> : <PiTruck className="h-5 w-5 text-text-muted" />}
-                          <div>
-                            <p className="font-medium text-text-primary">{fahrzeug.funkrufname}</p>
-                            {fahrzeug.kennzeichen && <p className="text-sm text-text-muted">{fahrzeug.kennzeichen}</p>}
-                          </div>
-                          <Button intent="secondary" appearance="ghost" size="icon" onClick={() => handleOpenZeichen(fahrzeug.id)} title="Taktisches Zeichen" aria-label="Taktisches Zeichen verwalten">
-                            <PiMapPin className="h-4 w-4" />
-                          </Button>
-                        </div>
-                        <div className="w-48 flex-shrink-0">
-                          <EinheitZuweisungsDropdown
-                            currentEinheitId={fahrzeug.einheitId}
-                            einheiten={einheitenOptions}
-                            onAssign={(einheitId) => handleEinheitAssign(fahrzeug.id, einheitId)}
-                            isLoading={assigningFahrzeugIds.has(fahrzeug.id)}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* Andere Status */}
-          {fahrzeugeAndere.length > 0 && (
-            <div className="rounded-panel bg-surface-panel shadow-sm">
-              <div className="border-b border-border-subtle bg-surface-raised px-4 py-3">
-                <h3 className="text-sm font-semibold text-text-primary">Weitere Fahrzeuge ({fahrzeugeAndere.length})</h3>
-              </div>
-              <div className="divide-y divide-border-subtle">
-                {fahrzeugeAndere.map((fahrzeug) => {
-                  const zeichen = zeichenByFahrzeug.get(fahrzeug.id);
-                  return (
-                    <div key={fahrzeug.id} className="px-4 py-4">
-                      <div className="flex items-start justify-between">
-                        <div className="flex items-center gap-3">
-                          {zeichen ? <ZeichenPreview definition={zeichen.zeichenDefinition as unknown as ZeichenDefinition} size="sm" /> : <PiTruck className="h-5 w-5 text-text-muted" />}
-                          <div>
-                            <p className="font-medium text-text-primary">{fahrzeug.funkrufname}</p>
-                            {fahrzeug.kennzeichen && <p className="text-sm text-text-muted">{fahrzeug.kennzeichen}</p>}
-                          </div>
-                          <Button intent="secondary" appearance="ghost" size="icon" onClick={() => handleOpenZeichen(fahrzeug.id)} title="Taktisches Zeichen" aria-label="Taktisches Zeichen verwalten">
-                            <PiMapPin className="h-4 w-4" />
-                          </Button>
-                        </div>
-                        <div className="w-48 flex-shrink-0">
-                          <EinheitZuweisungsDropdown
-                            currentEinheitId={fahrzeug.einheitId}
-                            einheiten={einheitenOptions}
-                            onAssign={(einheitId) => handleEinheitAssign(fahrzeug.id, einheitId)}
-                            isLoading={assigningFahrzeugIds.has(fahrzeug.id)}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+      {/* Karten-Grid */}
+      {filteredFahrzeuge.length > 0 ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filteredFahrzeuge.map((fahrzeug) => (
+            <FahrzeugGridCard
+              key={fahrzeug.id}
+              fahrzeug={fahrzeug}
+              zeichen={zeichenByFahrzeug.get(fahrzeug.id)}
+              einheitName={fahrzeug.einheitId ? einheitenMap.get(fahrzeug.einheitId) : null}
+              onSelect={handleSelectFahrzeug}
+              onStatusChange={handleStatusChange}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-panel bg-surface-panel py-12 text-center shadow-sm">
+          <PiTruck className="mx-auto mb-3 h-12 w-12 text-text-muted opacity-50" />
+          <p className="text-sm text-text-muted">{activeFilter === 'alle' ? 'Noch keine Fahrzeuge zugeordnet' : 'Keine Fahrzeuge in dieser Kategorie'}</p>
+          {activeFilter === 'alle' && (
+            <Button appearance="outline" size="sm" className="mt-4" onClick={handleOpenFahrzeugDialog}>
+              <PiTruck className="mr-2 h-4 w-4" />
+              Erstes Fahrzeug hinzufügen
+            </Button>
           )}
         </div>
+      )}
+
+      {/* Detail-Panel */}
+      {selectedFahrzeug && (
+        <FahrzeugDetailPanel
+          isOpen={!!selectedFahrzeugId}
+          onClose={handleCloseDetail}
+          fahrzeug={selectedFahrzeug}
+          zeichen={zeichenByFahrzeug.get(selectedFahrzeug.id)}
+          einheiten={einheitenOptions}
+          onStatusChange={handleStatusChange}
+          onEinheitAssign={handleEinheitAssign}
+          onManageZeichen={handleOpenZeichen}
+          isAssigning={assigningFahrzeugIds.has(selectedFahrzeug.id)}
+        />
       )}
 
       {/* Fahrzeug hinzufügen Dialog */}


### PR DESCRIPTION
## Summary

- Komplette Neugestaltung der Fahrzeuge-Seite von gruppierten Listen zu responsivem Karten-Grid (Statustableau-Stil)
- FMS-Status-Farbschema auf praxisnahe BOS-Zuordnung umgestellt (Tailwind v4 Palette)
- Detail-Panel (Slide-Over) und Filter-Tabs für schnelle Status-Navigation hinzugefügt

## Changes

### Frontend
- **Fahrzeuge Route** (`fahrzeuge.tsx`): Listenansicht durch `FahrzeugGridCard`-Karten im Grid ersetzt, Filter-Tabs und Detail-Panel integriert
- **FahrzeugGridCard** (neu): Kompakte Fahrzeug-Karte mit FMS-Badge, Einheit, Besatzungszähler und Zeichen-Preview
- **FahrzeugFilterTabs** (neu): Tab-Leiste mit Zählern (Alle / Im Einsatz / Einsatzbereit / Andere)
- **FahrzeugDetailPanel** (neu): Slide-Over mit vollständigen Fahrzeugdetails, Einheit-Zuweisung und FMS-Status-Wechsel
- **FMS-Status Constants**: Labels, Farben und Border-Klassen auf BOS-Standard aktualisiert; neue Helpers `isImEinsatzStatus`, `isEinsatzbereitStatus`, `getStatusBorderLeftClass`
- **FahrzeugZeichenPanel**: Panel schließt nun nach erfolgreichem Speichern automatisch

### Docs
- Design-Spec für das Fahrzeuge-Seiten-Redesign hinzugefügt

## Test plan

- [ ] Fahrzeuge-Seite öffnen — Karten-Grid wird korrekt dargestellt
- [ ] Filter-Tabs umschalten — Fahrzeuge werden korrekt gefiltert
- [ ] Klick auf Karte — Detail-Panel öffnet sich
- [ ] FMS-Badge klicken — Status ändert sich direkt (ohne Detail-Panel)
- [ ] Detail-Panel: Einheit zuweisen/ändern
- [ ] Detail-Panel: Taktisches Zeichen verwalten → Zeichen-Panel öffnet, Detail-Panel schließt
- [ ] Zeichen-Panel: Speichern → Panel schließt automatisch
- [ ] Responsive: Mobile (1 Spalte), Tablet (2 Spalten), Desktop (3 Spalten)
- [ ] Dark Mode: Alle FMS-Farben und Karten korrekt dargestellt

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)