### PR TITLE
📝(docs): Zielgruppe auf weiße Hilfsorganisationen präzisieren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Projekt-Überblick
 
-Bluelight Hub ist eine **Web + Tauri Desktop App** für Blaulicht-Organisationen (Katastrophenschutz).
+Bluelight Hub ist eine **Web + Tauri Desktop App** für **weiße Hilfsorganisationen** im Sanitätsdienst und Katastrophenschutz (DRK, JUH, MHD, ASB, DLRG). **Explizit nicht für Feuerwehr** — fachliche Annahmen, Terminologie, Rollen- und Zeichen-Modelle orientieren sich am Sanitäts-/KatS-Kontext der weißen HiOrgs. (FW-/THW-Zeichen werden im Taktische-Zeichen-Katalog aus Interop-Gründen unterstützt, bestimmen aber nicht die Zielgruppe.)
 
 | Package          | Stack                        | Beschreibung                                                             |
 | ---------------- | ---------------------------- | ------------------------------------------------------------------------ |

--- a/docs/project-documentation/00-index.md
+++ b/docs/project-documentation/00-index.md
@@ -1,6 +1,6 @@
 # Bluelight Hub — Dokumentationsindex
 
-> **Projekt:** Bluelight Hub — Einsatzverwaltung für Blaulicht-Organisationen (Katastrophenschutz, Rettungsdienst, Feuerwehr)
+> **Projekt:** Bluelight Hub — Einsatzverwaltung für **weiße Hilfsorganisationen** (DRK, JUH, MHD, ASB, DLRG) im Sanitätsdienst und Katastrophenschutz. **Explizit nicht für Feuerwehr.**
 > **Version:** siehe `CHANGELOG.md` (aktuell: `1.0.0-alpha.102`)
 > **Generiert:** 2026-04-17
 > **Quelle:** Projekt-Scan v1.2.0 (Exhaustive, Agent-basiert)
@@ -73,7 +73,15 @@ pnpm run generate-api                                  # OpenAPI-Client regeneri
 
 ## Fachlicher Kontext
 
-Bluelight Hub unterstützt **Blaulicht-Organisationen** (DRK, Feuerwehr, Rettungsdienst, THW) bei der strukturierten Dokumentation und Koordination von Einsätzen:
+### Zielgruppe
+
+Bluelight Hub richtet sich **explizit an weiße Hilfsorganisationen** (DRK, JUH, MHD, ASB, DLRG) im Sanitätsdienst und Katastrophenschutz. Die Fachdomäne — Rollen, Einheitenstruktur, Führungsrhythmus, ETB-Kontexte, Kräfte-Modell und Default-Taktische-Zeichen — ist auf diesen Einsatzbereich zugeschnitten (Sanitätsdienst, Betreuungsdienst, SEG, KatS-Zug, Führungsgruppen).
+
+**Nicht die Zielgruppe:** Feuerwehr (kein Brandschutz-/Technische-Hilfeleistung-Fokus, keine FwDV-konforme Einsatzabwicklung), Polizei, Bundeswehr. FW-/THW-Zeichen im Taktische-Zeichen-Katalog existieren ausschließlich für Interoperabilität auf der Lagekarte (überörtliche Einsätze mit gemischten Kräften) und prägen weder Rollen-Modell noch Workflows.
+
+### Fachliche Fähigkeiten
+
+Bluelight Hub unterstützt die strukturierte Dokumentation und Koordination von Einsätzen:
 
 - **Einsatz-Management** — Erstellen, Aktualisieren, Archivieren (inkl. 10-Jahre-Aufbewahrung, GoBD-konform)
 - **Einsatztagebuch (ETB)** — Event-sourced Logbuch mit Snapshot-Optimierung, Discriminated-Union-Kontexte (ADR-005)

--- a/docs/project-documentation/01-projektueberblick.md
+++ b/docs/project-documentation/01-projektueberblick.md
@@ -6,7 +6,27 @@
 
 ## 1.1 Fachlicher Kontext
 
-**Bluelight Hub** ist eine Einsatzverwaltungs-Plattform für **Blaulicht-Organisationen** (Katastrophenschutz, DRK, Feuerwehr, Rettungsdienst, THW). Die Software begleitet einen Einsatz von der Alarmierung über die Führung bis zur rechtssicheren Archivierung.
+**Bluelight Hub** ist eine Einsatzverwaltungs-Plattform **explizit für die „weißen Hilfsorganisationen"** (DRK, JUH, MHD, ASB, DLRG) im Sanitätsdienst und Katastrophenschutz. Die Software begleitet einen Einsatz von der Alarmierung über die Führung bis zur rechtssicheren Archivierung.
+
+### 1.1.1 Zielgruppe & Abgrenzung
+
+| Zielgruppe (Primärfokus)                               | **Nicht** Zielgruppe                        |
+| ------------------------------------------------------ | ------------------------------------------- |
+| **DRK** (Deutsches Rotes Kreuz)                        | Feuerwehr (BF, FF, WF)                      |
+| **JUH** (Johanniter-Unfall-Hilfe)                      | Polizei / BOS-Sicherheit                    |
+| **MHD** (Malteser Hilfsdienst)                         | Bundeswehr                                  |
+| **ASB** (Arbeiter-Samariter-Bund)                      | THW (als Primär-Nutzer; Interop unterstützt) |
+| **DLRG** (Deutsche Lebens-Rettungs-Gesellschaft)       | Kommerzielle Rettungsdienste ohne KatS-Bezug |
+
+**Einsatzszenarien, die die Fachdomäne prägen:**
+
+- Sanitätsdienstliche Absicherung (San-Dienst bei Veranstaltungen, MANV-Vorhaltung)
+- Schnelle Einsatzgruppen (SEG Sanität, SEG Betreuung, SEG Transport)
+- Betreuungsdienst (Notunterkünfte, Evakuierung, Verpflegung)
+- KatS-Züge / Verbandsführung im (über-)örtlichen Katastrophenschutz
+- Ehrenamtliche Einsatzkräfte mit HiOrg-internen Qualifikations- und Rollenmodellen
+
+> **Warum diese Abgrenzung architekturrelevant ist:** Rollen (`Führungskraft`/`Einsatzkraft`/`Externe`, operative Rollen im Einsatz), ETB-Kontexte (ADR-005: Text/Funkspruch/Patient/Einsatzmittel/Notiz), Kräfte-Modell (Fahrzeug/Person/Einheit mit Qualifikationen), HiOrg-Server-Integration (OAuth2 + Qualifikations-Import) und die Default-Befüllung des Taktische-Zeichen-Katalogs orientieren sich an weißen HiOrgs. Es gibt bewusst **kein** FwDV-/FFS-Modell, **keine** Brandbekämpfungs-Workflows, **keine** THW-Fachzug-Strukturen. FW-/THW-Taktische-Zeichen sind im Katalog enthalten, aber ausschließlich für die Lagekarten-Interoperabilität bei überörtlichen Einsätzen mit gemischten Kräften — sie bestimmen weder Datenmodell noch User-Journeys.
 
 ### Kern-Fähigkeiten
 


### PR DESCRIPTION
## Summary

- Präzisiert die Zielgruppe von Bluelight Hub auf **weiße Hilfsorganisationen** (DRK, JUH, MHD, ASB, DLRG) im Sanitätsdienst und Katastrophenschutz.
- Grenzt **explizit gegen Feuerwehr, Polizei und Bundeswehr** ab.
- Begründet, warum die Abgrenzung Architektur-relevant ist (Rollen-, ETB-, Kräfte-, Zeichen-Modell).

## Changes

### Docs
- `CLAUDE.md` — Projekt-Überblick mit Zielgruppen-Abgrenzung (1 Absatz)
- `docs/project-documentation/00-index.md` — Fachlicher Kontext erweitert um Zielgruppen-Sektion
- `docs/project-documentation/01-projektueberblick.md` — Zielgruppen-Tabelle + Einsatzszenarien + Architektur-Begründung

## Kontext

FW-/THW-Taktische-Zeichen bleiben im Katalog für Lagekarten-Interoperabilität bei überörtlichen Einsätzen mit gemischten Kräften — sie sind aber nicht Domäne-leitend. Die bisherige generische "Blaulicht-Organisationen"-Formulierung hat die fachliche Ausrichtung verschleiert und fälschlich FW/THW als Ziel-Zielgruppe suggeriert.

## Test plan

- [ ] Review der drei Markdown-Dateien auf Konsistenz
- [ ] Keine Code-Änderungen — kein CI-Testlauf nötig

🤖 Generated with [Claude Code](https://claude.com/claude-code)