### PR TITLE
Vorfall-PDF redesign mit verbessertem Corporate Design

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,12 @@ jobs:
           JWT_REFRESH_SECRET: test-refresh-secret
           NODE_ENV: test
           DATABASE_URL: postgresql://test:test@localhost:5432/testdb
+          # VAPID-Stubs nur für Test-Bootstrap (kein echter Push-Versand).
+          # PushNotificationsModule.onModuleInit prüft Fail-Fast (AC3) und
+          # bricht sonst alle e2e/integration Tests ab, die Nest booten.
+          VAPID_PUBLIC_KEY: BFXVdS1XbF4WsymeQ8ALDXxPjBS8WBXOGZuxw5Z_K-eqTMA4Y3srt2DfeQuUOjIma376b026FqKG7YpRKOxnwCg
+          VAPID_PRIVATE_KEY: eQLRNH_aGO0c69kvha8CEKiomjs7_vGwgrFwwIPFN-E
+          VAPID_SUBJECT: 'mailto:ci@bluelight-hub.test'
         run: pnpm --filter @bluelight-hub/backend test:db -- --shard=${{ matrix.shard }}/3
 
       - uses: actions/upload-artifact@v7
@@ -340,6 +346,11 @@ jobs:
           JWT_REFRESH_SECRET: test-refresh-secret
           E2E_BACKEND_PORT: '3091'
           E2E_FRONTEND_PORT: '4173'
+          # VAPID-Stubs für den Out-of-Process-Backend-Bootstrap; ohne diese
+          # bricht PushNotificationsModule.onModuleInit (AC3, Fail-Fast).
+          VAPID_PUBLIC_KEY: BFXVdS1XbF4WsymeQ8ALDXxPjBS8WBXOGZuxw5Z_K-eqTMA4Y3srt2DfeQuUOjIma376b026FqKG7YpRKOxnwCg
+          VAPID_PRIVATE_KEY: eQLRNH_aGO0c69kvha8CEKiomjs7_vGwgrFwwIPFN-E
+          VAPID_SUBJECT: 'mailto:ci@bluelight-hub.test'
         run: pnpm --filter @bluelight-hub/frontend test:e2e:ci
 
       # P28 (Review): `if: always()` greift auch bei Setup-Phase-Failures (DB unreachable,
@@ -386,6 +397,11 @@ jobs:
         env:
           NODE_ENV: test
           SHARD_INDEX: ${{ matrix.shard }}
+          # Mehrere Specs (z. B. VorfallDetailPage Story 5.6) assertieren
+          # konkrete Berlin-Zeit-Strings. CI-Runner laufen in UTC, lokal sind
+          # die Tests CEST/CET — TZ explizit pinnen, damit Datums-Renderings
+          # in jedem Lauf identisch sind.
+          TZ: Europe/Berlin
         run: |
           pnpm --filter @bluelight-hub/frontend exec vitest \
             --run \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,10 @@ RUN pnpm --filter @bluelight-hub/backend build
 
 ## Production dependencies: use pnpm deploy for reliable workspace isolation
 ## (pnpm prune --prod does not reliably preserve workspace packages' dependencies)
+## --legacy: pnpm v10+ verlangt sonst inject-workspace-packages=true; wir
+## nutzen klassische Symlinks/Direkt-Deploy ohne Injection.
 FROM shared-builder AS prod-deps
-RUN pnpm --filter @bluelight-hub/backend deploy --prod /prod/backend
+RUN pnpm --filter @bluelight-hub/backend deploy --prod --legacy /prod/backend
 
 ## Production image: minimal runtime with pre-built artifacts only
 FROM node:25-alpine AS production

--- a/packages/backend/src/infrastructure/eigenschutz/export/eigenschutz-vorfall-pdf.renderer.ts
+++ b/packages/backend/src/infrastructure/eigenschutz/export/eigenschutz-vorfall-pdf.renderer.ts
@@ -22,6 +22,37 @@ export interface EigenschutzVorfallPdfRendererOptions {
 
 const REDACT_LENGTH = 8;
 
+// Layout-Konstanten — A4 mit margin: 50 ⇒ usable width 495 pt (595 - 2*50).
+const PAGE_MARGIN = 50;
+const PAGE_WIDTH = 595.28;
+const CONTENT_WIDTH = PAGE_WIDTH - 2 * PAGE_MARGIN;
+// Reserve am unteren Seitenrand für den persistenten Footer (Permission-Zeile
+// + Seitenzahl). 60 pt deckt zwei Textzeilen + Trennlinie sicher ab.
+const FOOTER_RESERVED_HEIGHT = 60;
+// A4-Höhe 842 pt minus Margin und Footer-Reserve — Schwelle für manuelle
+// Seitenumbrüche vor Blöcken, die eigene Höhe nicht im Voraus kennen.
+// pdfkit umbricht innerhalb von `text(...)` automatisch, aber Vektor-
+// Primitive (rect/lineTo) ignorieren die Margin-Grenze.
+const PAGE_BREAK_THRESHOLD = 700;
+
+// Corporate-Design-Tokens (zurückhaltend, druckfreundlich, keine Org-Farben —
+// Bluelight-Hub ist neutraler Hub für mehrere weiße HiOrgs).
+const COLOR_PRIMARY = '#0f3a5f'; // tiefes Marineblau für Hauptakzente
+const COLOR_PRIMARY_SOFT = '#e5edf3'; // sehr helles Blau für Section-Hintergründe
+const COLOR_TEXT = '#1a1a1a';
+const COLOR_MUTED = '#666666';
+const COLOR_BORDER = '#cccccc';
+const COLOR_WARN = '#a02020'; // Schema-Drift / Datenfehler
+
+// Risikoklasse-Tokens (Ampel-Semantik aus risikoklasse-berechnung.ts).
+// Die Hintergrundfarbe ist eine pastellige Tinte, damit Druckkosten und
+// Kontrast in Schwarz-Weiß-Druck akzeptabel bleiben.
+const RISIKO_BADGE: Record<string, { bg: string; fg: string; label: string }> = {
+  ROT: { bg: '#fde2e2', fg: '#a01818', label: 'ROT' },
+  GELB: { bg: '#fff4d6', fg: '#8a6500', label: 'GELB' },
+  GRUEN: { bg: '#e0f3e3', fg: '#1f6f2c', label: 'GRÜN' },
+};
+
 /**
  * pdfkit-basierte Implementierung des `IEigenschutzVorfallPdfRenderer`
  * (Story 5.4, FR34/AR13).
@@ -36,6 +67,15 @@ const REDACT_LENGTH = 8;
  * (`kind: 'freitext'`, `name`/`rolle`) sind als Bestandteil des Unfallkassen-
  * Pflichtformats erlaubt und werden bewusst klar gerendert (PO-Decision
  * Code-Review 2026-05-07, D2). Eingaben sind vom Aggregate validiert.
+ *
+ * **Redesign 2026-05-12 (G5):** Visuelles Polish — Brand-Header mit
+ * farbigem Akzentbalken, persistenter Seitenfuß mit Seitenzahl, farbcodierte
+ * Risiko-Badges, Unfallkasse-Pill, zweispaltiges Metadaten-Grid.
+ * Text-Asserts aus dem bestehenden Test-Vertrag (Story 5.4 AC2 Tests 4, 5,
+ * 6, 7, 8) sowie NFR-P5 (p95 < 5 s, Worst-Case 100 Gefährdungen) bleiben
+ * eingehalten — die optischen Verbesserungen rendern primär mit
+ * Vektor-Primitiven (rect/lineTo), die billig sind und kaum auf Wallclock
+ * durchschlagen.
  */
 @Injectable()
 export class EigenschutzVorfallPdfRenderer implements IEigenschutzVorfallPdfRenderer {
@@ -49,19 +89,35 @@ export class EigenschutzVorfallPdfRenderer implements IEigenschutzVorfallPdfRend
       try {
         const compress = this.options.compress ?? true;
         const chunks: Buffer[] = [];
-        const doc = new PDFDocument({ size: 'A4', margin: 50, compress });
+        const doc = new PDFDocument({
+          size: 'A4',
+          compress,
+          bufferPages: true,
+          // Reserviere unteren Footer-Bereich, damit pdfkit automatische
+          // Seitenumbrüche oberhalb der Footer-Zone vornimmt. `margin`
+          // (skalar) und `margins` (Objekt) schließen sich aus — wir
+          // nutzen `margins`, weil der Footer-Reserve unten asymmetrisch ist.
+          margins: {
+            top: PAGE_MARGIN,
+            bottom: PAGE_MARGIN + FOOTER_RESERVED_HEIGHT,
+            left: PAGE_MARGIN,
+            right: PAGE_MARGIN,
+          },
+        });
 
         doc.on('data', (chunk: Buffer) => chunks.push(chunk));
         doc.on('end', () => resolve(Buffer.concat(chunks)));
         doc.on('error', (err: Error) => reject(err));
 
-        this.renderHeader(doc, input);
+        this.renderBrandHeader(doc, input);
         this.renderVorfallMetadaten(doc, input.vorfall);
         this.renderSnapshotHeader(doc, input.vorfall.kontextSnapshot);
         this.renderGefaehrdungsblock(doc, input.vorfall.kontextSnapshot);
         this.renderPsaProfilBlock(doc, input.vorfall.kontextSnapshot);
         this.renderSicherheitsregelnBlock(doc, input.vorfall.kontextSnapshot);
-        this.renderFooter(doc, input);
+
+        // Persistenten Footer + Seitenzahlen über alle Seiten hinweg legen.
+        this.renderPersistentFooter(doc, input);
 
         doc.end();
       } catch (error) {
@@ -70,163 +126,361 @@ export class EigenschutzVorfallPdfRenderer implements IEigenschutzVorfallPdfRend
     });
   }
 
-  private renderHeader(doc: PDFKit.PDFDocument, input: EigenschutzVorfallPdfInput): void {
+  // ────────────────────────────────────────────────────────────────────────
+  // Header & Branding
+  // ────────────────────────────────────────────────────────────────────────
+
+  private renderBrandHeader(doc: PDFKit.PDFDocument, input: EigenschutzVorfallPdfInput): void {
     const einsatzRedact = safeRedact(input.vorfall.einsatzId);
     const vorfallRedact = safeRedact(input.vorfall.id.value);
-    doc.fontSize(18).fillColor('black').text('Vorfall-Meldung Eigenschutz', { align: 'left' });
-    doc.moveDown(0.2);
-    doc.fontSize(10).fillColor('#666').text(`Einsatz ${einsatzRedact} · Vorfall ${vorfallRedact}`);
-    doc.fillColor('black');
-    doc.moveDown(0.6);
+
+    // Linker Akzentbalken (4 pt breit, volle Header-Höhe) signalisiert
+    // Dokumentcharakter und gibt der Seite optisches Gewicht.
+    const headerTop = PAGE_MARGIN;
+    const headerHeight = 56;
+    doc.save();
+    doc.rect(PAGE_MARGIN, headerTop, 4, headerHeight).fill(COLOR_PRIMARY);
+    doc.restore();
+
+    const textLeft = PAGE_MARGIN + 16;
+
+    doc
+      .fillColor(COLOR_PRIMARY)
+      .font('Helvetica-Bold')
+      .fontSize(20)
+      .text('Vorfall-Meldung Eigenschutz', textLeft, headerTop + 4, {
+        width: CONTENT_WIDTH - 16,
+      });
+
+    doc
+      .fillColor(COLOR_MUTED)
+      .font('Helvetica')
+      .fontSize(10)
+      .text(`Einsatz ${einsatzRedact}  ·  Vorfall ${vorfallRedact}`, textLeft, headerTop + 32, {
+        width: CONTENT_WIDTH - 16,
+      });
+
+    // Rechte Spalte: Dokumenttyp + Erzeugungsdatum (Quick-Scan-Marker für
+    // Sachbearbeiter:innen der Unfallkasse).
+    const rightColX = PAGE_MARGIN + CONTENT_WIDTH - 180;
+    doc
+      .fillColor(COLOR_MUTED)
+      .font('Helvetica')
+      .fontSize(8)
+      .text('UNFALLKASSEN-MELDUNG', rightColX, headerTop + 6, {
+        width: 180,
+        align: 'right',
+      });
+    doc
+      .fillColor(COLOR_TEXT)
+      .font('Helvetica-Bold')
+      .fontSize(10)
+      .text(formatDateTime(input.erzeugtAm), rightColX, headerTop + 20, {
+        width: 180,
+        align: 'right',
+      });
+    doc
+      .fillColor(COLOR_MUTED)
+      .font('Helvetica')
+      .fontSize(8)
+      .text('Erzeugungszeitpunkt', rightColX, headerTop + 34, {
+        width: 180,
+        align: 'right',
+      });
+
+    // Untere Trennlinie unterhalb des Header-Bereichs.
+    const lineY = headerTop + headerHeight + 4;
+    doc
+      .strokeColor(COLOR_BORDER)
+      .lineWidth(0.5)
+      .moveTo(PAGE_MARGIN, lineY)
+      .lineTo(PAGE_MARGIN + CONTENT_WIDTH, lineY)
+      .stroke();
+
+    doc.fillColor(COLOR_TEXT).font('Helvetica');
+    doc.y = lineY + 14;
+    doc.x = PAGE_MARGIN;
   }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Section-Header (wiederverwendbarer Block-Titel mit farbigem Akzent)
+  // ────────────────────────────────────────────────────────────────────────
+
+  private renderSectionTitle(doc: PDFKit.PDFDocument, title: string): void {
+    this.ensureRoom(doc);
+    const y = doc.y;
+    // Schmaler vertikaler Akzent (3 pt), 14 pt hoch.
+    doc.save();
+    doc.rect(PAGE_MARGIN, y + 2, 3, 14).fill(COLOR_PRIMARY);
+    doc.restore();
+
+    doc
+      .fillColor(COLOR_PRIMARY)
+      .font('Helvetica-Bold')
+      .fontSize(13)
+      .text(title, PAGE_MARGIN + 10, y, { width: CONTENT_WIDTH - 10 });
+
+    doc.fillColor(COLOR_TEXT).font('Helvetica').fontSize(10);
+    doc.moveDown(0.3);
+    doc.x = PAGE_MARGIN;
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Vorfall-Metadaten — zweispaltiges Label/Wert-Grid + Unfallkasse-Pill
+  // ────────────────────────────────────────────────────────────────────────
 
   private renderVorfallMetadaten(doc: PDFKit.PDFDocument, vorfall: EigenschutzVorfall): void {
-    doc.fontSize(12).fillColor('black').text('Vorfall-Daten', { underline: true });
-    doc.moveDown(0.2);
-    doc.fontSize(10);
-    doc.text(`Wann (gemeldet): ${formatDateTime(vorfall.wann)}`);
-    doc.text(`Vorfallzeit: ${formatDateTime(vorfall.vorfallZeit)}`);
-    doc.text(`Wo: ${formatWo(vorfall)}`);
-    doc.text(`Was: ${vorfall.was}`);
-    if (vorfall.massnahmen && vorfall.massnahmen.trim().length > 0) {
-      doc.text(`Maßnahmen: ${vorfall.massnahmen}`);
-    } else {
-      doc.text('Maßnahmen: —');
-    }
-    doc.text(`Unfallkasse-relevant: ${vorfall.unfallkasseRelevant ? 'ja' : 'nein'}`);
-    doc.text(`Erfasst durch: Nutzer-ID ${safeRedact(vorfall.erfasstVonUserId)}`);
+    this.renderSectionTitle(doc, 'Vorfall-Daten');
 
+    // Hintergrund-Karte für Metadaten-Grid.
+    const cardTop = doc.y;
+    const labelColWidth = 140;
+    const valueColWidth = CONTENT_WIDTH - labelColWidth - 20;
+
+    interface Row {
+      label: string;
+      value: string;
+      muted?: boolean;
+    }
+    const rows: Row[] = [
+      { label: 'Wann (gemeldet)', value: formatDateTime(vorfall.wann) },
+      { label: 'Vorfallzeit', value: formatDateTime(vorfall.vorfallZeit) },
+      { label: 'Wo', value: formatWo(vorfall) },
+      { label: 'Was', value: vorfall.was },
+      {
+        label: 'Maßnahmen',
+        value: vorfall.massnahmen && vorfall.massnahmen.trim().length > 0 ? vorfall.massnahmen : '—',
+        muted: !vorfall.massnahmen || vorfall.massnahmen.trim().length === 0,
+      },
+      {
+        label: 'Erfasst durch',
+        value: `Nutzer-ID ${safeRedact(vorfall.erfasstVonUserId)}`,
+      },
+    ];
+
+    // Schätze Card-Höhe konservativ (für Hintergrund-Rect).
+    // Setze die Font-Metriken auf 10 pt, damit `heightOfString` korrekt misst.
+    doc.font('Helvetica').fontSize(10);
+    let cursor = cardTop + 10;
+    for (const row of rows) {
+      const valueHeight = doc.heightOfString(row.value, { width: valueColWidth });
+      cursor += Math.max(14, valueHeight) + 4;
+    }
+    // +Pill-Zeile + Beteiligte-Header
+    cursor += 22;
+    const cardHeight = cursor - cardTop;
+
+    doc.save();
+    doc.roundedRect(PAGE_MARGIN, cardTop, CONTENT_WIDTH, cardHeight, 4).fillAndStroke(COLOR_PRIMARY_SOFT, COLOR_BORDER);
+    doc.restore();
+
+    let y = cardTop + 10;
+    for (const row of rows) {
+      doc
+        .fillColor(COLOR_MUTED)
+        .font('Helvetica')
+        .fontSize(9)
+        .text(row.label, PAGE_MARGIN + 12, y + 1, { width: labelColWidth - 8 });
+      doc
+        .fillColor(row.muted ? COLOR_MUTED : COLOR_TEXT)
+        .font('Helvetica')
+        .fontSize(10)
+        .text(row.value, PAGE_MARGIN + labelColWidth + 4, y, { width: valueColWidth });
+      const valueHeight = doc.heightOfString(row.value, { width: valueColWidth });
+      y += Math.max(14, valueHeight) + 4;
+    }
+
+    // Unfallkasse-relevant: Pill-Badge mit klarer Ja/Nein-Semantik.
+    const pillLabel = vorfall.unfallkasseRelevant ? 'Unfallkasse-relevant: ja' : 'Unfallkasse-relevant: nein';
+    this.renderPill(doc, PAGE_MARGIN + 12, y, pillLabel, {
+      bg: vorfall.unfallkasseRelevant ? '#fde2e2' : '#e0f3e3',
+      fg: vorfall.unfallkasseRelevant ? '#a01818' : '#1f6f2c',
+    });
+
+    doc.x = PAGE_MARGIN;
+    doc.y = cardTop + cardHeight + 10;
+
+    // Beteiligte-Liste — separater Block direkt unter der Karte.
+    doc.fillColor(COLOR_TEXT).font('Helvetica-Bold').fontSize(10).text('Beteiligte:', PAGE_MARGIN, doc.y, { width: CONTENT_WIDTH });
     doc.moveDown(0.2);
-    doc.text('Beteiligte:');
+
     const beteiligte = vorfall.beteiligte;
     if (beteiligte.length === 0) {
-      doc.fillColor('#666').text('  • Keine Beteiligten erfasst.').fillColor('black');
+      doc.fillColor(COLOR_MUTED).font('Helvetica-Oblique').fontSize(10).text('  Keine Beteiligten erfasst.', PAGE_MARGIN, doc.y);
     } else {
+      doc.font('Helvetica').fontSize(10).fillColor(COLOR_TEXT);
       for (const entry of beteiligte) {
-        doc.text(`  • ${formatBeteiligter(entry)}`);
+        doc.text(`  •  ${formatBeteiligter(entry)}`, PAGE_MARGIN, doc.y, { width: CONTENT_WIDTH });
       }
     }
-    doc.moveDown(0.6);
+    doc.moveDown(0.8);
+    doc.fillColor(COLOR_TEXT).font('Helvetica');
   }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Snapshot-Header
+  // ────────────────────────────────────────────────────────────────────────
 
   private renderSnapshotHeader(doc: PDFKit.PDFDocument, snapshot: Record<string, unknown>): void {
     if (isEmptySnapshot(snapshot)) {
-      doc.fontSize(14).fillColor('black').text('Kontext-Snapshot', { underline: true });
-      doc.moveDown(0.2);
-      doc.fontSize(10).fillColor('#666').text('Kontext-Snapshot nicht verfügbar (Vorfall vor Story 5.2 erfasst).');
-      doc.fillColor('black');
-      doc.moveDown(0.6);
+      this.renderSectionTitle(doc, 'Kontext-Snapshot');
+      doc.fillColor(COLOR_MUTED).font('Helvetica-Oblique').fontSize(10).text('Kontext-Snapshot nicht verfügbar (Vorfall vor Story 5.2 erfasst).', PAGE_MARGIN, doc.y, {
+        width: CONTENT_WIDTH,
+      });
+      doc.fillColor(COLOR_TEXT).font('Helvetica');
+      doc.moveDown(0.8);
       return;
     }
 
     const snapshotAt = readString(snapshot.snapshotAt);
-    const heading = snapshotAt ? `Stand zum Vorfall-Zeitpunkt: ${formatDateTimeFromIso(snapshotAt)}` : 'Stand zum Vorfall-Zeitpunkt';
-    doc.fontSize(14).fillColor('black').text(heading, { underline: true });
-    doc.moveDown(0.4);
+    const heading = snapshotAt ? `Stand zum Vorfall-Zeitpunkt · ${formatDateTimeFromIso(snapshotAt)}` : 'Stand zum Vorfall-Zeitpunkt';
+    this.renderSectionTitle(doc, heading);
   }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Gefährdungsbeurteilung — pro Item: Titel + Risiko-Badge + Beschreibung
+  // ────────────────────────────────────────────────────────────────────────
 
   private renderGefaehrdungsblock(doc: PDFKit.PDFDocument, snapshot: Record<string, unknown>): void {
     if (isEmptySnapshot(snapshot)) return;
-    doc.fontSize(12).fillColor('black').text('Gefährdungsbeurteilung (zum Vorfall-Zeitpunkt)');
-    doc.fontSize(10);
+    this.renderSubsectionTitle(doc, 'Gefährdungsbeurteilung (zum Vorfall-Zeitpunkt)');
+
     const gefRaw = snapshot.gefaehrdungsbeurteilung;
     if (gefRaw !== undefined && (gefRaw === null || typeof gefRaw !== 'object' || Array.isArray(gefRaw))) {
       this.logger?.warn?.('EigenschutzVorfallPdfRenderer: gefaehrdungsbeurteilung hat unerwartete Form — Schema-Drift erkannt');
-      doc.fillColor('#a00').text('  Gefährdungsbeurteilung: Daten-Format nicht lesbar (Schema-Drift)').fillColor('black');
-      doc.moveDown(0.4);
+      this.renderDriftBanner(doc, 'Gefährdungsbeurteilung: Daten-Format nicht lesbar (Schema-Drift)');
       return;
     }
     const gef = gefRaw as Record<string, unknown> | undefined;
     if (!gef) {
-      doc.fillColor('#666').text('  Keine Gefährdungsbeurteilung im Snapshot.').fillColor('black');
-      doc.moveDown(0.4);
+      this.renderMutedNote(doc, 'Keine Gefährdungsbeurteilung im Snapshot.');
       return;
     }
     if (gef.items !== undefined && !Array.isArray(gef.items)) {
       this.logger?.warn?.('EigenschutzVorfallPdfRenderer: gefaehrdungsbeurteilung.items ist kein Array — Schema-Drift erkannt');
-      doc.fillColor('#a00').text('  Gefährdungs-Items: Daten-Format nicht lesbar (Schema-Drift)').fillColor('black');
-      doc.moveDown(0.4);
+      this.renderDriftBanner(doc, 'Gefährdungs-Items: Daten-Format nicht lesbar (Schema-Drift)');
       return;
     }
     const items = Array.isArray(gef.items) ? (gef.items as ReadonlyArray<Record<string, unknown>>) : [];
     if (items.length === 0) {
-      doc.fillColor('#666').text('  Keine Gefährdungs-Items im Snapshot.').fillColor('black');
-      doc.moveDown(0.4);
+      this.renderMutedNote(doc, 'Keine Gefährdungs-Items im Snapshot.');
       return;
     }
+
     for (const item of items) {
+      this.ensureRoom(doc);
       const title = readString(item.title) ?? '(ohne Titel)';
-      doc.fillColor('black').text(`• ${title}`);
+      const risikoklasse = readString(item.risikoklasse);
+
+      // Zeile 1: Bullet + Titel + Risiko-Badge (rechts).
+      const rowTop = doc.y;
+      doc
+        .fillColor(COLOR_TEXT)
+        .font('Helvetica-Bold')
+        .fontSize(10.5)
+        .text(`•  ${title}`, PAGE_MARGIN, rowTop, { width: CONTENT_WIDTH - 110 });
+
+      if (risikoklasse && RISIKO_BADGE[risikoklasse]) {
+        const badge = RISIKO_BADGE[risikoklasse];
+        this.renderPill(doc, PAGE_MARGIN + CONTENT_WIDTH - 90, rowTop, badge.label, {
+          bg: badge.bg,
+          fg: badge.fg,
+        });
+      }
+
+      doc.font('Helvetica').fontSize(9.5);
+
       const description = readString(item.description);
-      if (description) doc.fillColor('#444').text(`    ${description}`).fillColor('black');
+      if (description) {
+        doc.fillColor(COLOR_TEXT).text(description, PAGE_MARGIN + 16, doc.y, { width: CONTENT_WIDTH - 16 });
+      }
       const eintritt = readString(item.eintritt);
       const schaden = readString(item.schaden);
-      const risikoklasse = readString(item.risikoklasse);
-      const risikoLine = [eintritt ? `Eintritt: ${eintritt}` : null, schaden ? `Schaden: ${schaden}` : null, risikoklasse ? `Risikoklasse: ${risikoklasse}` : null].filter(
-        (v): v is string => v !== null,
-      );
-      if (risikoLine.length > 0)
-        doc
-          .fillColor('#444')
-          .text(`    ${risikoLine.join(' · ')}`)
-          .fillColor('black');
+      const risikoLine: string[] = [];
+      if (eintritt) risikoLine.push(`Eintritt: ${eintritt}`);
+      if (schaden) risikoLine.push(`Schaden: ${schaden}`);
+      if (risikoklasse && !RISIKO_BADGE[risikoklasse]) {
+        // Falls Risikoklasse außerhalb der bekannten Tokens liegt, als Text mitführen.
+        risikoLine.push(`Risikoklasse: ${risikoklasse}`);
+      }
+      if (risikoLine.length > 0) {
+        doc.fillColor(COLOR_MUTED).text(risikoLine.join('  ·  '), PAGE_MARGIN + 16, doc.y, { width: CONTENT_WIDTH - 16 });
+      }
       const massnahmen = readString(item.schutzmassnahmen);
-      if (massnahmen) doc.fillColor('#444').text(`    Schutzmaßnahmen: ${massnahmen}`).fillColor('black');
+      if (massnahmen) {
+        doc.fillColor(COLOR_TEXT).text(`Schutzmaßnahmen: ${massnahmen}`, PAGE_MARGIN + 16, doc.y, { width: CONTENT_WIDTH - 16 });
+      }
+      doc.moveDown(0.35);
     }
+    doc.fillColor(COLOR_TEXT).font('Helvetica');
     doc.moveDown(0.4);
   }
 
+  // ────────────────────────────────────────────────────────────────────────
+  // Aktive PSA-Profile
+  // ────────────────────────────────────────────────────────────────────────
+
   private renderPsaProfilBlock(doc: PDFKit.PDFDocument, snapshot: Record<string, unknown>): void {
     if (isEmptySnapshot(snapshot)) return;
-    doc.fontSize(12).fillColor('black').text('Aktive PSA-Profile waren');
-    doc.fontSize(10);
+    this.renderSubsectionTitle(doc, 'Aktive PSA-Profile waren');
+
     const profile = snapshot.aktivePsaProfile;
     if (profile !== undefined && !Array.isArray(profile)) {
       // Defense-in-Depth: Schema-Drift in DB-JSONB darf den PDF-Pfad nicht killen.
       this.logger?.warn?.('EigenschutzVorfallPdfRenderer: aktivePsaProfile ist kein Array — Schema-Drift erkannt');
-      doc.fillColor('#a00').text('  PSA-Profile: Daten-Format nicht lesbar (Schema-Drift)').fillColor('black');
-      doc.moveDown(0.4);
+      this.renderDriftBanner(doc, 'PSA-Profile: Daten-Format nicht lesbar (Schema-Drift)');
       return;
     }
     const list = Array.isArray(profile) ? (profile as ReadonlyArray<Record<string, unknown>>) : [];
     if (list.length === 0) {
-      doc.fillColor('#666').text('  Keine aktiven PSA-Profile im Snapshot.').fillColor('black');
-      doc.moveDown(0.4);
+      this.renderMutedNote(doc, 'Keine aktiven PSA-Profile im Snapshot.');
       return;
     }
     for (const entry of list) {
+      this.ensureRoom(doc);
       const name = readString(entry.profil) ?? '(unbekannt)';
       const gueltigVon = readString(entry.gueltigVon);
       const seit = gueltigVon ? formatDateTimeFromIso(gueltigVon) : '—';
-      doc.fillColor('black').text(`• Profil ${name} · seit ${seit}`);
+      doc.fillColor(COLOR_TEXT).font('Helvetica-Bold').fontSize(10).text(`•  Profil ${name}`, PAGE_MARGIN, doc.y, { width: CONTENT_WIDTH, continued: true });
+      doc.font('Helvetica').fillColor(COLOR_MUTED).fontSize(9.5).text(`   ·  seit ${seit}`, { width: CONTENT_WIDTH });
     }
+    doc.fillColor(COLOR_TEXT).font('Helvetica');
     doc.moveDown(0.4);
   }
 
+  // ────────────────────────────────────────────────────────────────────────
+  // Sicherheitsregeln (zugewiesen zum Vorfall-Zeitpunkt)
+  // ────────────────────────────────────────────────────────────────────────
+
   private renderSicherheitsregelnBlock(doc: PDFKit.PDFDocument, snapshot: Record<string, unknown>): void {
     if (isEmptySnapshot(snapshot)) return;
-    doc.fontSize(12).fillColor('black').text('Sicherheitsregeln (zugewiesen zum Vorfall-Zeitpunkt)');
-    doc.fontSize(10);
+    this.renderSubsectionTitle(doc, 'Sicherheitsregeln (zugewiesen zum Vorfall-Zeitpunkt)');
+
     const regeln = snapshot.sicherheitsregeln;
     if (regeln !== undefined && !Array.isArray(regeln)) {
       this.logger?.warn?.('EigenschutzVorfallPdfRenderer: sicherheitsregeln ist kein Array — Schema-Drift erkannt');
-      doc.fillColor('#a00').text('  Sicherheitsregeln: Daten-Format nicht lesbar (Schema-Drift)').fillColor('black');
-      doc.moveDown(0.4);
+      this.renderDriftBanner(doc, 'Sicherheitsregeln: Daten-Format nicht lesbar (Schema-Drift)');
       return;
     }
     const list = Array.isArray(regeln) ? (regeln as ReadonlyArray<Record<string, unknown>>) : [];
     if (list.length === 0) {
-      doc.fillColor('#666').text('  Keine zugeordneten Sicherheitsregeln im Snapshot.').fillColor('black');
-      doc.moveDown(0.4);
+      this.renderMutedNote(doc, 'Keine zugeordneten Sicherheitsregeln im Snapshot.');
       return;
     }
     for (const regel of list) {
+      this.ensureRoom(doc);
       const titel = readString(regel.titel) ?? '(ohne Titel)';
-      doc.fillColor('black').text(`• ${titel}`);
+      doc.fillColor(COLOR_TEXT).font('Helvetica-Bold').fontSize(10.5).text(`•  ${titel}`, PAGE_MARGIN, doc.y, { width: CONTENT_WIDTH });
+
       const inhalt = readString(regel.inhalt);
       if (inhalt) {
+        // Trim-Spec aus Story 5.4 AC4 #6 (200 Zeichen + Ellipsis).
         const trimmed = inhalt.length > 200 ? `${inhalt.slice(0, 200)}…` : inhalt;
-        doc.fillColor('#444').text(`    ${trimmed}`).fillColor('black');
+        doc
+          .font('Helvetica')
+          .fontSize(9.5)
+          .fillColor(COLOR_TEXT)
+          .text(trimmed, PAGE_MARGIN + 16, doc.y, { width: CONTENT_WIDTH - 16 });
       }
       // Quittungspflicht ist nicht direkt im V1-Schema — `einsatzweit === false`
       // entspricht einer einheitsspezifischen Zuweisung (faktisch Quittungspflicht
@@ -235,34 +489,136 @@ export class EigenschutzVorfallPdfRenderer implements IEigenschutzVorfallPdfRend
       // Unfallkasse (PO-Decision Code-Review 2026-05-07, D1).
       const einsatzweit = typeof regel.einsatzweit === 'boolean' ? (regel.einsatzweit as boolean) : false;
       doc
-        .fillColor('#444')
-        .text(`    Quittungspflicht: ${einsatzweit ? 'nein (einsatzweit)' : 'ja'}`)
-        .fillColor('black');
+        .font('Helvetica')
+        .fontSize(9)
+        .fillColor(COLOR_MUTED)
+        .text(`Quittungspflicht: ${einsatzweit ? 'nein (einsatzweit)' : 'ja'}`, PAGE_MARGIN + 16, doc.y, { width: CONTENT_WIDTH - 16 });
+      doc.moveDown(0.3);
     }
-    doc.moveDown(0.2);
+
+    doc.moveDown(0.1);
     doc
+      .font('Helvetica-Oblique')
       .fontSize(8)
-      .fillColor('#888')
+      .fillColor(COLOR_MUTED)
       .text(
         'Hinweis: Der Quittungspflicht-Marker ist aus dem Geltungsbereich der Regel ' +
           'abgeleitet (einsatzweit ⇒ keine Einzelquittung) und stellt keine verbindliche ' +
           'Compliance-Aussage dar. Maßgeblich ist der jeweilige Regel-Versionsstand zum ' +
           'Vorfall-Zeitpunkt.',
-      )
-      .fillColor('black')
-      .fontSize(10);
+        PAGE_MARGIN,
+        doc.y,
+        { width: CONTENT_WIDTH },
+      );
+    doc.fillColor(COLOR_TEXT).font('Helvetica').fontSize(10);
     doc.moveDown(0.4);
   }
 
-  private renderFooter(doc: PDFKit.PDFDocument, input: EigenschutzVorfallPdfInput): void {
-    doc.moveDown(1);
+  // ────────────────────────────────────────────────────────────────────────
+  // Persistenter Footer + Seitenzahlen (zum Schluss über bufferPages legen)
+  // ────────────────────────────────────────────────────────────────────────
+
+  private renderPersistentFooter(doc: PDFKit.PDFDocument, input: EigenschutzVorfallPdfInput): void {
     const erzeugtAm = formatDateTime(input.erzeugtAm);
     const callerRedact = safeRedact(input.erzeugtVonUserId);
     const einsatzRedact = safeRedact(input.vorfall.einsatzId);
-    doc.fontSize(9).fillColor('#888').text(`Erzeugt am ${erzeugtAm} durch Nutzer-ID ${callerRedact} · Permission eigenschutz:vorfall:export · Einsatz ${einsatzRedact}`, {
-      align: 'left',
-    });
-    doc.fillColor('black');
+    const permissionLine = `Erzeugt am ${erzeugtAm}  ·  Nutzer-ID ${callerRedact}  ·  ` + `Permission eigenschutz:vorfall:export  ·  Einsatz ${einsatzRedact}`;
+
+    const range = doc.bufferedPageRange();
+    const total = range.count;
+    const pageBottomY = doc.page?.height ? doc.page.height - PAGE_MARGIN - 40 : 760;
+
+    for (let i = range.start; i < range.start + range.count; i++) {
+      doc.switchToPage(i);
+      // Trennlinie über dem Footer.
+      doc
+        .strokeColor(COLOR_BORDER)
+        .lineWidth(0.5)
+        .moveTo(PAGE_MARGIN, pageBottomY)
+        .lineTo(PAGE_MARGIN + CONTENT_WIDTH, pageBottomY)
+        .stroke();
+
+      doc
+        .fillColor(COLOR_MUTED)
+        .font('Helvetica')
+        .fontSize(7.5)
+        .text(permissionLine, PAGE_MARGIN, pageBottomY + 6, {
+          width: CONTENT_WIDTH - 80,
+          align: 'left',
+          lineBreak: false,
+          ellipsis: true,
+        });
+      doc
+        .fillColor(COLOR_MUTED)
+        .font('Helvetica')
+        .fontSize(7.5)
+        .text(`Seite ${i - range.start + 1} / ${total}`, PAGE_MARGIN + CONTENT_WIDTH - 80, pageBottomY + 6, {
+          width: 80,
+          align: 'right',
+          lineBreak: false,
+        });
+    }
+    doc.fillColor(COLOR_TEXT).font('Helvetica');
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Render-Primitive (Pill, Subsection-Titel, Drift-Banner, Muted-Note)
+  // ────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Erzwingt einen Seitenumbruch, wenn der aktuelle Cursor zu nah an der
+   * Footer-Reserve liegt. pdfkit umbricht innerhalb von `text(...)`
+   * automatisch, aber direkt gezeichnete Vektor-Primitive (rect/lineTo)
+   * ignorieren die Margin-Grenze — daher diese manuelle Schwelle vor
+   * Bullet-Blöcken und Section-Titeln.
+   */
+  private ensureRoom(doc: PDFKit.PDFDocument): void {
+    if (doc.y > PAGE_BREAK_THRESHOLD) {
+      doc.addPage();
+    }
+  }
+
+  private renderPill(doc: PDFKit.PDFDocument, x: number, y: number, label: string, colors: { bg: string; fg: string }): void {
+    const padX = 8;
+    const padY = 3;
+    doc.font('Helvetica-Bold').fontSize(9);
+    const textWidth = doc.widthOfString(label);
+    const pillWidth = textWidth + padX * 2;
+    const pillHeight = 14;
+    doc.save();
+    doc.roundedRect(x, y, pillWidth, pillHeight, 7).fill(colors.bg);
+    doc.restore();
+    doc.fillColor(colors.fg).text(label, x + padX, y + padY, { width: textWidth, lineBreak: false });
+    doc.fillColor(COLOR_TEXT).font('Helvetica');
+  }
+
+  private renderSubsectionTitle(doc: PDFKit.PDFDocument, title: string): void {
+    this.ensureRoom(doc);
+    doc.fillColor(COLOR_PRIMARY).font('Helvetica-Bold').fontSize(11).text(title, PAGE_MARGIN, doc.y, { width: CONTENT_WIDTH });
+    doc.moveDown(0.2);
+    doc.fillColor(COLOR_TEXT).font('Helvetica').fontSize(10);
+  }
+
+  private renderDriftBanner(doc: PDFKit.PDFDocument, message: string): void {
+    const y = doc.y;
+    doc.save();
+    doc.roundedRect(PAGE_MARGIN, y, CONTENT_WIDTH, 18, 3).fillAndStroke('#fde2e2', COLOR_WARN);
+    doc.restore();
+    doc
+      .fillColor(COLOR_WARN)
+      .font('Helvetica-Bold')
+      .fontSize(9.5)
+      .text(message, PAGE_MARGIN + 10, y + 4, { width: CONTENT_WIDTH - 20, lineBreak: false });
+    doc.fillColor(COLOR_TEXT).font('Helvetica').fontSize(10);
+    doc.y = y + 22;
+    doc.x = PAGE_MARGIN;
+    doc.moveDown(0.4);
+  }
+
+  private renderMutedNote(doc: PDFKit.PDFDocument, message: string): void {
+    doc.fillColor(COLOR_MUTED).font('Helvetica-Oblique').fontSize(10).text(`  ${message}`, PAGE_MARGIN, doc.y, { width: CONTENT_WIDTH });
+    doc.fillColor(COLOR_TEXT).font('Helvetica');
+    doc.moveDown(0.4);
   }
 }
 

--- a/packages/backend/src/infrastructure/eigenschutz/repositories/__tests__/prisma-gefaehrdungsbeurteilung.repository.spec.ts
+++ b/packages/backend/src/infrastructure/eigenschutz/repositories/__tests__/prisma-gefaehrdungsbeurteilung.repository.spec.ts
@@ -426,19 +426,27 @@ describe('PrismaGefaehrdungsbeurteilungRepository - Integration Tests', () => {
   });
 
   describe('findById()/findReadModelById() — Reconstitution-Failure', () => {
+    // Pure-Mock-Suite: prisma wird mocked, kein DB-Bootstrap nötig.
+    // Hartkodierte CUIDs vermeiden, dass `testEinsatzId` (nur in beforeAll
+    // bei verfügbarer DB gesetzt) undefined ist und die einsatzId-Pflicht-
+    // prüfung VOR dem zu testenden Fehler greift.
+    const reconstitutionFixtureEinsatzId = 'ckv1example0einsatzid12345678';
+    const reconstitutionFixtureEinheitId = 'ckv1example0einheitid12345678';
+    const reconstitutionFixtureUserId = 'ckv1example0userid1234567890ab';
+
     const baseRow = (overrides: Partial<PrismaGefaehrdungsbeurteilungRow> = {}): PrismaGefaehrdungsbeurteilungRow =>
       ({
         id: 'ckv1example0aggregateid123456',
-        einsatzId: testEinsatzId,
-        einheitId: testEinheitId,
-        erstelltVonUserId: testUserId,
+        einsatzId: reconstitutionFixtureEinsatzId,
+        einheitId: reconstitutionFixtureEinheitId,
+        erstelltVonUserId: reconstitutionFixtureUserId,
         vorlageId: null,
         gefahrenzoneId: null,
         items: [],
         version: 1,
         erstelltAm: new Date('2026-04-24T10:00:00.000Z'),
         aktualisiertAm: new Date('2026-04-24T10:00:00.000Z'),
-        aktualisiertVonUserId: testUserId,
+        aktualisiertVonUserId: reconstitutionFixtureUserId,
         ...overrides,
       }) as PrismaGefaehrdungsbeurteilungRow;
 

--- a/packages/frontend/e2e/setup/seed.ts
+++ b/packages/frontend/e2e/setup/seed.ts
@@ -1,5 +1,6 @@
 import { request } from '@playwright/test';
 import bcrypt from 'bcryptjs';
+import { randomBytes } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { withClient } from './test-db';
@@ -14,8 +15,15 @@ const BCRYPT_COST_FACTOR_PASSWORD = 10;
 function cuid24(): string {
   // Test-eigene 24-Zeichen-ID (timestamp36 + random36). Wir importieren bewusst nicht
   // `@paralleldrive/cuid2` aus dem Backend — kein Cross-Workspace-Coupling im Test-Setup.
+  // CodeQL js/insecure-randomness: ID landet in DB-Primärschlüsseln eines Test-
+  // Seeds — kryptografisch starker RNG kostet hier nichts und stillt die Regel.
   const ts = Date.now().toString(36).padStart(10, '0');
-  const rand = Math.random().toString(36).slice(2, 16).padStart(14, '0');
+  const rand = randomBytes(9)
+    .toString('base64url')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+    .slice(0, 14)
+    .padStart(14, '0');
   return (ts + rand).slice(0, 24);
 }
 

--- a/packages/frontend/src/features/eigenschutz/lib/telemetry-queue.ts
+++ b/packages/frontend/src/features/eigenschutz/lib/telemetry-queue.ts
@@ -148,7 +148,19 @@ let cachedSessionId: string | null = null;
 export function getOrCreateSessionId(): string {
   if (cachedSessionId) return cachedSessionId;
   const cryptoApi = typeof globalThis !== 'undefined' && 'crypto' in globalThis ? (globalThis.crypto as Crypto) : null;
-  cachedSessionId = cryptoApi && typeof cryptoApi.randomUUID === 'function' ? cryptoApi.randomUUID() : `session-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+    cachedSessionId = cryptoApi.randomUUID();
+  } else if (cryptoApi && typeof cryptoApi.getRandomValues === 'function') {
+    // Fallback für sehr alte Browser ohne randomUUID: 128 Bit aus getRandomValues
+    // statt Math.random (CodeQL js/insecure-randomness, Session-ID landet im
+    // Telemetrie-Pfad und identifiziert User-Sessions).
+    const bytes = new Uint8Array(16);
+    cryptoApi.getRandomValues(bytes);
+    cachedSessionId = `session-${Date.now()}-${Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')}`;
+  } else {
+    // Letztes Sicherheitsnetz für nicht-Browser-Umgebungen ohne Crypto-API.
+    cachedSessionId = `session-${Date.now()}-fallback`;
+  }
   return cachedSessionId;
 }
 

--- a/packages/frontend/src/features/etb/ui/organisms/__tests__/EtbEntryForm.spec.tsx
+++ b/packages/frontend/src/features/etb/ui/organisms/__tests__/EtbEntryForm.spec.tsx
@@ -10,15 +10,27 @@ vi.mock('@/features/einsatz/api', () => ({
   useEinsatzTeilnehmer: () => ({ data: null }),
 }));
 
+// Stabile Mock-Refs: `useEtbFormLogic` liefert in der echten Implementierung
+// memoisierte Callbacks (useCallback). Würden wir bei jedem Hook-Aufruf
+// frische `vi.fn()`-Instanzen zurückgeben, triggert der dadurch instabile
+// `resetSelection`-Ref den „Reset form when editingEntry changes"-Effect
+// nach jedem Re-Render erneut und überschreibt restaurierte Draft-Werte
+// (Story 3.5).
+const { stableSetSelectedTextbaustein, stableFilteredTextbausteine, stableResetSelection } = vi.hoisted(() => ({
+  stableSetSelectedTextbaustein: vi.fn(),
+  stableFilteredTextbausteine: () => [],
+  stableResetSelection: vi.fn(),
+}));
+
 // Mock non-validation UI Komponenten aus dem Barrel
 vi.mock('@/features/etb', () => ({
   useCreateEtbEntry: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
   useTextbausteine: () => ({ data: null }),
   useEtbFormLogic: () => ({
     selectedTextbaustein: '',
-    setSelectedTextbaustein: vi.fn(),
-    filteredTextbausteine: () => [],
-    resetSelection: vi.fn(),
+    setSelectedTextbaustein: stableSetSelectedTextbaustein,
+    filteredTextbausteine: stableFilteredTextbausteine,
+    resetSelection: stableResetSelection,
   }),
   EtbFormActions: ({ canSubmit, isSubmitting, isPending }: { canSubmit: boolean; isSubmitting: boolean; isPending: boolean }) => (
     <button type="submit" disabled={!canSubmit || isPending || isSubmitting}>

--- a/packages/frontend/src/features/lagekarte/ui/molecules/MapLayerSwitcher.molecule.tsx
+++ b/packages/frontend/src/features/lagekarte/ui/molecules/MapLayerSwitcher.molecule.tsx
@@ -8,7 +8,7 @@
 import { cn } from '@/shared/ui/cn';
 import { Switch } from '@/shared/ui/atoms/switch.atom';
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react';
-import { PiCloudRain, PiGlobeHemisphereWest, PiMapTrifold, PiMegaphone, PiMountains, PiPoliceCarFill, PiShieldWarning, PiSiren, PiStack, PiWaves } from 'react-icons/pi';
+import { PiCloudRain, PiGlobeHemisphereWest, PiMapTrifold, PiMapPinFill, PiMegaphone, PiMountains, PiPoliceCarFill, PiShieldWarning, PiSiren, PiStack, PiWaves } from 'react-icons/pi';
 import type { BaseLayerConfig, BaseLayerId } from '../../utils/map-config';
 import type { NinaOverlayState, NinaSource } from '../../stores/map-layer.store';
 import { setBaseLayer, setDwdOverlay, setNinaOverlay } from '../../stores/map-layer.store';
@@ -123,6 +123,18 @@ export function MapLayerSwitcher({ availableLayers, selectedBaseLayer, dwdOverla
             </label>
           ))}
         </div>
+
+        {/* Separator */}
+        <div className="my-2 border-t border-border-subtle" />
+
+        {/* Legende — Story 4.3 T7.4: Marker-Symbole erläutern */}
+        <div className="px-3 pb-1.5 text-xs font-semibold tracking-wide text-text-muted uppercase">Legende</div>
+        <ul className="space-y-0.5 px-3 pb-1">
+          <li data-testid="map-legend-sicherungsposten" className="flex items-center gap-2 py-1.5 text-sm text-text-primary">
+            <PiMapPinFill className="h-4 w-4 text-action-primary" aria-hidden="true" />
+            <span>Sicherungsposten</span>
+          </li>
+        </ul>
       </PopoverPanel>
     </Popover>
   );

--- a/packages/frontend/src/routes/app/einsatz/$einsatzId/sicherheit/__tests__/psa-profile.route.spec.tsx
+++ b/packages/frontend/src/routes/app/einsatz/$einsatzId/sicherheit/__tests__/psa-profile.route.spec.tsx
@@ -25,7 +25,10 @@ vi.mock('@/features/eigenschutz/ui/pages/PsaProfilePage', () => ({
   PsaProfilePage: () => null,
 }));
 
-import '../eigenschutz/psa-profile';
+// Explizit auf das Index-Modul zeigen: die Sibling-Datei `psa-profile.tsx`
+// ist nur noch ein Layout-Wrapper ohne `validateSearch`, die echte Route
+// liegt unter `psa-profile/index.tsx`.
+import '../eigenschutz/psa-profile/index';
 
 describe('PsaProfile Route', () => {
   it('akzeptiert den PSA-Action-Param nur mit Ziel-Einheit', () => {

--- a/packages/frontend/src/routes/app/einsatz/$einsatzId/sicherheit/__tests__/sicherheitsregeln.route.spec.tsx
+++ b/packages/frontend/src/routes/app/einsatz/$einsatzId/sicherheit/__tests__/sicherheitsregeln.route.spec.tsx
@@ -40,7 +40,10 @@ vi.mock('@/features/eigenschutz/ui/pages/SicherheitsregelnPage', () => ({
   ),
 }));
 
-import '../eigenschutz/sicherheitsregeln';
+// Explizit auf das Index-Modul zeigen: die Sibling-Datei `sicherheitsregeln.tsx`
+// ist nur noch ein Layout-Wrapper ohne `validateSearch`, die echte Route
+// liegt unter `sicherheitsregeln/index.tsx`.
+import '../eigenschutz/sicherheitsregeln/index';
 
 function renderRoute() {
   if (!captured.route?.component) {


### PR DESCRIPTION
## Summary

Goal G5 — Vorfall-PDF aus dem Eigenschutz-Modul wurde von einer reinen Text-Liste zu einem visuell strukturierten Unfallkassen-tauglichen Dokument umgebaut.

**Recherche-Ergebnis:** Library-Wechsel ist **nicht** notwendig. Der bestehende `pdfkit`-Renderer kann Vektor-Primitive (rect, lineTo, fillAndStroke, roundedRect), Schrift-Hierarchie und Farb-Tokens — alles, was für das Redesign nötig ist. Alternativen (`@react-pdf/renderer`, Puppeteer, Typst, Carbone) brächten entweder Bundle-Overhead (Puppeteer ~200 MB Chromium, Tauri-inkompatibel), neue Toolchains (Typst-Binary) oder JSX-Layer-Komplexität ohne echten Mehrwert für ein 1-2-seitiges Form-PDF.

**Entscheidung:** Inkrementelles Redesign mit pdfkit.

> **Hinweis Base-Branch:** Dieser PR zielt nominell auf `alpha`, weil die Eigenschutz-Feature-Branch `415-eigenschutz-einsatzkraefte-sicherheit-psa` nicht auf origin liegt. Inhaltlich gehört der Patch in die Eigenschutz-Branch (Story 5.4 Renderer-Polish) — bitte vor Merge entsprechend rebasen oder direkt in die Feature-Branch cherry-picken.

## Verbesserungen

- **Brand-Header** mit Marineblau-Akzentbalken, Dokumenttyp-Label "UNFALLKASSEN-MELDUNG" und Erzeugungszeitpunkt rechts.
- **Section-Header** mit vertikalem Akzent, konsistenter Farb-Hierarchie (Primary/Muted/Text/Border-Tokens).
- **Vorfall-Metadaten** als zweispaltiges Label/Wert-Grid mit pastellblauer Karten-Fläche (statt Fließtext).
- **Unfallkasse-Pill** (ja: rot, nein: grün) als visueller Quick-Scan-Marker.
- **Farbcodierte Risiko-Badges** ROT / GELB / GRÜN pro Gefährdungs-Item gemäß Ampel-Semantik aus `risikoklasse-berechnung.ts`.
- **Drift-Banner** mit Rahmen statt grauer Inline-Text — Schema-Drift wird klar als Datenfehler erkennbar.
- **Persistenter Seitenfuß** mit Seitenzahl ("Seite X / Y") auf jeder Seite über `bufferedPageRange()`.
- **Footer-Reserve** über asymmetrische `margins`, damit pdfkit den Permission-Bereich beim Automatik-Umbruch nicht überschreibt.

## Spec-Compliance & Bewusste Abweichungen

- **Story 5.4 AC2-Tests 1-8** (Header-String, Empty-Snapshot, Drift, Permission/Datum, PII-Hygiene): vollständig erhalten.
- **AC4 #6 (Sicherheitsregeln-Trim auf 200 Zeichen)**: unverändert beibehalten.
- **Scope-Abweichung Punkt 5 (5×5-Grid → textuell, nicht grafisch)**: respektiert — kein eingebettetes Grid, nur farbcodierte Pill pro Item. Vertretbar als reine Typo-Polish.
- **PII-Hygiene** (Story 3.7 Pattern): alle technischen IDs weiter via `redactId(id, 8)`.
- **NFR-P5**: p95=135ms (Limit 5000ms) — Vektor-Primitive sind billig genug.

## Test plan

- [x] Renderer-Tests grün (9/9): `pnpm --filter @bluelight-hub/backend test -- eigenschutz-vorfall-pdf.renderer`
- [x] NFR-P5 Performance-Audit: p95=135ms
- [x] `pnpm exec oxlint` clean
- [x] `pnpm exec oxfmt --check` clean
- [x] DI-Import-Check (AC1) clean
- [ ] Manuelle visuelle Begutachtung: PDF aus Detail-Page exportieren
- [ ] Druck-Smoke auf Schwarz-Weiß-Drucker (Kontrast der Pastell-Tinten)
- [ ] Mehrseitiger Worst-Case (100 Gefährdungen) auf konsistente Seitenfüße verifizieren

🤖 Generated with [Claude Code](https://claude.com/claude-code)