### PR TITLE
✨(eigenschutz): Gefährdungsmatrix entzerrt (Touch-Targets ≥ 44 px)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## Performance
+
+- **Deutlich schnellere CI-Pipeline**: Frontend-Tests laufen nun parallel in drei Shards statt nacheinander – die Testzeit wurde von ~8 Minuten auf ~3 Minuten pro Shard reduziert. Backend-Unit-Tests ebenfalls parallelisiert und von 20+ Minuten auf unter 15 Minuten beschleunigt.
+
+- **Performance-Messungen präziser**: Performance-Tests laufen jetzt isoliert von CPU-lastigen Unit-Tests, um Timing-Verfälschungen zu vermeiden und verlässliche Baseline-Messungen zu gewährleisten.
+
+## Sicherheit & Stabilität
+
+- **Wichtiges Sicherheitsupdate**: DOMPurify auf Version 3.4.0 aktualisiert – behebt Cross-Site-Scripting (XSS) und Prototype-Pollution-Sicherheitslücken.
+
+- **Lagekarten-Anzeige verbessert**: MapLibre GL auf Version 5.23.0 aktualisiert – behebt einen Fehler, bei dem Beschriftungen von Polygon-Gefahrenzonen falsch positioniert wurden.
+
+- **Modernere Technologie-Basis**: TypeScript auf Version 6.0.3 aktualisiert – die letzte JavaScript-basierte Version vor dem großen Rewrite in TypeScript 7.
+
+- **Stabilere Dependencies**: 28 sichere Abhängigkeits-Updates ohne Breaking Changes durchgeführt, darunter NestJS, React Query, React Router, Vite und weitere Kernbibliotheken.
+
+## Dokumentation & Projektausrichtung
+
+- **Zielgruppe präzisiert**: Die Dokumentation wurde aktualisiert und stellt nun klar, dass Bluelight Hub speziell für **weiße Hilfsorganisationen** (DRK, JUH, MHD, ASB, DLRG) im Sanitätsdienst und Katastrophenschutz entwickelt wird – nicht für Feuerwehr, Polizei oder Bundeswehr. Die fachliche Ausrichtung auf Betreuungsdienst, MANV und Sanitätswachendienst ist jetzt deutlicher dokumentiert.
+
+- **Neues Modul geplant: Eigenschutz**: Das Produktkonzept für ein Eigenschutz-Modul wurde dokumentiert. Es soll Sicherheitsbeauftragte im Stab bei der Gefährdungsbeurteilung (5×5-Risikomatrix), PSA-Verwaltung, Sicherheitsregeln und Vorfallmeldungen während laufender Einsätze digital unterstützen.
+
 ## Gefahrenzonen auf der Lagekarte
 
 Die Lagekarte bietet nun die Möglichkeit, Gefahrenzonen direkt auf der Karte zu zeichnen und zu verwalten. Gefahrenzonen werden farblich nach ihrer Warnstufe (KEINE, NIEDRIG, MITTEL, HOCH, AKUT) dargestellt und sind mit der Gefahrenmatrix verknüpft.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluelight-hub/backend",
-  "version": "1.0.0-alpha.103",
+  "version": "1.0.0-alpha.104",
   "private": true,
   "scripts": {
     "dev": "nest start --watch",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluelight-hub/frontend",
-  "version": "1.0.0-alpha.103",
+  "version": "1.0.0-alpha.104",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/frontend/src/features/eigenschutz/ui/organisms/RiskMatrix5x5.tsx
+++ b/packages/frontend/src/features/eigenschutz/ui/organisms/RiskMatrix5x5.tsx
@@ -18,10 +18,23 @@
  * - Roving-Tabindex: nur die fokussierte bzw. ausgewählte Zelle trägt
  *   `tabIndex=0`; alle anderen `-1`. Pfeiltasten verschieben den Fokus,
  *   Enter/Space ruft `onChange` auf (AC7, UX-DR22).
- * - Touch-Targets erfüllen das 48×48px-Minimum über `min-h-12 min-w-12`.
+ * - Touch-Targets erfüllen das 48×48px-Minimum über `min-h-12 min-w-12` und
+ *   wachsen auf größeren Viewports (`sm:min-h-14 sm:min-w-14`,
+ *   `lg:min-h-16 lg:min-w-16`), damit die Matrix auf Desktop nicht
+ *   zusammengequetscht wirkt (Goal G2).
  * - `prefers-reduced-motion: reduce` deaktiviert die Transition-Klasse —
  *   wir prüfen `window.matchMedia` client-seitig, in jsdom-Tests lässt sich
  *   das über `vi.stubGlobal('matchMedia', …)` steuern.
+ *
+ * Responsive-Strategie (Goal G2):
+ * - Das `<table>` selbst bleibt ein 5×5-Grid (semantisch korrekt für
+ *   Screenreader). Auf sehr schmalen Viewports < 360 px (z. B. iPhone SE 1.
+ *   Gen mit 320 px Breite) würde das Grid optisch zerquetschen. Lösung:
+ *   ein Wrapper-`<div>` mit `overflow-x-auto`, der die Matrix horizontal
+ *   scrollbar macht. `min-w-[20rem]` an der Tabelle hält die Mindest-Größe
+ *   bei, ab `sm` (640 px) breitet sich die Tabelle wieder auf 100 %.
+ *   Damit bleibt die 2-dim-Navigation (Pfeiltasten) auf allen Viewports
+ *   konsistent, statt zwischen Grid und Stacked-Layout zu wechseln.
  *
  * Farbgebung:
  * - Die Tailwind-v4-Theme-Tokens heißen `warnstufe-{keine,niedrig,mittel,hoch,akut}`
@@ -29,6 +42,9 @@
  *   vier Ampel-Klassen GRUEN/GELB/ORANGE/ROT. Bewusst nutzen wir stattdessen
  *   die Standard-Tailwind-Paletten (`green/yellow/orange/red`) — sie sind
  *   farbblind-freundlich und semantisch klar mit den Ampelklassen gekoppelt.
+ *   Für Dark-Mode (`.dark`-Klasse) hinterlegen wir abgedunkelte Surface-
+ *   Varianten plus hellen Text, damit das Kontrastverhältnis gegen den
+ *   dunklen Hintergrund mindestens WCAG AA erreicht.
  */
 
 import { calculateRisikoklasse } from '@bluelight-hub/shared';
@@ -81,12 +97,18 @@ const RISIKOKLASSE_LABELS: Record<Risikoklasse, string> = {
   ROT: 'Rot',
 };
 
-/** Tailwind-Farb-Tokens pro Risikoklasse (Fallback auf Standard-Paletten, siehe Datei-Doc). */
+/**
+ * Tailwind-Farb-Tokens pro Risikoklasse (Fallback auf Standard-Paletten, siehe Datei-Doc).
+ *
+ * Light-Mode: helle Surface (`100`/`200`) + dunkler Text (`900`).
+ * Dark-Mode: deutlich abgedunkelte Surface (`900`/`950`) + heller Text (`100`/`200`),
+ * damit das Kontrastverhältnis im Dark-Theme nicht unter WCAG AA fällt.
+ */
 const RISIKOKLASSE_STYLES: Record<Risikoklasse, string> = {
-  GRUEN: 'bg-green-100 text-green-900 hover:bg-green-200',
-  GELB: 'bg-yellow-100 text-yellow-900 hover:bg-yellow-200',
-  ORANGE: 'bg-orange-200 text-orange-900 hover:bg-orange-300',
-  ROT: 'bg-red-200 text-red-900 hover:bg-red-300',
+  GRUEN: 'bg-green-100 text-green-900 hover:bg-green-200 dark:bg-green-900/50 dark:text-green-100 dark:hover:bg-green-900/70',
+  GELB: 'bg-yellow-100 text-yellow-900 hover:bg-yellow-200 dark:bg-yellow-900/50 dark:text-yellow-100 dark:hover:bg-yellow-900/70',
+  ORANGE: 'bg-orange-200 text-orange-900 hover:bg-orange-300 dark:bg-orange-900/60 dark:text-orange-100 dark:hover:bg-orange-900/80',
+  ROT: 'bg-red-200 text-red-900 hover:bg-red-300 dark:bg-red-900/60 dark:text-red-100 dark:hover:bg-red-900/80',
 };
 
 // Konstanten als Arrays für den numerischen Zugriff bei Keyboard-Nav.
@@ -182,74 +204,81 @@ export function RiskMatrix5x5({ value, onChange, disabled = false, readOnly = fa
   }, [value?.eintritt, value?.schaden]);
 
   return (
-    <table
-      ref={gridRef}
-      role="grid"
-      aria-labelledby={ariaLabelledBy}
-      aria-disabled={disabled || undefined}
-      aria-readonly={readOnly || undefined}
-      className="w-full border-separate border-spacing-1"
-      data-testid="risk-matrix-5x5"
-    >
-      <thead>
-        <tr>
-          {/* Leere Ecke oben-links — kein Label. */}
-          <th scope="col" aria-hidden="true" className="w-28" />
-          {SCHADEN_ORDER.map((schaden) => (
-            <th key={schaden} scope="col" className="px-1 pb-2 text-center text-xs font-medium text-text-secondary">
-              {SCHADEN_LABELS[schaden]}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {EINTRITT_ORDER.map((eintritt, rowIdx) => (
-          <tr key={eintritt}>
-            <th scope="row" className="pr-2 text-right text-xs font-medium text-text-secondary">
-              {EINTRITT_LABELS[eintritt]}
-            </th>
-            {SCHADEN_ORDER.map((schaden, colIdx) => {
-              const klasse = calculateRisikoklasse(eintritt, schaden);
-              const cellKey = `${rowIdx}:${colIdx}`;
-              const isSelected = selectedKey === cellKey;
-              const isFocusable = focus.row === rowIdx && focus.col === colIdx;
-              const ariaLabel = `Eintrittswahrscheinlichkeit ${EINTRITT_LABELS[eintritt]}, Schadensausmaß ${SCHADEN_LABELS[schaden]}, Risikoklasse ${RISIKOKLASSE_LABELS[klasse]}`;
-              return (
-                <td
-                  key={schaden}
-                  role="gridcell"
-                  aria-label={ariaLabel}
-                  aria-selected={isSelected}
-                  aria-disabled={disabled || undefined}
-                  tabIndex={disabled ? -1 : isFocusable ? 0 : -1}
-                  data-matrix-row={rowIdx}
-                  data-matrix-col={colIdx}
-                  data-risikoklasse={klasse}
-                  data-testid={`risk-matrix-cell-${eintritt}-${schaden}`}
-                  onClick={() => {
-                    if (disabled) return;
-                    shouldRefocus.current = false;
-                    setFocus({ row: rowIdx, col: colIdx });
-                    if (readOnly) return;
-                    onChange({ eintritt, schaden });
-                  }}
-                  onKeyDown={(event) => handleCellKeyDown(event, rowIdx, colIdx)}
-                  className={cn(
-                    'relative min-h-12 min-w-12 cursor-pointer rounded-control border text-center align-middle text-xs font-semibold select-none',
-                    'focus:outline-none focus-visible:shadow-focus-ring',
-                    RISIKOKLASSE_STYLES[klasse],
-                    isSelected ? 'border-action-primary ring-2 ring-action-primary/60' : 'border-transparent',
-                    disabled ? 'cursor-not-allowed opacity-50' : null,
-                    reducedMotion ? null : 'transition-[background-color,border-color,box-shadow] duration-150',
-                  )}
-                >
-                  <span aria-hidden="true">{RISIKOKLASSE_LABELS[klasse]}</span>
-                </td>
-              );
-            })}
+    // Wrapper sorgt für horizontalen Scroll auf sehr schmalen Viewports (Goal G2):
+    // unterhalb von 360 px Breite passen 5 Zellen + Achsenlabel sonst nicht hin.
+    <div className="overflow-x-auto" data-testid="risk-matrix-5x5-scroll">
+      <table
+        ref={gridRef}
+        role="grid"
+        aria-labelledby={ariaLabelledBy}
+        aria-disabled={disabled || undefined}
+        aria-readonly={readOnly || undefined}
+        className="w-full min-w-[20rem] border-separate border-spacing-2 sm:border-spacing-3"
+        data-testid="risk-matrix-5x5"
+      >
+        <thead>
+          <tr>
+            {/* Leere Ecke oben-links — kein Label. */}
+            <th scope="col" aria-hidden="true" className="w-24 sm:w-32" />
+            {SCHADEN_ORDER.map((schaden) => (
+              <th key={schaden} scope="col" className="px-1.5 pb-2.5 text-center text-xs font-medium text-text-secondary sm:text-sm">
+                {SCHADEN_LABELS[schaden]}
+              </th>
+            ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {EINTRITT_ORDER.map((eintritt, rowIdx) => (
+            <tr key={eintritt}>
+              <th scope="row" className="pr-2.5 text-right text-xs font-medium text-text-secondary sm:pr-3 sm:text-sm">
+                {EINTRITT_LABELS[eintritt]}
+              </th>
+              {SCHADEN_ORDER.map((schaden, colIdx) => {
+                const klasse = calculateRisikoklasse(eintritt, schaden);
+                const cellKey = `${rowIdx}:${colIdx}`;
+                const isSelected = selectedKey === cellKey;
+                const isFocusable = focus.row === rowIdx && focus.col === colIdx;
+                const ariaLabel = `Eintrittswahrscheinlichkeit ${EINTRITT_LABELS[eintritt]}, Schadensausmaß ${SCHADEN_LABELS[schaden]}, Risikoklasse ${RISIKOKLASSE_LABELS[klasse]}`;
+                return (
+                  <td
+                    key={schaden}
+                    role="gridcell"
+                    aria-label={ariaLabel}
+                    aria-selected={isSelected}
+                    aria-disabled={disabled || undefined}
+                    tabIndex={disabled ? -1 : isFocusable ? 0 : -1}
+                    data-matrix-row={rowIdx}
+                    data-matrix-col={colIdx}
+                    data-risikoklasse={klasse}
+                    data-testid={`risk-matrix-cell-${eintritt}-${schaden}`}
+                    onClick={() => {
+                      if (disabled) return;
+                      shouldRefocus.current = false;
+                      setFocus({ row: rowIdx, col: colIdx });
+                      if (readOnly) return;
+                      onChange({ eintritt, schaden });
+                    }}
+                    onKeyDown={(event) => handleCellKeyDown(event, rowIdx, colIdx)}
+                    className={cn(
+                      // Touch-Targets: Basis 48 × 48 px (Primär-Aktion), auf sm/lg-Viewports
+                      // großzügig auf 56 × 56 / 64 × 64 px wachsen (Goal G2). Padding gibt
+                      // dem Risikoklasse-Label optisch Luft, ohne die Touch-Fläche zu beschneiden.
+                      'relative min-h-12 min-w-12 cursor-pointer rounded-control border p-1.5 text-center align-middle text-xs font-semibold select-none sm:min-h-14 sm:min-w-14 sm:p-2 sm:text-sm lg:min-h-16 lg:min-w-16',
+                      'focus:outline-none focus-visible:shadow-focus-ring',
+                      RISIKOKLASSE_STYLES[klasse],
+                      isSelected ? 'border-action-primary ring-2 ring-action-primary/60' : 'border-transparent',
+                      disabled ? 'cursor-not-allowed opacity-50' : null,
+                      reducedMotion ? null : 'transition-[background-color,border-color,box-shadow] duration-150',
+                    )}
+                  >
+                    <span aria-hidden="true">{RISIKOKLASSE_LABELS[klasse]}</span>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluelight-hub/shared",
-  "version": "1.0.0-alpha.103",
+  "version": "1.0.0-alpha.104",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Goal G2 — Gefährdungsmatrix-Layout entzerren

Die 5×5-Risikomatrix in der Gefährdungsbeurteilung wirkte optisch zusammengequetscht und war auf schmalen Viewports schwer bedienbar. Diese PR entzerrt das Layout, vergrößert Touch-Targets responsive und passt das Spacing inkl. Achsen-Labels an.

## Änderungen

**`packages/frontend/src/features/eigenschutz/ui/organisms/RiskMatrix5x5.tsx`** (einzige Datei)

- **Touch-Targets**: `min-h-12 min-w-12` (48 × 48 px) bleibt als Basis (Mobile), wächst auf `sm:min-h-14 sm:min-w-14` (56 px) und `lg:min-h-16 lg:min-w-16` (64 px). Damit > 44 px Sekundär-Spec auf allen Viewports, und großzügiger auf Desktop, wo Platz ist.
- **Spacing**: `border-spacing-1` → `border-spacing-2` (Mobile) bzw. `border-spacing-3` (≥ sm). Cells haben außerdem `p-1.5 sm:p-2` für optisches Padding, ohne die Touch-Fläche zu beschneiden.
- **Achsen-Labels**: `text-xs` → `text-xs sm:text-sm`. Padding zwischen Label und erster Zellreihe leicht erhöht (`pr-2 → pr-2.5 sm:pr-3`, `pb-2 → pb-2.5`).
- **Corner-Spacer**: `w-28` → `w-24 sm:w-32` (Mobile schmaler, Desktop etwas großzügiger).

**Responsive Layout-Entscheidung**

Das 5×5-Grid bleibt strukturell erhalten — die `<table role="grid">`-Semantik mit 2D-Pfeiltasten-Navigation ist screenreader-kritisch und sollte nicht zwischen Layouts springen. Stattdessen wird die Tabelle in einen `<div className="overflow-x-auto">`-Wrapper gepackt mit `min-w-[20rem]` an der Tabelle. Unterhalb von ~360 px Wrapper-Breite wird die Matrix horizontal scrollbar — die 2D-Navigation bleibt konsistent, statt auf ein Stacked-/Listen-Layout zu wechseln. Bei ≥ sm (640 px) breitet sich die Tabelle wieder auf 100 %.

**Severity-Farben + Dark Mode**

Light-Mode-Farbgebung (Grün/Gelb/Orange/Rot) ist erhalten. Für `.dark`-Mode wurden abgedunkelte Surface-Varianten plus heller Text hinterlegt (z. B. `dark:bg-green-900/50 dark:text-green-100`), damit das Kontrastverhältnis im Dark-Theme nicht unter WCAG AA fällt.

## Verification

- **Unit-Tests**: `pnpm exec vitest run src/features/eigenschutz` — **1048/1048 grün** (incl. 14/14 `RiskMatrix5x5.spec.tsx` und alle Audit-Specs: `touch-target-audit`, `a11y-audit`, `reflow-audit`, `aria-structure-audit`, `keyboard-journeys-audit`, `contrast-audit`).
- **Lint**: `pnpm lint:check` — **0 Errors** (36 Pre-existing Warnings in nicht betroffenen Dateien).
- **Format**: `oxfmt --check` grün.
- **Visueller Browser-Smoke**: In diesem Worktree übersprungen — der Worktree war initial auf einem veralteten Commit (vor dem Eigenschutz-Feature) und musste auf `415-eigenschutz-einsatzkraefte-sicherheit-psa` rebased werden, um die Quelldatei überhaupt vorzufinden. Nach dem Rebase wurden `bash scripts/worktree-setup.sh` (Docker + DB-Seed) erfolgreich ausgeführt; die Browser-MCP-Validierung (Light/Dark/Mobile/Desktop-Screenshots) sollte vor dem Merge manuell auf `https://localhost:3090` an einer Gefährdungs-Detail-Seite mit ≥ 5 Gefährdungen nachgezogen werden — die Änderung ist rein CSS-Class-basiert, kein Logik-Pfad ist betroffen.

## Branching

PR-Basis: `alpha` (analog zu PR #748 und #747). Die Branch enthält die Eigenschutz-Feature-Commits von `415-eigenschutz-einsatzkraefte-sicherheit-psa` plus diesen Layout-Fix — die Diffs gegen alpha zeigen daher die volle Feature-Surface; der Goal-G2-Commit ist `605650339`.

## Test Plan (vor Merge zu prüfen)

- [ ] Browser-Smoke (Light + Dark Mode) auf einer Gefährdungs-Detail-Seite mit ≥ 5 Items, Viewports 320 px (Mobile S), 768 px (Tablet), 1280 px (Desktop).
- [ ] Touch-Target-Inspect in DevTools: jede Zelle ≥ 44 × 44 px (Sekundär), Desktop ≥ 64 × 64 px.
- [ ] Severity-Farben weiterhin unterscheidbar (auch bei Farbenblindheit, Severity-Label-Text in Zelle bleibt).
- [ ] Keyboard-Navigation: Pfeiltasten + Enter/Space funktionieren unverändert, Roving-Tabindex intakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)